### PR TITLE
Indent instead of outdent of keywords

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,7 +51,7 @@ RSpec/FilePath:
 
 # private/protected/public
 Style/AccessModifierIndentation:
-  EnforcedStyle: outdent
+  EnforcedStyle: indent
 
 # Just indent parameters by two spaces. It's less volatile if methods change,
 # and there's less busy work lining things up.

--- a/app/controllers/calculator_controller.rb
+++ b/app/controllers/calculator_controller.rb
@@ -17,7 +17,7 @@ class CalculatorController < ApplicationController
     end
   end
 
-private
+  private
 
   def create_from_params
     @r2 = R2Calculator.new(r2_calc_params)

--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -25,7 +25,7 @@ class DwpChecksController < ApplicationController
     authorize! :show, DwpCheck
   end
 
-private
+  private
 
   def new_from_params
     @dwp_checker = DwpCheck.new(dwp_params)

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -29,7 +29,7 @@ class FeedbackController < ApplicationController
     end
   end
 
-private
+  private
 
   def feedback_params
     params.require(:feedback).permit(:experience, :ideas, :rating, :help)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
   def index
   end
 
-private
+  private
 
   def load_dwp_data
     @dwpchecks = DwpCheck.

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -41,7 +41,7 @@ class OfficesController < ApplicationController
     respond_with(@office)
   end
 
-private
+  private
 
   def set_office
     @office = Office.find(params[:id])

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -13,7 +13,7 @@ class Users::InvitationsController < Devise::InvitationsController
     render :new
   end
 
-private
+  private
 
   def invite_resource
     resource_class.invite!(invite_params, current_inviter)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
     respond_with @user
   end
 
-protected
+  protected
 
   def user_params
     params.require(:user).permit(:name, :role, :office_id, :jurisdiction_id)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -26,7 +26,7 @@ class Ability
     true
   end
 
-private
+  private
 
   def users_can
     can :read, Office

--- a/app/models/dwp_check.rb
+++ b/app/models/dwp_check.rb
@@ -52,7 +52,7 @@ class DwpCheck < ActiveRecord::Base
     end
   end
 
-private
+  private
 
   def generate_unique_number
     new_uid = ''

--- a/app/models/r2_calculator.rb
+++ b/app/models/r2_calculator.rb
@@ -44,7 +44,7 @@ class R2Calculator < ActiveRecord::Base
     type == 'None'
   end
 
-private
+  private
 
   def build_type
     if to_pay == 0.00

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ActiveRecord::Base
     role == 'manager'
   end
 
-private
+  private
 
   def jurisdiction_is_valid
     unless jurisdiction_id.nil? || Jurisdiction.exists?(jurisdiction_id)

--- a/app/services/process_dwp_service.rb
+++ b/app/services/process_dwp_service.rb
@@ -16,7 +16,7 @@ class ProcessDwpService
     }.to_json
   end
 
-private
+  private
 
   def check_remote_api
     @dwp_checker.save!

--- a/lib/settings.rb
+++ b/lib/settings.rb
@@ -1,6 +1,6 @@
 module Settings
 
-module_function
+  module_function
 
   file_path = File.expand_path('../config/settings.yml', __dir__)
   @h        = YAML.load_file(file_path)


### PR DESCRIPTION
Changed the RuboCop setting so that the keywords are indented instead of
outdented. This applies to `private', `protected', ...