### PR TITLE
Update copy on various pages

### DIFF
--- a/app/views/layouts/_toolbar.html.slim
+++ b/app/views/layouts/_toolbar.html.slim
@@ -11,10 +11,10 @@
         =link_to t('functions.staff_guide').to_s, guide_path
       -if current_user.elevated?
         dd.right
-          =link_to 'Users', users_path
+          =link_to 'Staff', users_path
         -if current_user.admin?
           dd.right
             =link_to 'Offices', offices_path
         -if current_user.manager?
           dd.right
-            =link_to 'My office', current_user.office
+            =link_to 'Office', current_user.office

--- a/app/views/offices/show.html.slim
+++ b/app/views/offices/show.html.slim
@@ -3,7 +3,7 @@ h2 Office details
 #result_table
   .row
     .columns.small-4.large-2
-      label Name
+      label Name of office
     .columns.small-8.large-10
       =@office.name
   .row
@@ -15,8 +15,8 @@ h2 Office details
 
 .row.pad-top-thirty-pix
   .columns.small-12
-    =link_to 'Edit this office', edit_office_path(@office)
+    =link_to 'Change details', edit_office_path(@office)
 -unless current_user.manager?
   .row.pad-top-fifteen-px
     .columns.small-12
-      =link_to 'Back to office list', offices_path
+      =link_to 'Back to list of offices', offices_path

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,4 +1,4 @@
-h2 Edit user
+h2 Change details
 
 = form_for @user do |f|
   .row
@@ -45,7 +45,7 @@ h2 Edit user
   .row
     .columns.small-12.medium-8.large-5.columns
       .form-group
-        label Jurisdictions
+        label Main jurisdiction
         = f.label :jurisdiction_id, @user.errors[:jurisdiction_id].join(', ').html_safe, class: 'error' if @user.errors[:jurisdiction_id].present?
         - if @jurisdictions.present?
           .row.collapse
@@ -60,4 +60,4 @@ h2 Edit user
         - else
           = t('error_messages.jurisdictions.none_in_office')
 
-  .actions = f.submit 'Update user', class: 'button'
+  .actions = f.submit 'Save changes', class: 'button'

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -1,11 +1,11 @@
-h2 List users
+h2 Staff
 
 table
   tr
-    th Name
+    th Full name
     th Role
     th Office
-    th Jurisdiction
+    th Main jurisdiction
     th &nbsp;
 
   -@users.each do |user|
@@ -17,6 +17,6 @@ table
         =user.role
       td =user.office.name if user.office.present?
       td =user.jurisdiction.display if user.jurisdiction.present?
-      td =link_to 'Edit', edit_user_path(user)
+      td =link_to 'Change details', edit_user_path(user)
 
-=link_to 'Invite new user', new_user_invitation_path
+=link_to 'Add staff', new_user_invitation_path

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -3,7 +3,7 @@ h2 User details
 #result_table
   .row
     .columns.small-4.large-2
-      label Name
+      label Full name
     .columns.small-6.large-10
       =@user.name
   .row
@@ -23,12 +23,12 @@ h2 User details
       =@user.office.name
   .row
     .columns.small-4.large-2
-      label Jurisdiction
+      label Main jurisdiction
     .columns.small-6.large-10
       =@user.jurisdiction.name if @user.jurisdiction.present?
 .row.pad-top-thirty-pix
   .columns.small-12
-    =link_to 'Edit this user', edit_user_path(@user)
+    =link_to 'Change details', edit_user_path(@user)
 -if current_user == @user
   .row.pad-top-fifteen-px
     .columns.small-12
@@ -36,7 +36,7 @@ h2 User details
 -if current_user.elevated?
   .row.pad-top-fifteen-pix
     .columns.small-12
-      =link_to 'Delete this user', user_path(@user), method: :delete
+      =link_to 'Remove staff member', user_path(@user), method: :delete
   .row.pad-top-fifteen-px
     .columns.small-12
-      =link_to 'Back to user list', users_path
+      =link_to 'Back to list of staff', users_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,13 +25,14 @@ en:
     r2_calculator: 'Income calculator'
     feedback: 'Give feedback'
     staff_guide: Staff guide
+    log_in: Sign in
   error_messages:
     dwp_checker:
       unavailable: 'The benefits checker is not available at the moment. Please check again later.'
     user:
       moved_offices: "%{user} moved to %{office}, you will need to contact %{contact} there if this was done in error"
     jurisdictions:
-      none_in_office: 'Ask your manager to assign jurisdictions for your team.'
+      none_in_office: 'Ask your manager to assign jurisdictions to your office.'
   dictionary:
     invalid_email: "You’re not able to create an account with this email address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help, <a href='mailto:%{email}'>contact us</a>"
   feedback:
@@ -100,8 +101,8 @@ en:
         dob_hint: For example 01/11/1980
         dob_too_young: The applicant can't be under %{min_age} years old
         dob_too_old: The applicant can't be over %{max_age} years old
-        date_to_check: 'Date application made'
-        date_to_check_hint: 'For refunds enter the date the case or claim was issued by the court.'
+        date_to_check: 'Date application received'
+        date_to_check_hint: 'For refunds enter the date the fee was paid.'
       r2_calc:
         labels:
           fee: Fee

--- a/spec/controllers/users_controller/admin_user_spec.rb
+++ b/spec/controllers/users_controller/admin_user_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe UsersController, type: :controller do
         end
 
         it 'has delete user link' do
-          expect(response.body).to have_content 'Delete this user'
+          expect(response.body).to have_content 'Remove staff member'
         end
       end
 

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'User profile', type: :feature do
       before(:each) { visit edit_user_path user.id }
 
       scenario 'their profile' do
-        ['Edit user',
+        ['Change details',
          'Office',
          'Jurisdiction',
          'Role'].each { |value| expect(page).to have_text value }

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'User profile', type: :feature do
       scenario 'their profile' do
         ['Change details',
          'Office',
-         'Jurisdiction',
+         'Main jurisdiction',
          'Role'].each { |value| expect(page).to have_text value }
       end
 

--- a/spec/views/layouts/_toolbar.html.slim_spec.rb
+++ b/spec/views/layouts/_toolbar.html.slim_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "layouts/_toolbar.html.slim", type: :view do
     end
 
     it 'see admin' do
-      expect(rendered).to include('Users')
+      expect(rendered).to include('Staff')
     end
   end
   context 'logged in as manager' do
@@ -67,11 +67,11 @@ RSpec.describe "layouts/_toolbar.html.slim", type: :view do
     end
 
     it 'see offices' do
-      expect(rendered).to include('My office')
+      expect(rendered).to include('Office')
     end
 
     it 'see admin' do
-      expect(rendered).to include('Users')
+      expect(rendered).to include('Staff')
     end
   end
 end


### PR DESCRIPTION
- Used term ‘log in’, now use ‘sign in’
- Used term ‘users’, now use ‘staff’
- Used term ‘edit’, now use ‘change’
- Used term ‘Invite’, now use ‘add’
- Used term ‘delete’, now use ‘remove’
Because it is more plain English