### PR TITLE
Fix for user id in invitation url

### DIFF
--- a/app/views/users/mailer/invitation_instructions.html.slim
+++ b/app/views/users/mailer/invitation_instructions.html.slim
@@ -7,7 +7,7 @@ ol
     = t("devise.mailer.invitation_instructions.list_1")
   li
     = t("devise.mailer.invitation_instructions.list_2")
-    = link_to(accept_user_invitation_url(@resource, invitation_token: @token), accept_user_invitation_url(@resource, invitation_token: @token))
+    = link_to(accept_user_invitation_url(invitation_token: @token), accept_user_invitation_url(invitation_token: @token))
   li
     = t("devise.mailer.invitation_instructions.list_3")
 p


### PR DESCRIPTION
The user id should not be included in the invitation url.

It turns out that it isn't needed anyway.  Removing the 
resource and leaving the token is all that's required.

[finishes #94841546]
