### PR TITLE
Incorrect email error fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,3 @@ DEPENDENCIES
   web-console (~> 2.1)
   webmock
   will_paginate
-
-BUNDLED WITH
-   1.10.6

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,19 +1,24 @@
 class Users::InvitationsController < Devise::InvitationsController
   respond_to :html
   before_action :authenticate_user!
+  before_action :build_role_list, only: [:new, :create]
+
   load_and_authorize_resource User, except: [:edit, :update]
 
   def new
     @user = User.new
+    render :new
+  end
+
+  private
+
+  def build_role_list
     if current_user.admin?
       @roles = User::ROLES
     else
       @roles = User::ROLES - %w[admin]
     end
-    render :new
   end
-
-  private
 
   def invite_resource
     resource_class.invite!(invite_params, current_inviter)

--- a/spec/features/user_invite_spec.rb
+++ b/spec/features/user_invite_spec.rb
@@ -34,5 +34,21 @@ RSpec.feature 'User management,', type: :feature do
       expect(page).to_not have_xpath("//input[@value='#{user.email}']")
       expect(page).to have_content "#{user.email}"
     end
+
+    scenario 'invites a user with an invalid email address' do
+      new_email = 'invalid@email.com'
+      login_as(admin_user, scope: :user)
+      visit new_user_invitation_path
+
+      fill_in 'user_email', with: new_email
+      fill_in 'user_name', with: 'Test name'
+      select('User', from: 'user_role')
+      select('Bristol', from: 'user_office_id')
+
+      click_button 'Send an invitation'
+
+      expect(page).to have_xpath('//div[contains(@class, "field_with_errors")]/label[@for="user_email" and @class="error"]', text: /not able to create an account with this email address/)
+      expect(page).to have_xpath("//input[@value='#{new_email}']")
+    end
   end
 end


### PR DESCRIPTION
When an elevated user creates a new user, an enters an incorrect email
it was rendering a 500 error page.

This fix redirects them to the previous screen with the appropriate
error message.