### PR TITLE
New - Create unique identifier for API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,12 +52,7 @@ group :development, :test do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-
   gem 'rspec-rails', '~> 3.2'
-  # in browser debugging
-  gem 'better_errors'
-  gem 'binding_of_caller'
-
   gem 'factory_girl_rails'
 
   gem 'rubocop', require: false
@@ -67,7 +62,10 @@ group :development, :test do
 end
 
 group :test do
-  gem "codeclimate-test-reporter", require: nil
+  # in browser debugging
+  gem 'better_errors'
+  gem 'binding_of_caller'
+  gem 'codeclimate-test-reporter', require: nil
   gem 'webmock'
   gem 'capybara'
   gem 'launchy'

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,12 @@ group :development, :test do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+
   gem 'rspec-rails', '~> 3.2'
+  # in browser debugging
+  gem 'better_errors'
+  gem 'binding_of_caller'
+
   gem 'factory_girl_rails'
 
   gem 'rubocop', require: false
@@ -62,10 +67,7 @@ group :development, :test do
 end
 
 group :test do
-  # in browser debugging
-  gem 'better_errors'
-  gem 'binding_of_caller'
-  gem 'codeclimate-test-reporter', require: nil
+  gem "codeclimate-test-reporter", require: nil
   gem 'webmock'
   gem 'capybara'
   gem 'launchy'

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -51,6 +51,12 @@ class DwpCheck < ActiveRecord::Base
     end
   end
 
+  def unique_token
+    return '' unless persisted?
+    short_name = created_by.name.gsub(' ', '').downcase
+    "#{short_name.truncate(27)}@#{created_at.strftime('%y%m%d%H%M%S')}.#{unique_number}"
+  end
+
 private
 
   def generate_unique_number

--- a/app/services/process_dwp_service.rb
+++ b/app/services/process_dwp_service.rb
@@ -2,7 +2,6 @@ class ProcessDwpService
   def initialize(dwp_check)
     @dwp_checker = dwp_check
     check_remote_api
-    @dwp_checker
   end
 
 private

--- a/app/services/process_dwp_service.rb
+++ b/app/services/process_dwp_service.rb
@@ -1,0 +1,34 @@
+class ProcessDwpService
+  def initialize(dwp_check)
+    @dwp_checker = dwp_check
+    check_remote_api
+    @dwp_checker
+  end
+
+private
+
+  def check_remote_api
+    @dwp_checker.save!
+    @dwp_checker.dwp_result = query_proxy_api
+    @dwp_checker.benefits_valid = (@dwp_checker.dwp_result == 'Yes' ? true : false)
+    @dwp_checker.save!
+  end
+
+  def query_proxy_api
+    params = {
+      id: @dwp_checker.unique_token,
+      ni_number: @dwp_checker.ni_number,
+      surname: @dwp_checker.last_name.upcase,
+      birth_date: @dwp_checker.dob.strftime('%Y%m%d'),
+      entitlement_check_date: process_check_date
+    }
+    response = RestClient.post "#{ENV['DWP_API_PROXY']}/api/benefit_checks", params
+    JSON.parse(response)['benefit_checker_status']
+  end
+
+  def process_check_date
+    check_date = @dwp_checker.date_to_check ? @dwp_checker.date_to_check : Date.today
+    check_date.strftime('%Y%m%d')
+  end
+
+end

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe DwpChecksController, type: :controller do
                   "confirmation_ref": "T1426267181940",
                   "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
           stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-            with(body: { birth_date: '19800101', entitlement_check_date: Date.today.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'LAST_NAME' }).
             to_return(status: 200, body: json, headers: {})
         end
         it 'accepts d/m/yy' do
@@ -123,7 +122,6 @@ RSpec.describe DwpChecksController, type: :controller do
                   "confirmation_ref": "T1426267181940",
                   "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
           stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-            with(body: { birth_date: '19800101', entitlement_check_date: Date.today.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'LAST_NAME' }).
             to_return(status: 200, body: json, headers: {})
           post :lookup, dwp_check: dwp_params
         end
