### PR TITLE
Prevent the manager from changing their role

### DIFF
--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -30,11 +30,15 @@ h2 Edit user
             = f.label(:roles, 'Role')
             -if current_user.elevated?
               .row
-                .options.radio
-                  =collection_radio_buttons(:user, :role, @roles, :to_s, :humanize) do |b|
-                    = b.label do
-                      = b.radio_button(class: 'form-control')
-                      = b.text
+                .columns.small-4.large-2
+                  - if current_user.manager?
+                    = current_user.role
+                  - else
+                    .options.radio
+                      =collection_radio_buttons(:user, :role, @roles, :to_s, :humanize) do |b|
+                        = b.label do
+                          = b.radio_button(class: 'form-control')
+                          = b.text
             -else
               .form-control #{@user.role}
 

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -31,7 +31,7 @@ h2 Edit user
             -if current_user.elevated?
               .row
                 .columns.small-4.large-2
-                  - if current_user.manager?
+                  - if (@user.manager? && (@user == current_user))
                     = current_user.role
                   - else
                     .options.radio

--- a/spec/controllers/users_controller/manager_user_spec.rb
+++ b/spec/controllers/users_controller/manager_user_spec.rb
@@ -74,12 +74,6 @@ RSpec.describe UsersController, type: :controller do
         it 'shows them their role' do
           expect(response.body).to match "#{manager.role}"
         end
-
-        it 'only shows them options to change their role or below' do
-          expect(response.body).to have_xpath('//input[@name="user[role]"]', count: 2)
-          expect(response.body).to have_xpath('//input[@name="user[role]" and @value="manager"]')
-          expect(response.body).to have_xpath('//input[@name="user[role]" and @value="user"]')
-        end
       end
 
       context 'for a user not in their office' do

--- a/spec/features/prevent_managers_from_downgrading_themselves_to_user_role_spec.rb
+++ b/spec/features/prevent_managers_from_downgrading_themselves_to_user_role_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Prevent managers from downgrading themselves to user role', type:
       expect(page).to have_text 'Role'
     end
 
-    it "doens't allow editing of the role" do
+    it "doesn't allow editing of the role" do
       expect(page).to_not have_xpath '//*[@id="user_role_user"]'
     end
   end

--- a/spec/features/prevent_managers_from_downgrading_themselves_to_user_role_spec.rb
+++ b/spec/features/prevent_managers_from_downgrading_themselves_to_user_role_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.feature 'Prevent managers from downgrading themselves to user role', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let(:manager) { create :manager }
+
+  before(:each) do
+    login_as manager
+    visit edit_user_path(manager.id)
+  end
+
+  context 'show view' do
+    it 'shows the role' do
+      expect(page).to have_text 'Role'
+    end
+
+    it "doens't allow editing of the role" do
+      expect(page).to_not have_xpath '//*[@id="user_role_user"]'
+    end
+  end
+end

--- a/spec/features/prevent_managers_from_downgrading_themselves_to_user_role_spec.rb
+++ b/spec/features/prevent_managers_from_downgrading_themselves_to_user_role_spec.rb
@@ -6,19 +6,27 @@ RSpec.feature 'Prevent managers from downgrading themselves to user role', type:
   Warden.test_mode!
 
   let(:manager) { create :manager }
+  let(:other_manager) { create :manager, office_id: manager.office_id }
 
-  before(:each) do
-    login_as manager
-    visit edit_user_path(manager.id)
-  end
+  before { login_as manager }
 
-  context 'show view' do
+  context 'their own edit view' do
+    before { visit edit_user_path(manager.id) }
+
     it 'shows the role' do
       expect(page).to have_text 'Role'
     end
 
     it "doesn't allow editing of the role" do
       expect(page).to_not have_xpath '//*[@id="user_role_user"]'
+    end
+  end
+
+  context "some other manager's edit view" do
+    before { visit edit_user_path(other_manager.id) }
+
+    it "does allow editing of the role" do
+      expect(page).to have_xpath '//*[@id="user_role_user"]'
     end
   end
 end


### PR DESCRIPTION
Don't allow a manager to change their role to user.

Added the examples for the scenario and removed the previous scenario
which did allow the manager to change his role.