### PR TITLE
Added white listed email domains

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,8 @@ class User < ActiveRecord::Base
 
   scope :sorted_by_email, -> {  all.order(:email) }
 
-  validates :email, format: Devise.email_regexp
+  email_regex = /\A([^@\s]+)@(hmcts\.gsi|digital\.justice)\.gov\.uk\z/i
+  validates :email, format: { with: email_regex, on: :create }
   validates :role, :name, presence: true
   validates :role, inclusion: {
     in: ROLES,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UsersController, type: :controller do
   # adjust the attributes here as well.
   let(:valid_attributes) {
     {
-      email: 'test@example.com',
+      email: 'test@digital.justice.gov.uk',
       password: 'aabbccdd',
       role: 'user',
       name: 'test'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :user do
     role 'user'
-    sequence(:email)     { |n| "user_#{n}@example.com" }
+    sequence(:email)     { |n| "user_#{n}@digital.justice.gov.uk" }
     password 'password'
     name 'user'
     factory :admin_user do

--- a/spec/features/user_invite_spec.rb
+++ b/spec/features/user_invite_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Office management', type: :feature do
   context 'Admin user' do
     scenario 'invites a user' do
 
-      new_email = 'test@email.com'
+      new_email = 'test@digital.justice.gov.uk'
       new_name = 'Test'
       login_as(admin_user, scope: :user)
       visit new_user_invitation_path

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 describe User, type: :model do
@@ -10,21 +11,36 @@ describe User, type: :model do
   end
 
   describe 'validations' do
-    it 'require an email' do
-      user.email = nil
-      expect(user).to be_invalid
-    end
+    context 'email' do
+      it 'require an email' do
+        user.email = nil
+        expect(user).to be_invalid
+      end
 
-    it 'require a valid email' do
-      user.email = 'testemail'
-      expect(user).to be_invalid
-    end
+      it 'require a valid email' do
+        user.email = 'testemail'
+        expect(user).to be_invalid
+      end
 
-    it 'require a unique email' do
-      original = FactoryGirl.create(:user)
-      duplicate = FactoryGirl.build(:user)
-      duplicate.email = original.email
-      expect(duplicate).to be_invalid
+      it 'require a unique email' do
+        original = FactoryGirl.create(:user)
+        duplicate = FactoryGirl.build(:user)
+        duplicate.email = original.email
+        expect(duplicate).to be_invalid
+      end
+
+      context '(hmcts.gsi|digital.justice).gov.uk email addresses' do
+        let(:user) { FactoryGirl.build(:user) }
+
+        it 'requires only whitelisted email addresses' do
+          expect(user).to be_valid
+        end
+
+        it 'will not accept non white listed emails' do
+          user.email = 'valid.email.that.rocks@gmail.com'
+          expect(user).to be_invalid
+        end
+      end
     end
 
     it 'requires a name' do


### PR DESCRIPTION
So that nobody outside of those domains can be invited to the
application.
Right now it's only allowing: (hmcts.gsi|digital.justice).gov.uk.