### PR TITLE
Implement manager role 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'logstasher'
 
 # Date validation
 gem 'date_validator'
+gem 'will_paginate'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,7 @@ GEM
     webmock (1.20.4)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    will_paginate (3.0.7)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -371,3 +372,4 @@ DEPENDENCIES
   unicorn
   web-console (~> 2.1)
   webmock
+  will_paginate

--- a/app/assets/stylesheets/pagination.sass
+++ b/app/assets/stylesheets/pagination.sass
@@ -1,4 +1,4 @@
-.digg_pagination
+.pagination
   background: white
   cursor: default
   a, span, em
@@ -45,60 +45,3 @@
   *:first-child+html &
     overflow: hidden
 
-.apple_pagination
-  background: #f1f1f1
-  border: 1px solid #e5e5e5
-  text-align: center
-  padding: 1em
-  cursor: default
-  a, span
-    padding: 0.2em 0.3em
-  .disabled
-    color: #aaaaaa
-  .current
-    font-style: normal
-    font-weight: bold
-    background-color: darken(#f1f1f1, 20)
-    display: inline-block
-    width: 1.4em
-    height: 1.4em
-    line-height: 1.5
-    -moz-border-radius: 1em
-    -webkit-border-radius: 1em
-    border-radius: 1em
-    text-shadow: rgba(white, .8) 1px 1px 1px
-  a
-    text-decoration: none
-    color: black
-    &:hover, &:focus
-      text-decoration: underline
-
-.flickr_pagination
-  text-align: center
-  padding: 0.3em
-  cursor: default
-  a, span, em
-    padding: 0.2em 0.5em
-  .disabled
-    color: #aaaaaa
-  .current
-    font-style: normal
-    font-weight: bold
-    color: #ff0084
-  a
-    border: 1px solid #dddddd
-    color: #0063dc
-    text-decoration: none
-    &:hover, &:focus
-      border-color: #003366
-      background: #0063dc
-      color: white
-  .page_info
-    color: #aaaaaa
-    padding-top: 0.8em
-  .previous_page, .next_page
-    border-width: 2px
-  .previous_page
-    margin-right: 1em
-  .next_page
-    margin-left: 1em

--- a/app/assets/stylesheets/pagination.sass
+++ b/app/assets/stylesheets/pagination.sass
@@ -1,0 +1,104 @@
+.digg_pagination
+  background: white
+  cursor: default
+  a, span, em
+    padding: 0.1em 0.5em
+    display: block
+    float: left
+    margin-right: 1px
+  .disabled
+    color: #999999
+    border: 1px solid #dddddd
+  .current
+    font-style: normal
+    font-weight: bold
+    background: #2e6ab1
+    color: white
+    border: 1px solid #2e6ab1
+  a
+    text-decoration: none
+    color: #105cb6
+    border: 1px solid #9aafe5
+    &:hover, &:focus
+      color: #000033
+      border-color: #000033
+  .page_info
+    background: #2e6ab1
+    color: white
+    padding: 0.4em 0.6em
+    width: 22em
+    margin-bottom: 0.3em
+    text-align: center
+    b
+      color: #000033
+      background: #2e6ab1 + 60
+      padding: 0.1em 0.25em
+  /* self-clearing method:
+  &:after
+    content: "."
+    display: block
+    height: 0
+    clear: both
+    visibility: hidden
+  * html &
+    height: 1%
+  *:first-child+html &
+    overflow: hidden
+
+.apple_pagination
+  background: #f1f1f1
+  border: 1px solid #e5e5e5
+  text-align: center
+  padding: 1em
+  cursor: default
+  a, span
+    padding: 0.2em 0.3em
+  .disabled
+    color: #aaaaaa
+  .current
+    font-style: normal
+    font-weight: bold
+    background-color: darken(#f1f1f1, 20)
+    display: inline-block
+    width: 1.4em
+    height: 1.4em
+    line-height: 1.5
+    -moz-border-radius: 1em
+    -webkit-border-radius: 1em
+    border-radius: 1em
+    text-shadow: rgba(white, .8) 1px 1px 1px
+  a
+    text-decoration: none
+    color: black
+    &:hover, &:focus
+      text-decoration: underline
+
+.flickr_pagination
+  text-align: center
+  padding: 0.3em
+  cursor: default
+  a, span, em
+    padding: 0.2em 0.5em
+  .disabled
+    color: #aaaaaa
+  .current
+    font-style: normal
+    font-weight: bold
+    color: #ff0084
+  a
+    border: 1px solid #dddddd
+    color: #0063dc
+    text-decoration: none
+    &:hover, &:focus
+      border-color: #003366
+      background: #0063dc
+      color: white
+  .page_info
+    color: #aaaaaa
+    padding-top: 0.8em
+  .previous_page, .next_page
+    border-width: 2px
+  .previous_page
+    margin-right: 1em
+  .next_page
+    margin-left: 1em

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,13 +1,4 @@
 class HomeController < ApplicationController
   def index
-    if user_signed_in? && current_user.admin?
-      @report_data = []
-      Office.non_digital.each do |office|
-        @report_data << {
-          name: office.name,
-          dwp_checks: DwpCheck.by_office_grouped_by_type(office.id).checks_by_day
-        }
-      end
-    end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,15 @@
 class HomeController < ApplicationController
+  before_action :load_dwp_data, only: [:index], if: 'user_signed_in? && current_user.manager?'
+
   def index
+  end
+
+private
+
+  def load_dwp_data
+    @dwpchecks = DwpCheck.
+                 by_office(current_user.office_id).
+                 page(params[:page]).
+                 order('created_at DESC')
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -3,6 +3,11 @@ class Users::InvitationsController < Devise::InvitationsController
   before_action :authenticate_user!
   load_and_authorize_resource User, except: [:edit, :update]
 
+  def new
+    @user = User.new
+    render :new
+  end
+
 private
 
   def invite_resource

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -5,6 +5,11 @@ class Users::InvitationsController < Devise::InvitationsController
 
   def new
     @user = User.new
+    if current_user.admin?
+      @roles = User::ROLES
+    else
+      @roles = User::ROLES - %w[admin]
+    end
     render :new
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,8 @@ class UsersController < ApplicationController
   respond_to :html
   before_action :authenticate_user!
   before_action :find_user, only: [:edit, :show, :update]
-  before_action :populate_roles, only: [:edit]
-  before_action :populate_offices, only: [:edit]
+  before_action :populate_roles, only: [:edit, :update]
+  before_action :populate_offices, only: [:edit, :update]
   load_and_authorize_resource
 
   def index
@@ -32,7 +32,7 @@ class UsersController < ApplicationController
 protected
 
   def user_params
-    params.require(:user).permit(:email, :role, :office_id)
+    params.require(:user).permit(:name, :email, :role, :office_id)
   end
 
   def current_user_can_change_office?(user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,11 @@ class UsersController < ApplicationController
   load_and_authorize_resource
 
   def index
-    @users = User.sorted_by_email
+    if current_user.admin?
+      @users = User.sorted_by_email
+    elsif current_user.manager?
+      @users = User.by_office(current_user.office_id).sorted_by_email
+    end
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,12 +29,6 @@ class UsersController < ApplicationController
     respond_with(@user)
   end
 
-  def destroy
-    @user = User.find(params[:id])
-    @user.destroy
-    respond_with(@user)
-  end
-
 protected
 
   def user_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
     if current_user.admin?
       @users = User.sorted_by_email
     elsif current_user.manager?
-      @users = User.by_office(current_user.office_id).sorted_by_email
+      @users = User.by_office(current_user.office_id).where.not(role: 'admin').sorted_by_email
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,11 @@ class UsersController < ApplicationController
 
   def edit
     @user = User.find(params[:id])
+    if current_user.admin?
+      @roles = User::ROLES
+    else
+      @roles = User::ROLES - %w[admin]
+    end
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,7 @@ class UsersController < ApplicationController
   def update
     flash[:notice] = 'User updated' if @user.update_attributes(user_params)
     if current_user_can_change_office?(@user)
-      flash[:notice] = t('error_messages.user.moved_offices', office_name: @user.office.name)
+      flash[:notice] = user_transfer_message(@user)
       return redirect_to users_path
     end
     respond_with(@user)
@@ -37,6 +37,15 @@ protected
 
   def current_user_can_change_office?(user)
     current_user.manager? && (user.office != current_user.office)
+  end
+
+  def user_transfer_message(user)
+    office = user.office
+    t('error_messages.user.moved_offices',
+      user: user.name,
+      office: office.name,
+      contact: office.managers_email
+    )
   end
 
   def find_user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,11 +7,21 @@ class Ability
     if user.admin?
       can :manage, :all
     elsif user.manager?
-      can [:read, :create, :show], User, office_id: user.office_id
+      can [:manage], User do |staff_member|
+        can_manage_user?(user, staff_member)
+      end
       users_can
     else
       users_can
     end
+  end
+
+  def can_manage_user?(manager, staff_member)
+    if staff_member.office_id != manager.office_id
+      raise CanCan::AccessDenied.new(I18n.t('unauthorized.manage.wrong_office'), User, :manage)
+    end
+
+    true
   end
 
 private

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,13 +6,22 @@ class Ability
 
     if user.admin?
       can :manage, :all
+    elsif user.manager?
+      can [:read, :create, :show], User, office_id: user.office_id
+      users_can
     else
-      can :read, Office
-      can :new, DwpCheck
-      can :lookup, DwpCheck
-      can :show, DwpCheck
-      can :create, R2Calculator
-      can :create, Feedback
+      users_can
     end
+  end
+
+private
+
+  def users_can
+    can :read, Office
+    can :new, DwpCheck
+    can :lookup, DwpCheck
+    can :show, DwpCheck
+    can :create, R2Calculator
+    can :create, Feedback
   end
 end

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -31,10 +31,8 @@ class DwpCheck < ActiveRecord::Base
 
   scope :non_digital, -> { joins(:office).where('offices.name != ?', 'Digital') }
 
-  scope :by_office, lambda { |office_id|
-    joins('left outer join users on dwp_checks.created_by_id = users.id').
-      where('dwp_checks.office_id = ?', office_id)
-  }
+  scope :by_office, -> (office_id) { where('dwp_checks.office_id = ?', office_id) }
+
   scope :by_office_grouped_by_type, lambda { |office_id|
     joins('left outer join users on dwp_checks.created_by_id = users.id').
       where('dwp_checks.office_id = ?', office_id).

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -6,4 +6,16 @@ class Office < ActiveRecord::Base
 
   validates :name, presence: true
 
+  def managers
+    users.where(office_id: id, role: 'manager')
+  end
+
+  def managers_email
+    return 'a manager' unless managers.present?
+    emails = []
+    managers.each do |m|
+      emails << "<a href=\"mailto:#{m.email}\">#{m.name}</a>".html_safe
+    end
+    emails.join(', ')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ActiveRecord::Base
 
   scope :sorted_by_email, -> {  all.order(:email) }
 
+  scope :by_office, ->(office_id) { where('office_id = ?', office_id) }
+
   email_regex = /\A([^@\s]+)@(hmcts\.gsi|digital\.justice)\.gov\.uk\z/i
   validates :role, :name, presence: true
   validates :email, format: {
@@ -25,6 +27,10 @@ class User < ActiveRecord::Base
     message: "%{value} is not a valid role",
     allow_nil: true
   }
+
+  def elevated?
+    admin? || manager?
+  end
 
   def admin?
     role == 'admin'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   belongs_to :office
 
-  ROLES = %w[admin user]
+  ROLES = %w[user manager admin]
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :registerable, :rememberable and :omniauthable
   devise :database_authenticatable,
@@ -28,5 +28,9 @@ class User < ActiveRecord::Base
 
   def admin?
     role == 'admin'
+  end
+
+  def manager?
+    role == 'manager'
   end
 end

--- a/app/views/home/_manager.html.slim
+++ b/app/views/home/_manager.html.slim
@@ -1,5 +1,4 @@
-.row.small-collapse
-  h2 Manager summary for #{current_user.office.name}
+h2 Manager summary for #{current_user.office.name}
 .row
   .columns.small-12
     table

--- a/app/views/home/_manager.html.slim
+++ b/app/views/home/_manager.html.slim
@@ -1,0 +1,21 @@
+.row.small-collapse
+  h2 Manager summary for #{current_user.office.name}
+.row
+  .columns.small-12
+    table
+      thead
+        tr
+          th Staff member
+          th Date made
+          th Remission Type
+          th Decision
+      tbody
+        -@dwpchecks.each do |dwp|
+          tr
+            td =dwp.created_by.name
+            td =dwp.created_at.strftime('%d/%m/%y')
+            td R1
+            td =link_to dwp.dwp_result.nil? ? dwp.unique_number : dwp.dwp_result, dwp_checks_path(dwp.unique_number)
+.row
+  .columns.small-12.pagination
+    = will_paginate @dwpchecks

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -10,6 +10,8 @@
         .columns.small-12.medium-8.large-6.end
           h3 #{data[:name]} R1
           = column_chart data[:dwp_checks], colors: ['#dc3912', '#109618', '#ff9900', '#dd4477', '#990099', '#3366cc', '#0099c6'], library: { isStacked: true, title: 'Checks made by date (last 7 days)', vAxis: { format: '#' } }
+  -elsif current_user.manager?
+    =render 'home/manager'
   -else
     p 
       span.bold 'Check benefits'

--- a/app/views/layouts/_toolbar.html.slim
+++ b/app/views/layouts/_toolbar.html.slim
@@ -9,8 +9,9 @@
         =link_to t('functions.feedback').to_s, feedback_path
       dd#staff-guide
         =link_to t('functions.staff_guide').to_s, guide_path
-      -if current_user.admin?
+      -if current_user.elevated?
         dd.right
           =link_to 'Users', users_path
+      -if current_user.admin?
         dd.right
           =link_to 'Offices', offices_path

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -35,7 +35,7 @@ html[lang="en"]
       .large-12.columns
         - flash.each do |key, value|
           .alert-box class="#{key}" data-alert=''
-            |#{value}
+            |#{value.html_safe}
             = link_to '&times;'.html_safe, '#', class: 'close'
     .row
       .large-12.columns

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -8,5 +8,5 @@ h2 Edit #{@user.name}
     = f.text_field :email
   .form-group
     = f.label(:roles, 'Role')
-    = f.collection_select :role, User::ROLES, :to_s, :humanize
+    = f.collection_select :role, @roles, :to_s, :humanize
   .actions = f.submit class: 'button btn tiny'

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,7 +1,11 @@
-h2 Edit #{@user.name}
+h2 Edit user
 
 = form_for @user do |f|
 
+  .form-group
+    = f.label :name, @user.errors[:name].join(', ').html_safe, class: 'error' if @user.errors[:name].present?
+    = f.label :name
+    = f.text_field :name
   .form-group
     = f.label :email, @user.errors[:email].join(', ').html_safe, class: 'error' if @user.errors[:email].present?
     = f.label :email
@@ -12,4 +16,4 @@ h2 Edit #{@user.name}
   .form-group
     = f.label :office_id
     = f.collection_select :office_id, @offices, :id, :name
-  .actions = f.submit class: 'button btn tiny'
+  .actions = f.submit class: 'button'

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -9,4 +9,7 @@ h2 Edit #{@user.name}
   .form-group
     = f.label(:roles, 'Role')
     = f.collection_select :role, @roles, :to_s, :humanize
+  .form-group
+    = f.label :office_id
+    = f.collection_select :office_id, @offices, :id, :name
   .actions = f.submit class: 'button btn tiny'

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -5,7 +5,7 @@ table
     th Name
     th Role
     th Office
-    th colspan="2" &nbsp;
+    th &nbsp;
 
   -@users.each do |user|
     tr
@@ -16,6 +16,5 @@ table
         =user.role
       td =user.office.name if user.office.present?
       td =link_to 'Edit', edit_user_path(user)
-      td =link_to 'Destroy', user_path(user), method: :delete
 
 =link_to 'Invite new user', new_user_invitation_path

--- a/app/views/users/invitations/new.html.slim
+++ b/app/views/users/invitations/new.html.slim
@@ -28,13 +28,16 @@ h2
         .row
           .columns.small-12.medium-8.large-5
             = f.label(:roles, 'Role')
-            = f.collection_select :role, User::ROLES, :to_s, :humanize
+            = f.collection_select :role, @roles, :to_s, :humanize
   .row
     .small-12.columns
       .form-group
         .row
           .columns.small-12.medium-8.large-5
-            = f.label(:office_id, 'Office')
-            = f.collection_select :office_id, Office.all, :id, :name
+            -if current_user.admin?
+              = f.label(:office_id, 'Office')
+              = f.collection_select :office_id, Office.all, :id, :name
+            -elsif current_user.manager?
+              = f.hidden_field :office_id, value: current_user.office.id
   p
     = f.submit t("devise.invitations.new.submit_button"), class: 'button btn tiny'

--- a/app/views/users/invitations/new.html.slim
+++ b/app/views/users/invitations/new.html.slim
@@ -1,13 +1,13 @@
 h2
   = t "devise.invitations.new.header"
-= form_for resource, as: resource_name, url: user_invitation_path, html: {:method => :post} do |f|
-  - resource.class.invite_key_fields.each do |field|
+= form_for @user, url: user_invitation_path, html: {:method => :post} do |f|
+  - User.invite_key_fields.each do |field|
     .row
       .small-12.columns
         .form-group
           .row
             .columns.small-12
-              = f.label field, resource.errors[field].join(', ').html_safe, class: 'error' if resource.errors[field].present?
+              = f.label field, @user.errors[field].join(', ').html_safe, class: 'error' if @user.errors[field].present?
           .row
             .columns.small-12.medium-8.large-5
               = f.label field
@@ -17,7 +17,7 @@ h2
         .form-group
           .row
             .columns.small-12
-              = f.label :name, resource.errors[:name].join(', ').html_safe, class: 'error' if resource.errors[:name].present?
+              = f.label :name, @user.errors[:name].join(', ').html_safe, class: 'error' if @user.errors[:name].present?
           .row
             .columns.small-12.medium-8.large-5
               = f.label :name

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,29 @@
-h2 =@user.email
+h2 User details
 
-div
-  =@user.role
-
-div =@user.office.name
+#user-data.calculator-data
+  .row
+    .columns.small-4.large-2
+      label Name
+    .columns.small-6.large-10
+      =@user.name
+  .row
+    .columns.small-4.large-2
+      label Email
+    .columns.small-6.large-10
+      =@user.email
+  .row
+    .columns.small-4.large-2
+      label Role
+    .columns.small-6.large-10
+      =@user.role
+  .row
+    .columns.small-4.large-2
+      label Office
+    .columns.small-6.large-10
+      =@user.office.name
+.row.pad-top-thirty-pix
+  .columns.small-12
+    =link_to 'Edit this user', edit_user_path(@user)
+.row.pad-top-fifteen-px
+  .columns.small-12
+    =link_to 'Back to user list', users_path

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,4 +34,6 @@ module FrStaffapp
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += %W[#{config.root}/scrapers #{config.root}/lib]
   end
+
+  WillPaginate.per_page = 20
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,7 +29,7 @@ en:
     dwp_checker:
       unavailable: 'The benefits checker is not available at the moment. Please check again later.'
     user:
-      moved_offices: "User moved to %{office_name}, you will need to contact a manager there if this was done in error"
+      moved_offices: "%{user} moved to %{office}, you will need to contact %{contact} there if this was done in error"
   dictionary:
     invalid_email: "You’re not able to create an account with this email address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help, <a href='mailto:%{email}'>contact us</a>"
   feedback:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,9 +37,8 @@ en:
     rating_4: 'Other'
   unauthorized:
     manage:
-      user: You are not authorized to access this page.
-    show:
-      user: You can only access accounts in your office
+      all: You are not authorized to access this page.
+      wrong_office: You are not authorized to manage this user.
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,8 @@ en:
   error_messages:
     dwp_checker:
       unavailable: 'The benefits checker is not available at the moment. Please check again later.'
+    user:
+      moved_offices: "User moved to %{office_name}, you will need to contact a manager there if this was done in error"
   dictionary:
     invalid_email: "You’re not able to create an account with this email address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help, <a href='mailto:%{email}'>contact us</a>"
   feedback:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,11 @@ en:
     rating_2: 'I used an accessibility tool such as a screen reader'
     rating_3: 'I needed other kind of help'
     rating_4: 'Other'
+  unauthorized:
+    manage:
+      user: You are not authorized to access this page.
+    show:
+      user: You can only access accounts in your office
   activerecord:
     errors:
       models:
@@ -43,6 +48,7 @@ en:
             email:
               blank: 'Enter your email address'
               not_found: Your email address has not been recognised. First check that you've typed it correctly. For more help <a href='mailto:trial.feedback@digital.justice.gov.uk'>contact us</a>
+              taken: This email has already been taken
             name:
               blank: You must enter a name for the user
             password:

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -6,12 +6,29 @@ RSpec.describe HomeController, type: :controller do
 
   describe "GET #index" do
     let(:user)          { FactoryGirl.create :user }
+    let(:manager)       { FactoryGirl.create :manager }
 
     context 'when the user is authenticated' do
-      before { sign_in user }
-      it "returns http success" do
-        get :index
-        expect(response).to have_http_status(:success)
+      context 'as a user' do
+        before { sign_in user }
+        it "returns http success" do
+          get :index
+          expect(response).to have_http_status(:success)
+        end
+      end
+      context 'as a manager' do
+        before(:each) do
+          DwpCheck.delete_all
+          FactoryGirl.create_list :dwp_check, 2, created_by: manager, office: manager.office
+          sign_in manager
+          get :index
+        end
+        it 'returns http success' do
+          expect(response).to have_http_status(:success)
+        end
+        it 'populates a list of dwp_checks' do
+          expect(assigns(:dwpchecks).count).to eql(2)
+        end
       end
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -25,11 +25,6 @@ RSpec.describe UsersController, type: :controller do
     }
   }
 
-  # This should return the minimal set of values that should be in the session
-  # in order to pass any filters (e.g. authentication) defined in
-  # UsersController. Be sure to keep this updated too.
-  let(:valid_session) { {} }
-
   let(:user)          { FactoryGirl.create :user }
   let(:admin_user)    { FactoryGirl.create :admin_user }
   let(:test_user) { User.create! valid_attributes }
@@ -37,19 +32,19 @@ RSpec.describe UsersController, type: :controller do
   context 'logged out user' do
     describe 'GET #index' do
       it 'redirects to login page' do
-        get :index, {}, valid_session
+        get :index, {}
         expect(response).to redirect_to(user_session_path)
       end
     end
     describe 'GET #show' do
       it 'redirects to login page' do
-        get :show, { id: test_user.to_param }, valid_session
+        get :show, id: test_user.to_param
         expect(response).to redirect_to(user_session_path)
       end
     end
     describe 'GET #edit' do
       it 'redirects to login page' do
-        get :edit, { id: test_user.to_param }, valid_session
+        get :edit, id: test_user.to_param
         expect(response).to redirect_to(user_session_path)
       end
     end
@@ -60,21 +55,21 @@ RSpec.describe UsersController, type: :controller do
     describe 'GET #index' do
       it 'generates access denied error' do
         expect {
-          get :index, {}, valid_session
+          get :index, {}
         }.to raise_error CanCan::AccessDenied, 'You are not authorized to access this page.'
       end
     end
     describe 'GET #show' do
       it 'generates access denied error' do
         expect {
-          get :edit, { id: test_user.to_param }, valid_session
+          get :edit, id: test_user.to_param
         }.to raise_error CanCan::AccessDenied, 'You are not authorized to access this page.'
       end
     end
     describe 'GET #edit' do
       it 'generates access denied error' do
         expect {
-          get :show, { id: test_user.to_param }, valid_session
+          get :show, id: test_user.to_param
         }.to raise_error CanCan::AccessDenied, 'You are not authorized to access this page.'
       end
     end
@@ -84,7 +79,7 @@ RSpec.describe UsersController, type: :controller do
     before(:each) { sign_in admin_user }
     describe 'GET #index' do
       it 'shows user list' do
-        get :index, {}, valid_session
+        get :index, {}
         test_user
         user
         expect(assigns(:users).last).to eql(user)
@@ -92,13 +87,13 @@ RSpec.describe UsersController, type: :controller do
     end
     describe 'GET #show' do
       it 'shows user details' do
-        get :show, { id: test_user.to_param }, valid_session
+        get :show, id: test_user.to_param
         expect(assigns(:user)).to eq(test_user)
       end
     end
     describe 'GET #edit' do
       it 'shows edit page' do
-        get :edit, { id: test_user.to_param }, valid_session
+        get :edit, id: test_user.to_param
         expect(assigns(:user)).to eq(test_user)
       end
     end
@@ -113,29 +108,29 @@ RSpec.describe UsersController, type: :controller do
         }
 
         it 'updates the requested user' do
-          put :update, { id: test_user.to_param, user: new_attributes }, valid_session
+          put :update, id: test_user.to_param, user: new_attributes
           user.reload
         end
 
         it 'assigns the requested user as @user' do
-          put :update, { id: test_user.to_param, user: valid_attributes }, valid_session
+          put :update, id: test_user.to_param, user: valid_attributes
           expect(assigns(:user)).to eq(test_user)
         end
 
         it 'redirects to the user' do
-          put :update, { id: test_user.to_param, user: valid_attributes }, valid_session
+          put :update, id: test_user.to_param, user: valid_attributes
           expect(response).to redirect_to(user_path)
         end
       end
 
       context 'with invalid params' do
         it 'assigns the user as @user' do
-          put :update, { id: test_user.to_param, user: invalid_attributes }, valid_session
+          put :update, id: test_user.to_param, user: invalid_attributes
           expect(assigns(:user)).to eq(test_user)
         end
 
         it 're-renders the "edit" template' do
-          put :update, { id: test_user.to_param, user: invalid_attributes }, valid_session
+          put :update, id: test_user.to_param, user: invalid_attributes
           expect(response).to render_template('edit')
         end
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe UsersController, type: :controller do
         expect(assigns(:users).count).to eql(4)
         expect(User.count).to eql(7)
       end
+      it 'does not show admins assigned to their office' do
+        FactoryGirl.create :admin_user, office: manager.office
+        get :index
+        expect(User.count).to eql(8)
+        expect(assigns(:users).count).to eql(4)
+      end
     end
     describe 'GET #show' do
       context 'for a user in their office' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe UsersController, type: :controller do
       end
     end
   end
+
   context 'manager' do
     before do
       User.delete_all
@@ -120,20 +121,40 @@ RSpec.describe UsersController, type: :controller do
       end
     end
   end
+
   context 'admin user' do
+    before do
+      User.delete_all
+      FactoryGirl.create_list :user, 3, office: admin_user.office
+      FactoryGirl.create_list :user, 3, office: FactoryGirl.create(:office)
+    end
     before(:each) { sign_in admin_user }
     describe 'GET #index' do
       it 'shows user list' do
-        get :index, {}
-        test_user
-        user
-        expect(assigns(:users).last).to eql(user)
+        get :index
+        expect(assigns(:users).count).to eql(7)
       end
     end
     describe 'GET #show' do
-      it 'shows user details' do
-        get :show, id: test_user.to_param
-        expect(assigns(:user)).to eq(test_user)
+      context 'for a user in their office' do
+        before(:each) do
+          get :show, id: User.first.to_param
+        end
+        it 'renders the view' do
+          expect(response).to render_template :show
+        end
+        it 'returns a success code' do
+          expect(response).to have_http_status(:success)
+        end
+      end
+      context 'for a user not in their office' do
+        before(:each) { get :show, id: User.last.to_param }
+        it 'returns a success code' do
+          expect(response).to have_http_status(:success)
+        end
+        it 'renders the index view' do
+          expect(response).to render_template :show
+        end
       end
     end
     describe 'GET #edit' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe UsersController, type: :controller do
       it 'generates access denied error' do
         expect {
           get :show, id: test_user.to_param
-        }.to raise_error CanCan::AccessDenied, 'You can only access accounts in your office'
+        }.to raise_error CanCan::AccessDenied, 'You are not authorized to access this page.'
       end
     end
   end
@@ -106,17 +106,32 @@ RSpec.describe UsersController, type: :controller do
         it 'returns a redirect code' do
           expect {
             get :show, id: User.last.to_param
-          }.to raise_error CanCan::AccessDenied, 'You can only access accounts in your office'
+          }.to raise_error CanCan::AccessDenied, 'You are not authorized to manage this user.'
         end
         it 'renders the index view' do
           expect {
             get :show, id: User.last.to_param
-          }.to raise_error CanCan::AccessDenied, 'You can only access accounts in your office'
+          }.to raise_error CanCan::AccessDenied, 'You are not authorized to manage this user.'
         end
-        it 'displays a flash message' do
+      end
+    end
+    describe 'GET #edit' do
+      context 'for a user not in their office' do
+        it 'returns a redirect code' do
           expect {
             get :show, id: User.last.to_param
-          }.to raise_error CanCan::AccessDenied, 'You can only access accounts in your office'
+          }.to raise_error CanCan::AccessDenied, 'You are not authorized to manage this user.'
+        end
+        it 'renders the index view' do
+          expect {
+            get :show, id: User.last.to_param
+          }.to raise_error CanCan::AccessDenied, 'You are not authorized to manage this user.'
+        end
+      end
+      context 'for a user in their office' do
+        it 'shows edit page' do
+          get :edit, id: User.first.to_param
+          expect(response).to render_template :edit
         end
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe UsersController, type: :controller do
             expect(response).to redirect_to users_path
           end
           it 'displays an alert containing contact details for the new manager' do
-            err_msg = "User moved to #{new_office.name}, you will need to contact a manager there if this was done in error"
+            err_msg = I18n.t('error_messages.user.moved_offices', user: User.first.name, office: new_office.name, contact: new_office.managers_email)
             expect(flash[:notice]).to be_present
             expect(flash[:notice]).to eql(err_msg)
           end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,8 @@ FactoryGirl.define do
     factory :admin_user do
       role 'admin'
     end
+    factory :manager do
+      role 'manager'
+    end
   end
 end

--- a/spec/features/user_invite_spec.rb
+++ b/spec/features/user_invite_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Office management', type: :feature do
+RSpec.feature 'User management,', type: :feature do
 
   include Warden::Test::Helpers
   Warden.test_mode!

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -2,10 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Office, type: :model do
 
+  let(:office)      { FactoryGirl.build :office }
+
   context 'validations' do
-
-    let(:office)      { FactoryGirl.build :office }
-
     it 'not accept office with no name' do
       office.name = nil
       expect(office).to be_invalid
@@ -15,6 +14,40 @@ RSpec.describe Office, type: :model do
     it 'validate' do
       expect(office).to be_valid
     end
+  end
 
+  context 'responds to' do
+    it 'managers' do
+      expect(office).to respond_to(:managers)
+    end
+  end
+
+  describe 'managers' do
+    let(:office)      { FactoryGirl.create :office }
+    it 'returns a list of user in the manager role' do
+      User.delete_all
+      FactoryGirl.create_list :user, 3, office: office
+      FactoryGirl.create :manager, office: office
+      expect(office.managers.count).to eql 1
+    end
+  end
+  describe 'managers_email' do
+    let(:office)      { FactoryGirl.create :office }
+    context 'managers are empty' do
+      before(:each) { User.delete_all }
+      it 'returns a text prompt' do
+        FactoryGirl.create_list :user, 3, office: office
+        expect(office.managers_email).to eql('a manager')
+      end
+    end
+    context 'managers are populated' do
+      before(:each) { User.delete_all }
+      it 'returns an html string of emails of users in the manager role' do
+        manager1 = FactoryGirl.create :manager, office: office
+        manager2 = FactoryGirl.create :manager, office: office
+        expected = "<a href=\"mailto:#{manager1.email}\">#{manager1.name}</a>, <a href=\"mailto:#{manager2.email}\">#{manager2.name}</a>"
+        expect(office.managers_email).to eql(expected)
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,11 +3,28 @@ require 'rails_helper'
 
 describe User, type: :model do
 
-  let(:user)          { FactoryGirl.build :user }
-  let(:admin_user)    { FactoryGirl.build :admin_user }
+  let(:user)       { FactoryGirl.build :user }
+  let(:admin_user) { FactoryGirl.build :admin_user }
+  let(:manager)    { FactoryGirl.build :manager }
 
   it 'pass factory build' do
     expect(user).to be_valid
+  end
+
+  describe 'scopes' do
+    describe 'by_office' do
+      before { described_class.delete_all }
+      it 'filters users by office' do
+        office1 = FactoryGirl.create(:office)
+        office2 = FactoryGirl.create(:office)
+        FactoryGirl.create(:user, office: office1)
+        FactoryGirl.create_list :user, 3, office: office2
+
+        expect(described_class.by_office(office1).count).to eql(1)
+        expect(described_class.by_office(office2).count).to eql(3)
+
+      end
+    end
   end
 
   describe 'validations' do
@@ -75,12 +92,43 @@ describe User, type: :model do
     end
   end
 
+  describe '@elevated?' do
+    it 'respond true if manager user' do
+      expect(manager.elevated?).to be true
+    end
+
+    it 'respond true if admin user' do
+      expect(admin_user.elevated?).to be true
+    end
+
+    it 'respond false if  user' do
+      expect(user.elevated?).to be false
+    end
+  end
+
+  describe '@manager?' do
+    it 'respond true if manager user' do
+      expect(manager.manager?).to be true
+    end
+
+    it 'respond false if admin user' do
+      expect(admin_user.manager?).to be false
+    end
+
+    it 'respond false if  user' do
+      expect(user.manager?).to be false
+    end
+  end
+
   describe '@admin?' do
-    it 'resond true if admin user' do
+    it 'respond true if admin user' do
       expect(admin_user.admin?).to be true
     end
 
-    it 'respond false if not admin user' do
+    it 'respond false if manager' do
+      expect(manager.admin?).to be false
+    end
+    it 'respond false if user' do
       expect(user.admin?).to be false
     end
   end

--- a/spec/views/layouts/_toolbar.html.slim_spec.rb
+++ b/spec/views/layouts/_toolbar.html.slim_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "layouts/_toolbar.html.slim", type: :view do
 
   let(:user)          { FactoryGirl.create :user }
   let(:admin_user)    { FactoryGirl.create :admin_user }
+  let(:manager)       { FactoryGirl.create :manager }
 
   context 'logged out user' do
 
@@ -52,6 +53,21 @@ RSpec.describe "layouts/_toolbar.html.slim", type: :view do
 
     it 'see offices' do
       expect(rendered).to include('Offices')
+    end
+
+    it 'see admin' do
+      expect(rendered).to include('Users')
+    end
+  end
+  context 'logged in as manager' do
+
+    before(:each) do
+      sign_in manager
+      render
+    end
+
+    it 'see offices' do
+      expect(rendered).not_to include('Offices')
     end
 
     it 'see admin' do

--- a/spec/views/users/invitations/new.html.slim_spec.rb
+++ b/spec/views/users/invitations/new.html.slim_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'users/invitations/new', type: :view do
+
+  include Devise::TestHelpers
+
+  context 'as an admin' do
+    let(:admin)          { FactoryGirl.create :admin_user }
+    before(:each) do
+      assign(:user, User.new)
+      assign(:roles, User::ROLES)
+      sign_in admin
+      render
+    end
+    it 'renders new user invite form with three roles' do
+      expect(rendered).to have_xpath("//select[@name='user[role]']/option", count: 3)
+      expect(rendered).to have_xpath("//select[@name='user[role]']/option", text: 'Admin')
+      expect(rendered).to have_xpath("//select[@name='user[role]']/option", text: 'Manager')
+      expect(rendered).to have_xpath("//select[@name='user[role]']/option", text: 'User')
+    end
+    it 'renders the office as a drop down' do
+      expect(rendered).to have_xpath("//select[@name='user[office_id]']")
+      expect(rendered).to have_xpath("//select[@name='user[office_id]']/option")
+    end
+
+  end
+
+  context 'as a manager' do
+    let(:manager)          { FactoryGirl.create :manager }
+
+    before(:each) do
+      assign(:user, User.new)
+      assign(:roles, User::ROLES - %w[admin])
+      sign_in manager
+      render
+    end
+    it 'renders new user invite form with three roles' do
+      expect(rendered).to have_xpath("//select[@name='user[role]']/option", count: 2)
+      expect(rendered).to have_xpath("//select[@name='user[role]']/option", text: 'Manager')
+      expect(rendered).to have_xpath("//select[@name='user[role]']/option", text: 'User')
+      expect(rendered).to_not have_xpath("//select[@name='user[role]']/option", text: 'Admin')
+    end
+    it 'does not render the office name' do
+      expect(rendered).to_not include(manager.office.name)
+    end
+    it 'adds a hidden field for office id' do
+      expect(rendered).to_not have_xpath("//select[@name='user[office_id]']")
+      expect(rendered).to have_xpath("//input[@name='user[office_id]' and @value='#{manager.office.id}']")
+
+    end
+  end
+end


### PR DESCRIPTION
Allow admins to create managers per-office

A manager can:
* invite users and managers to the same office as themselves
* edit users from their own office, fields:
  - name, email, role and office
* see a list of DWP checks on their dashboard that have 
been undertaken in their office
* they cannot see or amend users in other offices, or admins 
within their own office

**Note** : When a user is moved into another office, the manager
is shown the email addresses for managers in the new office

