### PR TITLE
94407712 date validation error on dwp check form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,9 @@ gem 'logstasher'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+# Date validation
+gem 'date_validator'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,8 @@ GEM
     columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
+    date_validator (0.7.1)
+      activemodel
     debug_inspector (0.0.2)
     devise (3.4.1)
       bcrypt (~> 3.0)
@@ -338,6 +340,7 @@ DEPENDENCIES
   chartkick
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
+  date_validator
   devise
   devise_invitable
   factory_girl_rails

--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -32,17 +32,7 @@ private
     @dwp_checker.update(
       created_by_id: current_user.id,
       office_id: current_user.office_id,
-      dob: process_incoming_date(dwp_params[:dob]),
-      date_to_check: process_incoming_date(dwp_params[:date_to_check])
     )
-  end
-
-  def process_incoming_date(date_str)
-    return nil if date_str.blank?
-    Date.parse(date_str)
-  rescue
-    format_str = "%d/%m/" + (date_str =~ /\d{4}/ ? "%Y" : "%y")
-    Date.strptime(date_str, format_str)
   end
 
   def dwp_params

--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -29,10 +29,8 @@ private
 
   def new_from_params
     @dwp_checker = DwpCheck.new(dwp_params)
-    @dwp_checker.update(
-      created_by_id: current_user.id,
-      office_id: current_user.office_id,
-    )
+    @dwp_checker.update(created_by_id: current_user.id,
+                        office_id: current_user.office_id)
   end
 
   def dwp_params

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -37,10 +37,7 @@ class DwpCheck < ActiveRecord::Base
   end
 
   def date_to_check_must_be_valid
-    if date_to_check.present? && (
-      date_to_check > Date.today ||
-      date_to_check < Date.today - 3.months
-    )
+    if date_to_check.present? && within_valid_range?
       errors.add(:date_to_check, 'must be in the last 3 months')
     end
   end
@@ -74,5 +71,17 @@ private
     short_name = created_by.name.gsub(' ', '').downcase.truncate(27)
     self.our_api_token = "#{short_name}@#{created_at.strftime('%y%m%d%H%M%S')}.#{unique_number}"
     self.save!
+  end
+
+  def before_today?
+    date_to_check > Date.today
+  end
+
+  def within_three_months_in_the_past?
+    date_to_check < Date.today - 3.months
+  end
+
+  def within_valid_range?
+    before_today? || within_three_months_in_the_past?
   end
 end

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -13,7 +13,7 @@ class DwpCheck < ActiveRecord::Base
 
   before_validation :strip_whitespace
 
-  validates :last_name, :dob, :ni_number, :office_id, presence: true
+  validates :last_name, :ni_number, :office_id, presence: true
   validates :last_name, length: { minimum: 2 }, allow_blank: true
 
   validates :dob, date: true, presence: true

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -50,7 +50,7 @@ class DwpCheck < ActiveRecord::Base
       begin
         Date.parse "#{date_to_check}"
       rescue ArgumentError
-        errors.add(:date_to_check, 'ffffffffff')
+        errors.add(:date_to_check, 'invalid date given')
       end
     end
   end

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -1,5 +1,7 @@
 class DwpCheck < ActiveRecord::Base
 
+  MAX_AGE = 120
+
   include CommonScopes
 
   belongs_to :created_by, class_name: 'User'
@@ -83,5 +85,11 @@ private
 
   def within_valid_range?
     before_today? || within_three_months_in_the_past?
+  end
+
+  def validate_dob_maximum
+    if dob < Date.today - MAX_AGE.years
+      errors.add(:dob, "can't be over #{MAX_AGE} years old")
+    end
   end
 end

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -1,6 +1,7 @@
 class DwpCheck < ActiveRecord::Base
 
   MAX_AGE = 120
+  MIN_AGE = 16
 
   include CommonScopes
 
@@ -94,11 +95,18 @@ private
   def dob_age_valid?
     errors.add(:dob, "can't contain non numbers") if dob =~ /a-zA-Z/
     validate_dob_maximum unless dob.blank?
+    validate_dob_minimum unless dob.blank?
   end
 
   def validate_dob_maximum
     if dob < Date.today - MAX_AGE.years
       errors.add(:dob, "can't be over #{MAX_AGE} years old")
+    end
+  end
+
+  def validate_dob_minimum
+    if dob > Date.today - MIN_AGE.years
+      errors.add(:dob, "can't be under #{MIN_AGE} years old")
     end
   end
 end

--- a/app/views/dwp_checks/new.html.slim
+++ b/app/views/dwp_checks/new.html.slim
@@ -1,6 +1,6 @@
 h2 Check benefits
 
-= form_for(@dwp_checker, url: dwp_checks_lookup_path, html: { autocomplete: 'off' } ) do |f|
+= form_for(@dwp_checker, url: dwp_checks_lookup_path, html: { autocomplete: 'off' }, method: :post) do |f|
   .row
     .small-12.medium-8.large-5.columns
       .form-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
             dob:
               blank: 'Enter the applicant’s date of birth'
               invalid: 'Enter the date as ‘day, month, year DD/MM/YYYY'
