### PR TITLE
Revert "Enforce all access to the app over SSL"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Set to :debug to see everything in the log.
   config.log_level = :info


### PR DESCRIPTION
Reverts ministryofjustice/fr-staffapp#163

 This is due to enforcement of secure cookies on **everything** which also includes **ping.json** which is not what we want. So reverting this change as the cookies will be secured by nginx.