### PR TITLE
Allow Admins to assign Users to an Office

### DIFF
--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,4 +1,5 @@
 class Office < ActiveRecord::Base
+  has_many :users
 
   scope :sorted, -> {  all.order(:name) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ActiveRecord::Base
+  belongs_to :office
 
   ROLES = %w[admin user]
   # Include default devise modules. Others available are:

--- a/app/views/users/invitations/new.html.slim
+++ b/app/views/users/invitations/new.html.slim
@@ -14,5 +14,8 @@ h2
   .form-group
     = f.label(:roles, 'Role')
     = f.collection_select :role, User::ROLES, :to_s, :humanize
+  .form-group
+    = f.label(:office, 'Office')
+    = f.collection_select :office, Office.all, :id, :name
   p
     = f.submit t("devise.invitations.new.submit_button")

--- a/db/migrate/20150417125341_users_offices.rb
+++ b/db/migrate/20150417125341_users_offices.rb
@@ -1,0 +1,5 @@
+class UsersOffices < ActiveRecord::Migration
+  def change
+    add_column :users, :office_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150326131421) do
+ActiveRecord::Schema.define(version: 20150417125341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 20150326131421) do
     t.string   "invited_by_type"
     t.integer  "invitations_count",      default: 0
     t.string   "name"
+    t.integer  "office_id"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+
+Office.create([{ name: 'Bristol' },
+               { name: 'Digital' }])

--- a/spec/features/user_invite_spec.rb
+++ b/spec/features/user_invite_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Office management', type: :feature do
   Warden.test_mode!
 
   let(:admin_user)    { FactoryGirl.create :admin_user }
+  let!(:offices)      { Office.create!(name: 'Bristol') }
 
   context 'Admin user' do
     scenario 'invites a user' do
@@ -18,6 +19,7 @@ RSpec.feature 'Office management', type: :feature do
       fill_in 'user_email', with: new_email
       fill_in 'user_name', with: new_name
       select('User', from: 'user_role')
+      select('Bristol', from: 'user_office')
 
       click_button 'Send an invitation'
 


### PR DESCRIPTION
Every user should be assigned to an office. The idea is to have an admin
per office so that when that admin creates/invites a user, that user
inherits that admin's office assignment.