### PR TITLE
Vulenrability fix for web-console gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
       raindrops (~> 0.7)
     warden (1.2.3)
       rack (>= 1.0)
-    web-console (2.1.2)
+    web-console (2.1.3)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)


### PR DESCRIPTION
Even though it's just an issue in development, it's good to silence
Gemnasium alerts also.

This is the vulnerability description:
https://groups.google.com/forum/#!topic/ruby-security-ann/lzmz9_ijUFw