### PR TITLE
Upgraded redcarpet gem due to vuln

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,7 +225,7 @@ GEM
       ffi (>= 0.5.0)
     rb-readline (0.5.2)
     rdoc (4.2.0)
-    redcarpet (3.2.3)
+    redcarpet (3.3.2)
     request_store (1.1.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)


### PR DESCRIPTION
As per http://seclists.org/oss-sec/2015/q2/818
redcarpet has a vuln. This upgrade fixes it.