### PR TITLE
Fixed markdown rendering bug

### DIFF
--- a/config/initializers/markdown_handler.rb
+++ b/config/initializers/markdown_handler.rb
@@ -5,8 +5,7 @@ class MarkdownTemplateHandler
     <<-SOURCE
     renderer = ::Redcarpet::Render::HTML.new(
       hard_wrap: true,
-      with_toc_data: true,
-      filter_html: true
+      with_toc_data: true
     )
     options = Rails.application.config.redcarpet_markdown_options
     ::Redcarpet::Markdown.new(renderer, options).render(begin;#{source};end).html_safe


### PR DESCRIPTION
Markdown was rendering, not executing, a script tag
the filter_html switch was the cause.

Removed the tag to ensure proper display

The JS was highlighting the page choice on the 
navigation bar.  This will be removed anyway once the 
design is updated.