### PR TITLE
Return 404 instead of 500

### DIFF
--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -26,7 +26,7 @@ class DwpChecksController < ApplicationController
     authorize! :show, DwpCheck
   end
 
-private
+  private
 
   def new_from_params
     @dwp_checker = DwpCheck.new(dwp_params)
@@ -39,6 +39,10 @@ private
   end
 
   def find_dwp_check
-    @dwp_checker = DwpCheck.find_by(unique_number: params[:unique_number])
+    if /\A[a-z\d]{4}-[a-z\d]{4}\z/.match(params[:unique_number])
+      @dwp_checker = DwpCheck.find_by(unique_number: params[:unique_number])
+    else
+      render file: 'public/404.html', status: 404
+    end
   end
 end

--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -3,6 +3,7 @@ class DwpChecksController < ApplicationController
   respond_to :html
   before_action :find_dwp_check, only: [:show]
   before_action :new_from_params, only: [:lookup]
+
   def new
     authorize! :new, DwpCheck
     @dwp_checker = DwpCheck.new

--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -26,7 +26,7 @@ class DwpChecksController < ApplicationController
     authorize! :show, DwpCheck
   end
 
-  private
+private
 
   def new_from_params
     @dwp_checker = DwpCheck.new(dwp_params)

--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -39,10 +39,6 @@ class DwpChecksController < ApplicationController
   end
 
   def find_dwp_check
-    if /\A[a-z\d]{4}-[a-z\d]{4}\z/.match(params[:unique_number])
-      @dwp_checker = DwpCheck.find_by(unique_number: params[:unique_number])
-    else
-      render file: 'public/404.html', status: 404
-    end
+    @dwp_checker = DwpCheck.find_by!(unique_number: params[:unique_number])
   end
 end

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe DwpChecksController, type: :controller do
         expect(assigns(:dwp_checker)).to eq(dwp_check)
         expect(response).to render_template('dwp_checks/show')
       end
+
+      context 'when invalid request is made' do
+        let(:invalid_number) { "'" }
+        before(:each) { get :show, unique_number: invalid_number }
+
+        it 'returns 404 on invalid request' do
+          expect(response.status).to eql 404
+        end
+
+        it 'renders 404 page' do
+          expect(response.status).to render_template(file: '404.html')
+        end
+      end
     end
 
     describe 'GET #new' do

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -38,14 +38,9 @@ RSpec.describe DwpChecksController, type: :controller do
 
       context 'when invalid request is made' do
         let(:invalid_number) { "'" }
-        before(:each) { get :show, unique_number: invalid_number }
 
-        it 'returns 404 on invalid request' do
-          expect(response.status).to eql 404
-        end
-
-        it 'renders 404 page' do
-          expect(response.status).to render_template(file: '404.html')
+        it 'throws an error when invalid request is made' do
+          expect { get :show, unique_number: invalid_number }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end


### PR DESCRIPTION
When the user tries to look up some made up DWP check, it would return an error with 500 status code. Which means that the app would actually take the invalid input and do a database query with it. Which is not what we want.

This change prevents that by only allowing the valid format of the DWP check reference to be looked up.
