### PR TITLE
Handle undetermined results

### DIFF
--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -13,9 +13,9 @@ class DwpChecksController < ApplicationController
     if @dwp_checker.valid?
       check = JSON.parse(ProcessDwpService.new(@dwp_checker).result)
       if check['success']
-        return redirect_to dwp_checks_path(@dwp_checker.unique_number) if @dwp_checker.reload
+        return redirect_to dwp_checks_path(@dwp_checker.unique_number)
       else
-        flash[:alert] = check['message']
+        flash.now[:alert] = check['message']
       end
     end
     render action: :new

--- a/app/services/process_dwp_service.rb
+++ b/app/services/process_dwp_service.rb
@@ -2,6 +2,7 @@ class ProcessDwpService
 
   attr_accessor :result
   attr_accessor :message
+  attr_accessor :response
 
   def initialize(dwp_check)
     @result = false
@@ -22,23 +23,35 @@ private
   def check_remote_api
     @dwp_checker.save!
     query_proxy_api
+    if @result
+      @dwp_checker.dwp_result = @response['benefit_checker_status']
+      @dwp_checker.dwp_id = @response['confirmation_ref']
+    end
     @dwp_checker.benefits_valid = (@dwp_checker.dwp_result == 'Yes' ? true : false)
     @dwp_checker.save!
   end
 
   def query_proxy_api
-    params = build_params
-    response = JSON.parse(RestClient.post "#{ENV['DWP_API_PROXY']}/api/benefit_checks", params)
-    @dwp_checker.dwp_result = response['benefit_checker_status']
-    @dwp_checker.dwp_id = response['confirmation_ref']
+    @response = JSON.parse(RestClient.post "#{ENV['DWP_API_PROXY']}/api/benefit_checks", set_params)
+    fail Exceptions::UndeterminedDwpCheck if @response['benefit_checker_status'] == 'Undetermined'
     @result = true
-    rescue Errno::ECONNREFUSED
-      log_error I18n.t('error_messages.dwp_checker.unavailable'), 'Server unavailable'
-    rescue => e
-      log_error(e.message, 'Unspecified error')
+  rescue Exceptions::UndeterminedDwpCheck
+    log_error I18n.t('activerecord.attributes.dwp_check.undetermined'), 'Undetermined'
+  rescue Errno::ECONNREFUSED
+    log_error I18n.t('error_messages.dwp_checker.unavailable'), 'Server unavailable'
+  rescue => e
+    log_error(e.message, 'Unspecified error')
   end
 
-  def build_params
+  def generate_api_response
+    yield
+  rescue Errno::ECONNREFUSED
+    log_error I18n.t('error_messages.dwp_checker.unavailable'), 'Server unavailable'
+  rescue => e
+    log_error(e.message, 'Unspecified error')
+  end
+
+  def set_params
     {
       id: @dwp_checker.our_api_token,
       ni_number: @dwp_checker.ni_number,

--- a/app/services/process_dwp_service.rb
+++ b/app/services/process_dwp_service.rb
@@ -1,8 +1,6 @@
 class ProcessDwpService
 
-  attr_accessor :result
-  attr_accessor :message
-  attr_accessor :response
+  attr_accessor :result, :message, :response
 
   def initialize(dwp_check)
     @result = false
@@ -37,14 +35,6 @@ private
     @result = true
   rescue Exceptions::UndeterminedDwpCheck
     log_error I18n.t('activerecord.attributes.dwp_check.undetermined'), 'Undetermined'
-  rescue Errno::ECONNREFUSED
-    log_error I18n.t('error_messages.dwp_checker.unavailable'), 'Server unavailable'
-  rescue => e
-    log_error(e.message, 'Unspecified error')
-  end
-
-  def generate_api_response
-    yield
   rescue Errno::ECONNREFUSED
     log_error I18n.t('error_messages.dwp_checker.unavailable'), 'Server unavailable'
   rescue => e

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,0 +1,3 @@
+module Exceptions
+  class UndeterminedDwpCheck < StandardError; end
+end


### PR DESCRIPTION
When a user searches using incorrect data
the system should return them to the input 
screen with a warning and allow them to 
amend the data.

[finishes #94226772]