### PR TITLE
Split assets generate and static page tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y
 EXPOSE $UNICORN_PORT
 
 #SECRET_TOKEN set here because otherwise devise blows up during the precompile.
-RUN bundle exec rake assets:precompile static_pages:generate RAILS_ENV=production SECRET_TOKEN=blah
+RUN bundle exec rake assets:precompile RAILS_ENV=production SECRET_TOKEN=blah
+RUN bundle exec rake static_pages:generate RAILS_ENV=production SECRET_TOKEN=blah
 
 CMD ./run.sh


### PR DESCRIPTION
These tasks must be separate because we need rails to generate the
manifest for the assets before we create the static pages.