### PR TITLE
Refactor date inputs for DWP check

### DIFF
--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -30,6 +30,8 @@ private
 
   def new_from_params
     @dwp_checker = DwpCheck.new(dwp_params)
+    @dwp_checker.dob = process_incoming_date(dwp_params[:dob])
+    @dwp_checker.date_to_check = process_incoming_date(dwp_params[:date_to_check])
   end
 
   def process_dwp_check
@@ -47,6 +49,14 @@ private
     }
     response = RestClient.post "#{ENV['DWP_API_PROXY']}/api/benefit_checks", params
     JSON.parse(response)['benefit_checker_status']
+  end
+
+  def process_incoming_date(date_str)
+    return nil if date_str.blank?
+    Date.parse(date_str)
+  rescue
+    format_str = "%d/%m/" + (date_str =~ /\d{4}/ ? "%Y" : "%y")
+    Date.strptime(date_str, format_str)
   end
 
   def process_check_date

--- a/app/views/dwp_checks/new.html.slim
+++ b/app/views/dwp_checks/new.html.slim
@@ -18,7 +18,7 @@ h2 Check benefits status
     .small-12.medium-8.large-5.columns
       .form-group
         = f.label :dob
-        = f.date_field :dob, { class: 'form-control' }
+        = f.text_field :dob, { class: 'form-control' }
   .row
     .small-12.medium-8.large-5.columns
       .form-group
@@ -28,7 +28,7 @@ h2 Check benefits status
     .small-12.medium-8.large-5.columns
       .form-group
         = f.label :date_to_check
-        = f.date_field :date_to_check, { class: 'form-control' }
+        = f.text_field :date_to_check, { class: 'form-control' }
   .row
     .small-12.medium-8.large-5.columns
       .form-group

--- a/config/initializers/date_time.rb
+++ b/config/initializers/date_time.rb
@@ -1,0 +1,2 @@
+Date::DATE_FORMATS[:default] = '%d/%m/%Y'
+Time::DATE_FORMATS[:default] = '%d/%m/%Y %H:%M'

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -64,33 +64,48 @@ RSpec.describe DwpChecksController, type: :controller do
         expect(response).to render_template('dwp_checks/new')
       end
     end
-  end
-
-  context 'logged in as admin user' do
-    before(:each) { sign_in admin_user }
-    describe 'GET #show' do
-      it 'assign the requested dwp_check as @dwp_check' do
-        dwp_check = DwpCheck.create! valid_attributes
-        get :show, { unique_number: dwp_check.unique_number }, valid_session
-        expect(assigns(:dwp_checker)).to eq(dwp_check)
-        expect(response).to render_template('dwp_checks/show')
-      end
-    end
-    describe 'GET #new' do
-      it 'render the expected view' do
-        get :new, {}, valid_session
-        expect(response.status).to eql(200)
-        expect(response).to render_template('dwp_checks/new')
-      end
-    end
-  end
-
-  context 'logged in as standard user' do
-    before(:each) { sign_in user }
-
     describe 'POST #lookup' do
 
       before { WebMock.disable_net_connect!(allow: 'codeclimate.com') }
+
+      context 'date format' do
+        let(:dwp_params) do
+          {
+            last_name: 'last_name',
+            dob: nil,
+            ni_number: 'AB123456A',
+            entitlement_check_date: "#{Date.today}"
+          }
+        end
+        before(:each) do
+          json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
+                  "confirmation_ref": "T1426267181940",
+                  "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
+          stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+            with(body: { birth_date: '19800101', entitlement_check_date: Date.today.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'LAST_NAME' }).
+            to_return(status: 200, body: json, headers: {})
+        end
+        it 'accepts d/m/yy' do
+          dwp_params[:dob] = '1/1/80'
+          post :lookup, dwp_check: dwp_params
+          expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
+        end
+        it 'accepts dd/mm/yy' do
+          dwp_params[:dob] = '01/01/80'
+          post :lookup, dwp_check: dwp_params
+          expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
+        end
+        it 'accepts dd mmm yy' do
+          dwp_params[:dob] = '01 Jan 80'
+          post :lookup, dwp_check: dwp_params
+          expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
+        end
+        it 'accepts dd mmmm yyyy' do
+          dwp_params[:dob] = '01 January 1980'
+          post :lookup, dwp_check: dwp_params
+          expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
+        end
+      end
 
       context 'valid request' do
 
@@ -140,4 +155,24 @@ RSpec.describe DwpChecksController, type: :controller do
       end
     end
   end
+
+  context 'logged in as admin user' do
+    before(:each) { sign_in admin_user }
+    describe 'GET #show' do
+      it 'assign the requested dwp_check as @dwp_check' do
+        dwp_check = DwpCheck.create! valid_attributes
+        get :show, { unique_number: dwp_check.unique_number }, valid_session
+        expect(assigns(:dwp_checker)).to eq(dwp_check)
+        expect(response).to render_template('dwp_checks/show')
+      end
+    end
+    describe 'GET #new' do
+      it 'render the expected view' do
+        get :new, {}, valid_session
+        expect(response.status).to eql(200)
+        expect(response).to render_template('dwp_checks/new')
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Users were getting errors when inputting two digit years
Pivotal story https://www.pivotaltracker.com/story/show/91439958
Added tests and handlers to ensure wider type of inputs accepted.
