### PR TITLE
Updating user jurisdiction management

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -69,7 +69,7 @@ class UsersController < ApplicationController
   end
 
   def populate_jurisdictions
-    @jurisdictions = Jurisdiction.all
+    @jurisdictions = @user.office.jurisdictions
   end
 
   def user_or_redirect

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -20,5 +20,8 @@ h2 Edit user
     = f.collection_select :office_id, @offices, :id, :name
   .form-group
     = f.label :jurisdiction_id
-    = f.collection_select :jurisdiction_id, @jurisdictions, :id, :name
+    - if @jurisdictions.present?
+      = f.collection_select :jurisdiction_id, @jurisdictions, :id, :name, { include_blank: 'No default jurisdiction' }
+    - else
+      = t('error_messages.jurisdictions.none_in_office')
   .actions = f.submit class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,8 @@ en:
       unavailable: 'The benefits checker is not available at the moment. Please check again later.'
     user:
       moved_offices: "%{user} moved to %{office}, you will need to contact %{contact} there if this was done in error"
+    jurisdictions:
+      none_in_office: 'Ask your manager to assign jurisdictions for your team.'
   dictionary:
     invalid_email: "You’re not able to create an account with this email address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help, <a href='mailto:%{email}'>contact us</a>"
   feedback:

--- a/spec/controllers/users_controller/manager_user_spec.rb
+++ b/spec/controllers/users_controller/manager_user_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe UsersController, type: :controller do
         it 'renders the view' do
           expect(response).to render_template :show
         end
+
         it 'returns a success code' do
           expect(response).to have_http_status(:success)
         end

--- a/spec/controllers/users_controller/standard_user_spec.rb
+++ b/spec/controllers/users_controller/standard_user_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe UsersController, type: :controller do
 
   include Devise::TestHelpers
 
-  let(:user)         { create :user }
-  let(:test_user)    { create :user }
+  let(:jurisdictions) { create_list :jurisdiction, 3 }
+  let(:user)          { create :user, jurisdiction: jurisdictions[0], office: create(:office, jurisdictions: jurisdictions) }
+  let(:test_user)     { create :user }
 
   context 'standard user' do
 

--- a/spec/controllers/users_controller/user_jurisdictions_spec.rb
+++ b/spec/controllers/users_controller/user_jurisdictions_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :controller do
+  render_views
+
+  include Devise::TestHelpers
+
+  let(:office)  { create :office, jurisdictions: create_list(:jurisdiction, 3) }
+  let(:user)    { create :user, office: office }
+  context 'standard user' do
+
+    before(:each) { sign_in user }
+
+    describe 'GET #edit' do
+      context 'when trying to edit their own profile' do
+        context 'when the users office has jurisdictions' do
+          it 'lists the offices jurisdictions' do
+            get :edit, id: user.to_param
+            expect(assigns(:jurisdictions).count).to eq 3
+          end
+        end
+
+        context 'when the users office has no jurisdictions' do
+          it 'shows text warning' do
+            office.jurisdictions.delete_all
+            get :edit, id: user.to_param
+            expect(assigns(:jurisdictions).count).to eq 0
+            expect(response.body).to match I18n.t('error_messages.jurisdictions.none_in_office')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As discussed between @kelliematheson and @colinbruce.

Users will only be shown jurisdictions currently selected 
by office managers.

If managers have not chosen any jurisdictions, users are 
shown a warning message.