### PR TITLE
Privilege escalation prevention

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,7 +38,11 @@ class UsersController < ApplicationController
   protected
 
   def user_params
-    params.require(:user).permit(:name, :role, :office_id, :jurisdiction_id)
+    if @user.admin?
+      params.require(:user).permit(:name, :role, :office_id, :jurisdiction_id)
+    else
+      params.require(:user).permit(:name, :office_id, :jurisdiction_id)
+    end
   end
 
   def no_longer_manages?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,10 +38,13 @@ class UsersController < ApplicationController
   protected
 
   def user_params
-    if @user.admin?
-      params.require(:user).permit(:name, :role, :office_id, :jurisdiction_id)
+    all_params   = [:name, :office_id, :jurisdiction_id, :role]
+    all_but_role = [:name, :office_id, :jurisdiction_id]
+
+    if current_user.admin? || manager_doesnt_escalate_to_admin?
+      params.require(:user).permit(all_params)
     else
-      params.require(:user).permit(:name, :office_id, :jurisdiction_id)
+      params.require(:user).permit(all_but_role)
     end
   end
 
@@ -101,5 +104,9 @@ class UsersController < ApplicationController
 
   def manages_user?
     current_user.manager? && current_user.office == @user.office
+  end
+
+  def manager_doesnt_escalate_to_admin?
+    manages_user? && params[:user][:role] != 'admin'
   end
 end

--- a/spec/controllers/users_controller/standard_user_spec.rb
+++ b/spec/controllers/users_controller/standard_user_spec.rb
@@ -101,6 +101,19 @@ RSpec.describe UsersController, type: :controller do
         end
       end
 
+
+      context 'when trying to escalate their own role' do
+
+        before do
+          post :update, id: user.id, user: { role: 'admin' }
+          user.reload
+        end
+
+        it "doesn't escalates their role" do
+          expect(user.role).not_to eq 'admin'
+        end
+      end
+
       context "when trying to edit somebody else's profile" do
         it "doesn't allow editing of the user details" do
           post :update, id: test_user.id, user: { name: 'random value' }

--- a/spec/controllers/users_controller/standard_user_spec.rb
+++ b/spec/controllers/users_controller/standard_user_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe UsersController, type: :controller do
         end
       end
 
-
       context 'when trying to escalate their own role' do
 
         before do


### PR DESCRIPTION
Privilege escalation prevention branch.

Workarounds for: 
* a user to prevent them from escalating their own privileges
* a manager to prevent them from escalating their user's or their own priviledges
