### PR TITLE
Link office and jurisdictions

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -102,3 +102,7 @@ input[type="button"],
 input[type="submit"] {
   font-size: 1rem;
 }
+
+td.center {
+  text-align: center;
+}

--- a/app/assets/stylesheets/feedback.scss
+++ b/app/assets/stylesheets/feedback.scss
@@ -30,7 +30,7 @@
   // Absolutely position inputs within label, to allow text to wrap
   input {
     position: absolute;
-    top: 18px;
+    top: 23px;
     left: $gutter-half;
     cursor: pointer;
   }

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -17,6 +17,7 @@ class OfficesController < ApplicationController
 
   def new
     @office = Office.new
+    @office.jurisdictions = []
     respond_with(@office)
   end
 
@@ -24,6 +25,7 @@ class OfficesController < ApplicationController
   end
 
   def create
+    @office = Office.new(office_params)
     @office.save
     respond_with(@office)
     flash[:notice] = 'Office was successfully created'

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -18,7 +18,6 @@ class OfficesController < ApplicationController
 
   def new
     @office = Office.new
-    @office.jurisdictions = []
     respond_with(@office)
   end
 

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -1,6 +1,7 @@
 class OfficesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_office, only: [:show, :edit, :update, :destroy]
+  before_action :list_jurisdictions, only: [:new, :edit]
 
   load_and_authorize_resource
 
@@ -48,6 +49,10 @@ private
   end
 
   def office_params
-    params.require(:office).permit(:name)
+    params.require(:office).permit(:name, jurisdiction_ids: [])
+  end
+
+  def list_jurisdictions
+    @jurisdictions = Jurisdiction.all
   end
 end

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -1,5 +1,8 @@
 class Jurisdiction < ActiveRecord::Base
 
+  has_many :office_jurisdictions
+  has_many :offices, through: :office_jurisdictions
+
   validates :name, uniqueness: true, presence: true
   validates :abbr, uniqueness: { allow_nil: true }
 

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -6,4 +6,10 @@ class Jurisdiction < ActiveRecord::Base
   def display
     self.abbr ||= name
   end
+
+  def display_full
+    result = name
+    result.concat(" (#{abbr})") unless abbr.blank?
+    result
+  end
 end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,5 +1,7 @@
 class Office < ActiveRecord::Base
   has_many :users
+  has_many :office_jurisdictions
+  has_many :jurisdictions, through: :office_jurisdictions
 
   scope :sorted, -> {  all.order(:name) }
   scope :non_digital, -> { where.not(name: 'Digital') }

--- a/app/models/office_jurisdiction.rb
+++ b/app/models/office_jurisdiction.rb
@@ -1,0 +1,4 @@
+class OfficeJurisdiction < ActiveRecord::Base
+  belongs_to :office
+  belongs_to :jurisdiction
+end

--- a/app/views/offices/_form.html.slim
+++ b/app/views/offices/_form.html.slim
@@ -9,4 +9,16 @@
   .field
     = f.label :name
     = f.text_field :name
+
+  .row
+    .small-12.columns.form-group
+      label Jurisdictions
+      .row
+        .options.radio
+          =collection_check_boxes(:office, :jurisdiction_ids, @jurisdictions, :id, :display_full) do |b|
+            .columns.small-12.medium-6.large-4.end
+              = b.label do
+                = b.check_box
+                = b.text
+
   .actions = f.submit class: 'button btn'

--- a/app/views/offices/index.html.slim
+++ b/app/views/offices/index.html.slim
@@ -4,17 +4,16 @@ table
   thead
     tr
       th Name
-      th colspan=3 Actions
+      th Jurisdiction(s)
+      th &nbsp;
 
   tbody
     - @offices.each do |office|
       tr
-        td = office.name
-        td = link_to 'Show', office
+        td = link_to office.name, office
+        td.center = office.jurisdictions.count
         - if can? :update, :office
           td = link_to 'Edit', edit_office_path(office)
