### PR TITLE
Updated office factory

### DIFF
--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
 
-  sequence(:name)     { |n| "Office no. #{n}" }
+  sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
 
   factory :office do
     name


### PR DESCRIPTION
* reduce likelihood of office name duplication

This should prevent recurrences of the following error:
Failure/Error: let(:office)  { create :office, jurisdictions: create_list(:jurisdiction, 3) }
     ActiveRecord::RecordInvalid:
       Validation failed: Name has already been taken
