### PR TITLE
Added error message for non white listed emails

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,13 @@ class User < ActiveRecord::Base
   scope :sorted_by_email, -> {  all.order(:email) }
 
   email_regex = /\A([^@\s]+)@(hmcts\.gsi|digital\.justice)\.gov\.uk\z/i
-  validates :email, format: { with: email_regex, on: :create }
+  email_message =  <<-END.gsub(/^\s+\|/, '').gsub(/\n/, '')
+    |you’re not able to create an account with this email
+    | address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help,
+    | contact us via #{Settings.mail_tech_support}
+  END
+
+  validates :email, format: { with: email_regex, on: :create, message: email_message }
   validates :role, :name, presence: true
   validates :role, inclusion: {
     in: ROLES,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -36,9 +36,19 @@ describe User, type: :model do
           expect(user).to be_valid
         end
 
-        it 'will not accept non white listed emails' do
-          user.email = 'valid.email.that.rocks@gmail.com'
-          expect(user).to be_invalid
+        context 'non white listed emails' do
+          let(:invalid_email) { 'email.that.rocks@gmail.com' }
+          before(:each) { user.email = invalid_email }
+
+          it 'will not accept non white listed emails' do
+            expect(user).to be_invalid
+          end
+
+          it 'has an informative error message for non white listed emails' do
+            message = "you’re not able to create an account with this email address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help, contact us via #{Settings.mail_tech_support}"
+            user.valid?
+            expect(user.errors.messages[:email].first).to match message
+          end
         end
       end
     end


### PR DESCRIPTION
Currently we should only allow emails from white listed domains. This
change introduces meaningful and descriptive error messages, so that
when the admin users add a non MOJ approved email, they will know what
the issue is.

The ticket for this PR is [here](https://www.pivotaltracker.com/story/show/93001180).