-        - if can? :destroy, :office
-          td = link_to 'Destroy', office, data: {:confirm => 'Are you sure?'}, :method => :delete
 
 br
 

--- a/app/views/offices/show.html.slim
+++ b/app/views/offices/show.html.slim
@@ -2,6 +2,12 @@ p
   strong Name:
   = @office.name
 
+-if @office.jurisdictions.present?
+  strong Jurisdictions
+  ul
+    - @office.jurisdictions.each do |j|
+      li =j.display
+
 = link_to 'Edit', edit_office_path(@office)
 '|
 = link_to 'Back', offices_path

--- a/db/migrate/20150619115804_create_join_table_office_jurisdiction.rb
+++ b/db/migrate/20150619115804_create_join_table_office_jurisdiction.rb
@@ -3,5 +3,7 @@ class CreateJoinTableOfficeJurisdiction < ActiveRecord::Migration
     create_join_table :offices, :jurisdictions, table_name: :office_jurisdictions do |t|
       t.index [:office_id, :jurisdiction_id]
     end
+    add_foreign_key :office_jurisdictions, :offices
+    add_foreign_key :office_jurisdictions, :jurisdictions
   end
 end

--- a/db/migrate/20150619115804_create_join_table_office_jurisdiction.rb
+++ b/db/migrate/20150619115804_create_join_table_office_jurisdiction.rb
@@ -1,0 +1,7 @@
+class CreateJoinTableOfficeJurisdiction < ActiveRecord::Migration
+  def change
+    create_join_table :offices, :jurisdictions, table_name: :office_jurisdictions do |t|
+      t.index [:office_id, :jurisdiction_id]
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150616100546) do
+ActiveRecord::Schema.define(version: 20150619115804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,13 @@ ActiveRecord::Schema.define(version: 20150616100546) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "office_jurisdictions", id: false, force: :cascade do |t|
+    t.integer "office_id",       null: false
+    t.integer "jurisdiction_id", null: false
+  end
+
+  add_index "office_jurisdictions", ["office_id", "jurisdiction_id"], name: "index_office_jurisdictions_on_office_id_and_jurisdiction_id", using: :btree
+
   create_table "offices", force: :cascade do |t|
     t.string   "name"
     t.datetime "created_at"
@@ -104,6 +111,7 @@ ActiveRecord::Schema.define(version: 20150616100546) do
     t.integer  "invitations_count",      default: 0
     t.string   "name"
     t.integer  "office_id",                           null: false
+    t.integer  "jurisdiction_id"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -122,6 +122,8 @@ ActiveRecord::Schema.define(version: 20150619115804) do
 
   add_foreign_key "feedbacks", "offices"
   add_foreign_key "feedbacks", "users"
+  add_foreign_key "office_jurisdictions", "jurisdictions"
+  add_foreign_key "office_jurisdictions", "offices"
   add_foreign_key "r2_calculators", "users", column: "created_by_id"
   add_foreign_key "users", "offices"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,21 +1,24 @@
-Office.create([{ name: 'Digital' },
-               { name: 'Bristol' }])
+Office.find_or_create_by(name: 'Digital')
+Office.find_or_create_by(name: 'Bristol')
 
-User.create([{
-              name: 'Admin',
-              email: 'fee-remission@digital.justice.gov.uk',
-              password: '123456789',
-              role: 'admin',
-              office_id: 1
-            },
-            {
-              name: 'User',
-              email: 'bristol.user@hmcts.gsi.gov.uk',
-              password: '987654321',
-              role: 'user',
-              office_id: 2
-            }
-            ])
+unless ENV=='production'
+  puts 'Creating users'
+  User.create([{
+                name: 'Admin',
+                email: 'fee-remission@digital.justice.gov.uk',
+                password: '123456789',
+                role: 'admin',
+                office_id: 1
+              },
+              {
+                name: 'User',
+                email: 'bristol.user@hmcts.gsi.gov.uk',
+                password: '987654321',
+                role: 'user',
+                office_id: 2
+              }
+              ])
+end
 
 Jurisdiction.create([{ name: 'County Court', abbr: nil },
                      { name: 'High Court', abbr: nil },

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,6 @@ Office.find_or_create_by(name: 'Digital')
 Office.find_or_create_by(name: 'Bristol')
 
 unless ENV=='production'
-  puts 'Creating users'
   User.create([{
                 name: 'Admin',
                 email: 'fee-remission@digital.justice.gov.uk',

--- a/spec/factories/jurisdictions.rb
+++ b/spec/factories/jurisdictions.rb
@@ -1,7 +1,7 @@
 FactoryGirl.define do
   factory :jurisdiction do
     name { Faker::Company.name }
-    abbr { Faker::Hacker.abbreviation }
+    abbr { |n| "#{Faker::Hacker.abbreviation} #{n}" }
     active true
   end
 end

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -13,14 +13,17 @@ RSpec.describe Jurisdiction, type: :model do
       jurisdiction.name = nil
       expect(jurisdiction).to be_invalid
     end
+
     it 'enforces unique name' do
       new = build(:jurisdiction, name: jurisdiction.name)
       expect(new).to be_invalid
     end
+
     it 'enforces unique abbreviation' do
       new = build(:jurisdiction, abbr: jurisdiction.abbr)
       expect(new).to be_invalid
     end
+    
     it 'allows multiple empty abbreviations' do
       create(:jurisdiction, name: 'High Court', abbr: nil)
       new = create(:jurisdiction, name: 'County Court', abbr: nil)
@@ -33,9 +36,44 @@ RSpec.describe Jurisdiction, type: :model do
     it 'returns abbr if set' do
       expect(jurisdiction.display).to eql(jurisdiction.abbr)
     end
+
     it 'returns name if abbreviation is empty' do
       jurisdiction.abbr = nil
       expect(jurisdiction.display).to eql(jurisdiction.name)
+    end
+  end
+
+  describe 'display_full' do
+    it 'returns name and abbr if set' do
+      expected = "#{jurisdiction.name} (#{jurisdiction.abbr})"
+      expect(jurisdiction.display_full).to eq expected
+    end
+
+    it 'returns name only if abbreviation is empty' do
+      jurisdiction.abbr = nil
+      expect(jurisdiction.display_full).to eql("#{jurisdiction.name}")
+    end
+  end
+
+  describe 'office' do
+    it 'can be nil' do
+      jurisdiction.offices.clear
+      expect(jurisdiction.offices.count).to eq 0
+      expect(jurisdiction).to be_valid
+    end
+
+    it 'can be added' do
+      jurisdiction.offices << create(:office)
+      jurisdiction.save
+      expect(jurisdiction.offices.count).to eq 1
+    end
+
+    it 'can have multiple added' do
+      jurisdiction.offices.clear
+      jurisdiction.offices << create(:office)
+      jurisdiction.offices << create(:office)
+      jurisdiction.save
+      expect(jurisdiction.offices.count).to eq 2
     end
   end
 end

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Jurisdiction, type: :model do
       new = build(:jurisdiction, abbr: jurisdiction.abbr)
       expect(new).to be_invalid
     end
-    
+
     it 'allows multiple empty abbreviations' do
       create(:jurisdiction, name: 'High Court', abbr: nil)
       new = create(:jurisdiction, name: 'County Court', abbr: nil)

--- a/spec/models/office_jurisdiction_spec.rb
+++ b/spec/models/office_jurisdiction_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe OfficeJurisdiction, type: :model do
+  subject { described_class.new office: create(:office), jurisdiction: create(:jurisdiction) }
+
+  it 'passes factory build' do
+    expect(subject).to be_valid
+  end
+
+  describe 'relationships' do
+    it { is_expected.to respond_to :office }
+    it { is_expected.to respond_to :jurisdiction }
+  end
+end

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -20,6 +20,35 @@ RSpec.describe Office, type: :model do
     it 'managers' do
       expect(office).to respond_to(:managers)
     end
+
+    it 'jurisdictions' do
+      expect(office).to respond_to(:jurisdictions)
+    end
+  end
+
+  describe 'jurisdiction' do
+    it 'can be nil' do
+      office.jurisdictions.clear
+      expect(office.jurisdictions.count).to eq 0
+      expect(office).to be_valid
+    end
+
+    it 'can be added' do
+      office.save
+      office.jurisdictions.clear
+      office.jurisdictions << create(:jurisdiction)
+      office.save
+      expect(office.jurisdictions.count).to eq 1
+    end
+
+    it 'can have multiple added' do
+      office.save
+      office.jurisdictions.clear
+      office.jurisdictions << create(:jurisdiction)
+      office.jurisdictions << create(:jurisdiction)
+      office.save
+      expect(office.jurisdictions.count).to eq 2
+    end
   end
 
   describe 'managers' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,9 @@ require 'webmock/rspec'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+
+  config.order = 'random'
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/views/offices/edit.html.slim_spec.rb
+++ b/spec/views/offices/edit.html.slim_spec.rb
@@ -2,13 +2,18 @@ require 'rails_helper'
 
 RSpec.describe 'offices/edit', type: :view do
   let(:office) { assign(:office, create(:office)) }
+  let(:jurisdictions) { assign(:jurisdictions, create_list(:jurisdiction, 4)) }
 
   it 'renders the edit office form' do
+
+    jurisdictions
     office
     render
-    assert_select 'form[action=?][method=?]', office_path(office), 'post' do
+    expect(rendered).to have_xpath('//input[@name="office[jurisdiction_ids][]"]', count: jurisdictions.count + 1)
 
+    assert_select 'form[action=?][method=?]', office_path(office), 'post' do
       assert_select 'input#office_name[name=?]', 'office[name]'
+
     end
   end
 end

--- a/spec/views/offices/index.html.slim_spec.rb
+++ b/spec/views/offices/index.html.slim_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "offices/index", type: :view do
 
     it 'not see the edit or destroy links' do
       expect(rendered).to_not have_css('a', text: 'Edit')
-      expect(rendered).to_not have_css('a', text: 'Destroy')
     end
   end
 
@@ -47,7 +46,6 @@ RSpec.describe "offices/index", type: :view do
 
     it 'see the edit and destroy links' do
       expect(rendered).to have_css('a', text: 'Edit', count: 2)
-      expect(rendered).to have_css('a', text: 'Destroy', count: 2)
     end
   end
 end

--- a/spec/views/offices/new.html.slim_spec.rb
+++ b/spec/views/offices/new.html.slim_spec.rb
@@ -1,21 +1,18 @@
 require 'rails_helper'
 
-RSpec.describe "offices/new", type: :view do
-  before(:each) do
-    assign(
-      :office,
-      Office.new(
-        name: "MyString"
-      )
-    )
-  end
+RSpec.describe 'offices/new', type: :view do
 
-  it "renders new office form" do
+  before(:each) { assign(:office, Office.new) }
+  let(:jurisdictions) { assign(:jurisdictions, create_list(:jurisdiction, 4)) }
+
+  it 'renders new office form' do
+
+    jurisdictions
     render
 
-    assert_select "form[action=?][method=?]", offices_path, "post" do
-
-      assert_select "input#office_name[name=?]", "office[name]"
+    expect(rendered).to have_xpath('//input[@name="office[jurisdiction_ids][]"]', count: jurisdictions.count + 1)
+    assert_select 'form[action=?][method=?]', offices_path, 'post' do
+      assert_select 'input#office_name[name=?]', 'office[name]'
     end
   end
 end


### PR DESCRIPTION
Create a link table between office and jurisdiction
* many-to-many link between the two models
* add jurisdiction check boxes to the office _form
* add jurisdiction display methods
* display the jurisdiction count on office index

Changes to existing objects
* a jurisdiction can be displayed as: name, name (abbr) and abbr only
* an office can have zero to many jurisdictions
* the office form views display jurisdiction checkboxes