@@ -134,6 +132,22 @@ RSpec.describe DwpChecksController, type: :controller do
 
         it 'redirects to the result page' do
           expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
+        end
+        context 'when service encounters an error' do
+          before(:each) do
+            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+              to_return(status: 500, headers: {})
+            post :lookup, dwp_check: dwp_params
+          end
+          it 're-renders the form' do
+            expect(response).to render_template(:new)
+          end
+          it 'displays a flash message' do
+            expect(flash[:alert]).to be_present
+          end
+          it 'displays the error description in the flash message' do
+            expect(flash[:alert]).to eql('500 Internal Server Error')
+          end
         end
       end
 
@@ -174,5 +188,4 @@ RSpec.describe DwpChecksController, type: :controller do
       end
     end
   end
-
 end

--- a/spec/features/perform_benefit_check_spec.rb
+++ b/spec/features/perform_benefit_check_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature 'Undertake benefit check', type: :feature do
                  "confirmation_ref": "T1426267181940",
                  "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
         stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-          with(body: { birth_date: '19800101', entitlement_check_date: Date.today.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'BRUCE' }).
           to_return(status: 200, body: json, headers: {})
       end
 

--- a/spec/models/dwp_check_spec.rb
+++ b/spec/models/dwp_check_spec.rb
@@ -7,8 +7,27 @@ RSpec.describe DwpCheck, type: :model do
   it 'pass factory build' do
     expect(check).to be_valid
   end
-
+  context 'methods' do
+    it 'generates a unique token for API checks' do
+      check.created_by = FactoryGirl.create(:user, name: 'Test User')
+      check.save!
+      expect(check).to be_valid
+      check_val = "testuser@#{check.created_at.strftime('%y%m%d%H%M%S')}.#{check.unique_number}"
+      expect(check.unique_token).to eql(check_val)
+    end
+  end
+  context 'associations' do
+    it 'responds with a unique_token' do
+      expect(check).to respond_to(:unique_token)
+    end
+  end
   context 'validations' do
+    it 'requires unique_token to be between 3 and 50 characters' do
+      user = FactoryGirl.create(:user, name: 'a' * 50)
+      check.created_by = user
+      check.save
+      expect(check.unique_token.length).to eql(50)
+    end
     it 'require a last name' do
       check.last_name = nil
       expect(check).to be_invalid

--- a/spec/services/process_dwp_service_spec.rb
+++ b/spec/services/process_dwp_service_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe ProcessDwpService do
+
+  before { WebMock.disable_net_connect!(allow: 'codeclimate.com') }
+
+  context 'called with invalid object' do
+    it 'fails' do
+      expect {
+        described_class.new(nil)
+      }.to raise_error
+    end
+  end
+  context 'called with valid object' do
+    context 'with valid params' do
+      it 'succeeds' do
+        user = FactoryGirl.create(:user)
+        check = FactoryGirl.create(:dwp_check, created_by_id: user.id, dob: '19800101', ni_number: 'AB123456A', last_name: 'LAST_NAME')
+
+        json = '{"original_client_ref": "' + check.unique_token + '", "benefit_checker_status": "Yes",
+               "confirmation_ref": "T1426267181940",
+               "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
+        stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+          with(body: { id: check.unique_token, birth_date: '19800101', entitlement_check_date: Date.today.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'LAST_NAME' }).
+          to_return(status: 200, body: json, headers: {})
+
+        expect {
+          described_class.new(check)
+        }.not_to raise_error
+      end
+    end
+
+    context 'simulating a 500 error' do
+      it 'returns the error' do
+        user = FactoryGirl.create(:user)
+        check = FactoryGirl.create(:dwp_check, created_by_id: user.id, dob: '19800101', ni_number: 'AB123456A', last_name: 'LAST_NAME')
+        stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+          to_return(status: 500, headers: {})
+
+        expect {
+          described_class.new(check)
+        }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
The front end should generate a unique value in the format:

username
timestamp in YYMMDDHHSS
unique id
Which will look like bsmith@YYMDDHHSS.some-id. 
It should be up to 50 characters long, as that is the constraint imposed by DWP API.