+              not_a_date: 'Enter the date as ‘day, month, year DD/MM/YYYY'
             ni_number:
               blank: 'Enter the applicant’s National Insurance number'
               invalid: 'Enter 2 letters, 6 numbers and 1 letter for the National Insurance number'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,10 +53,13 @@ en:
               blank: 'Enter the applicant’s last name'
             dob:
               blank: 'Enter the applicant’s date of birth'
-              invalid: 'Enter the date as ‘day, month, year DD/MM/YY'
+              invalid: 'Enter the date as ‘day, month, year DD/MM/YYYY'
             ni_number:
               blank: 'Enter the applicant’s National Insurance number'
               invalid: 'Enter 2 letters, 6 numbers and 1 letter for the National Insurance number'
+            date_to_check:
+              not_a_date: 'Enter the date the application was made'
+              invalid: 'Enter the date in this format day month, year DD/MM/YYYY'
     attributes:
       user:
         password: Password

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe DwpChecksController, type: :controller do
     {
       id: nil,
       last_name: 'Smith',
-      dob: '2000-01-01',
+      dob: Date.today - 20.years,
       ni_number: 'AB123456C',
       date_to_check: nil,
       checked_by: nil,

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -84,21 +84,13 @@ RSpec.describe DwpChecksController, type: :controller do
           stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
             to_return(status: 200, body: json, headers: {})
         end
-        it 'accepts d/m/yy' do
+
+        it "doesn't accepts d/m/yy date format" do
           dwp_params[:dob] = '1/1/80'
           post :lookup, dwp_check: dwp_params
-          expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
+          expect(response).to render_template('dwp_checks/new')
         end
-        it 'accepts dd/mm/yy' do
-          dwp_params[:dob] = '01/01/80'
-          post :lookup, dwp_check: dwp_params
-          expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
-        end
-        it 'accepts dd mmm yy' do
-          dwp_params[:dob] = '01 Jan 80'
-          post :lookup, dwp_check: dwp_params
-          expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
-        end
+
         it 'accepts dd mmmm yyyy' do
           dwp_params[:dob] = '01 January 1980'
           post :lookup, dwp_check: dwp_params

--- a/spec/factories/dwp_checks.rb
+++ b/spec/factories/dwp_checks.rb
@@ -3,7 +3,7 @@ FactoryGirl.define do
     last_name "Smith"
     dob "2000-01-01"
     ni_number "AB123456C"
-    date_to_check nil
+    date_to_check Date.yesterday
     checked_by nil
     laa_code nil
     unique_number nil

--- a/spec/factories/dwp_checks.rb
+++ b/spec/factories/dwp_checks.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :dwp_check do
     last_name "Smith"
-    dob "2000-01-01"
+    dob Date.today - 20.years
     ni_number "AB123456C"
     date_to_check Date.yesterday
     checked_by nil

--- a/spec/models/dwp_check_spec.rb
+++ b/spec/models/dwp_check_spec.rb
@@ -73,10 +73,11 @@ RSpec.describe DwpCheck, type: :model do
       end
     end
 
-    pending 'requires date of birth to be in the past, (more than 16 years ago!)' do
+    it 'requires date of birth to be in the past, (more than 16 years ago!)' do
       check.dob = Date.today
+      check.valid?
       expect(check).to be_invalid
-      expect(check.errors[:dob]).to eq ['must be before today']
+      expect(check.errors[:dob]).to eq ["can't be under 16 years old"]
     end
 
     it 'require a NI number' do

--- a/spec/models/dwp_check_spec.rb
+++ b/spec/models/dwp_check_spec.rb
@@ -56,15 +56,17 @@ RSpec.describe DwpCheck, type: :model do
       expect(check).to be_invalid
     end
 
-    it 'allows a date to check to be passed' do
-      check.date_to_check = Date.today
-      expect(check).to be_valid
-    end
+    context 'date to check' do
+      it 'allows a date to check to be passed' do
+        check.date_to_check = Date.today
+        expect(check).to be_valid
+      end
 
-    it 'requires date to check to be in the last three months' do
-      check.date_to_check = Date.today.-3.months.+1.day
-      expect(check).to be_invalid
-      expect(check.errors[:date_to_check]).to eq ['must be in the last 3 months']
+      it 'requires date to check to be in the last three months' do
+        check.date_to_check = Date.today.-3.months.+1.day
+        expect(check).to be_invalid
+        expect(check.errors[:date_to_check]).to eq ['must be in the last 3 months']
+      end
     end
 
     it 'only allow valid NI numbers' do

--- a/spec/models/dwp_check_spec.rb
+++ b/spec/models/dwp_check_spec.rb
@@ -40,9 +40,37 @@ RSpec.describe DwpCheck, type: :model do
       expect(check.errors[:last_name]).to eq ['is too short (minimum is 2 characters)']
     end
 
-    it 'require a date of birth' do
-      check.dob = nil
-      expect(check).to be_invalid
+    context 'date of birth' do
+      it 'require a date of birth' do
+        check.dob = nil
+        expect(check).to be_invalid
+      end
+
+      context 'maximum age' do
+        describe 'invalid maximum age' do
+          before do
+            check.dob = Date.today - 121.years
+            check.valid?
+          end
+
+          it "doesn't allow date of birth to be over 120 years" do
+            expect(check).to be_invalid
+          end
+
+          it 'has an error message' do
+            error = ["can't be over #{DwpCheck::MAX_AGE} years old"]
+            expect(check.errors.messages[:dob]).to eq error
+          end
+        end
+
+        describe 'valid maximum age' do
+          before { check.dob = Date.today - 120.years }
+
+          it 'does allow date of birth to be under 120 years' do
+            expect(check).to be_valid
+          end
+        end
+      end
     end
 
     it 'requires date of birth to be in the past' do

--- a/spec/models/dwp_check_spec.rb
+++ b/spec/models/dwp_check_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe DwpCheck, type: :model do
       end
     end
 
-    it 'requires date of birth to be in the past' do
+    pending 'requires date of birth to be in the past, (more than 16 years ago!)' do
       check.dob = Date.today
       expect(check).to be_invalid
       expect(check.errors[:dob]).to eq ['must be before today']
@@ -95,6 +95,45 @@ RSpec.describe DwpCheck, type: :model do
         expect(check).to be_invalid
         expect(check.errors[:date_to_check]).to eq ['must be in the last 3 months']
       end
+
+      it 'allows blank values as valid' do
+        check.date_to_check = ''
+        expect(check).to be_valid
+      end
+
+      context 'in format DD/MM/YY' do
+        let(:date) { Date.yesterday.strftime("%d/%m/%y") }
+
+        it "doesn't accepts date in format DD/MM/YY" do
+          check.date_to_check = "#{date}"
+          expect(check).to be_invalid
+        end
+
+        it "does accept date in format 'DD/MM/YY' + some string" do
+          check.date_to_check = "#{date}a"
+          expect(check).to be_invalid
+        end
+      end
+
+      context 'in format DD/MM/YYYY' do
+        let(:date) { Date.yesterday.strftime("%d/%m/%Y") }
+
+        it 'accepts the date in format DD/MM/YYYY' do
+          check.date_to_check = date
+          expect(check).to be_valid
+        end
+
+        it "does accept date in format 'DD/MM/YYYY' + some string" do
+          check.date_to_check = "#{date}aaaaa"
+          expect(check).to be_valid
+        end
+
+        it "does accept date in format 'some string' + 'DD/MM/YYYY' + some string" do
+          check.date_to_check = "aaaaa#{date}bbbb"
+          expect(check).to be_valid
+        end
+      end
+
     end
 
     it 'only allow valid NI numbers' do

--- a/spec/services/process_dwp_service_spec.rb
+++ b/spec/services/process_dwp_service_spec.rb
@@ -21,7 +21,7 @@ describe ProcessDwpService do
                "confirmation_ref": "T1426267181940",
                "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
         stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-          with(body: { id: check.our_api_token, birth_date: '19800101', entitlement_check_date: Date.today.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'LAST_NAME' }).
+          with(body: { id: check.unique_token, birth_date: '19800101', entitlement_check_date: Date.yesterday.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'LAST_NAME' }).
           to_return(status: 200, body: json, headers: {})
         described_class.new(check)
       end

--- a/spec/services/process_dwp_service_spec.rb
+++ b/spec/services/process_dwp_service_spec.rb
@@ -16,15 +16,21 @@ describe ProcessDwpService do
 
       let(:user) { FactoryGirl.create(:user) }
       let(:check) { FactoryGirl.create(:dwp_check, created_by_id: user.id, dob: '19800101', ni_number: 'AB123456A', last_name: 'LAST_NAME') }
+
       before(:each) do
         json = '{"original_client_ref": "' + check.our_api_token + '", "benefit_checker_status": "Yes",
                "confirmation_ref": "T1426267181940",
                "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
         stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-          with(body: { id: check.unique_token, birth_date: '19800101', entitlement_check_date: Date.yesterday.strftime('%Y%m%d'), ni_number: 'AB123456A', surname: 'LAST_NAME' }).
+          with(body: { id: check.our_api_token,
+                       birth_date: '19800101',
+                       entitlement_check_date: "#{Date.yesterday.strftime('%Y%m%d')}",
+                       ni_number: 'AB123456A',
+                       surname: 'LAST_NAME' }).
           to_return(status: 200, body: json, headers: {})
         described_class.new(check)
       end
+
       it 'succeeds' do
         expect {
           described_class.new(check)


### PR DESCRIPTION
Prevent the error popping up when an invalid date is entered for the date of birth of for the date_application_made.

Also added constraints such as 16 years being the minimum age and 120 years being the maximum age of an applicant. The logic is that we've agreed as a team to have 120 be the maximum age. For minimum age, the reason it's 16 is because you get your national insurance card at that age.