### PR TITLE
Savings summary

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -101,12 +101,12 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     applicant_age >= 61
   end
 
-  private
-
   def applicant_age
     now = Time.zone.now.utc.to_date
     now.year - date_of_birth.year - (date_of_birth.to_date.change(year: now.year) > now ? 1 : 0)
   end
+
+  private
 
   def active?
     status == 'active'

--- a/app/views/applications/build/savings_investments.html.slim
+++ b/app/views/applications/build/savings_investments.html.slim
@@ -51,6 +51,24 @@
 
   = f.submit 'Next', :class => 'button primary'
 
+.row
+  .small-12.columns
+    .row
+      .small-12.medium-8.large-7.columns
+        details
+          summary.primary Our calculation is based on this information
+          #result_table.row.pad-top-fifteen-px
+            .columns.small-12
+              .row
+                .columns.small-4.table-label Age
+                .columns.small-8 #{@application.applicant_age} years old
+              .row
+                .columns.small-4.table-label Status
+                .columns.small-8 =@application.married ? t('activerecord.attributes.application.page_1.married_true') : t('activerecord.attributes.application.page_1.married_false')
+              .row
+                .columns.small-4.table-label Fee
+                .columns.small-8 £#{@application.fee.floor}
+
 javascript:
   $('#application_threshold_exceeded_false').on('click', function () {
     $('#application_over_61_true').prop('checked', false);


### PR DESCRIPTION
Add the summary block to the foot of the 
savings and investment page.

This needed to access the applicant age 
from the model, so it was made public.