### PR TITLE
Faster TravisCI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
+sudo: false
 rvm:
 - 2.2.1
 before_install:
-- sudo apt-get update -qq
-- sudo apt-get install libqt4-dev -qq
-- sudo apt-get install xvfb -qq
+- apt-get update -qq
+- apt-get install libqt4-dev -qq
+- apt-get install xvfb -qq
 before_script:
 - psql -c 'create role fr login createdb;' -U postgres
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: ruby
 sudo: false
 rvm:
 - 2.2.1
-before_install:
-- apt-get update -qq
-- apt-get install libqt4-dev -qq
-- apt-get install xvfb -qq
 before_script:
 - psql -c 'create role fr login createdb;' -U postgres
 addons:
+  apt:
+    packages:
+    - libqt4-dev
+    - xvfb
   postgresql: 9.3
   code_climate:
     repo_token: 9d2abe9e2bdfe62892cf37ae25ff3e825b07dad9401025adcb6f387ac82a35a8


### PR DESCRIPTION
When building jobs on Travis CI, this message shows up:

`This job ran on our legacy infrastructure. Please read our docs on how
to upgrade'

The link to the document is: http://j.mp/1CtCCRO

Trying it out with this commit.

But still not sure if I have to remove all the mentions of **sudo** from
**.travis.yml**.