### PR TITLE
Update button sizes, column widths, text colour

### DIFF
--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -1452,6 +1452,4 @@ $body-font-family: 'nta', Arial, sans-serif;
 $body-font-color: $text-colour;
 
 $form-label-font-color: $text-colour;
-
-
 @import 'foundation';

--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -1451,4 +1451,7 @@ $include-html-global-classes: $include-html-classes;
 $body-font-family: 'nta', Arial, sans-serif;
 $body-font-color: $text-colour;
 
+$form-label-font-color: $text-colour;
+
+
 @import 'foundation';

--- a/app/views/calculator/income.html.slim
+++ b/app/views/calculator/income.html.slim
@@ -3,18 +3,18 @@
 #r2_calculator_income
   h2 =t('functions.r2_calculator')
   .row
-    .small-12.medium-3.large-3.columns.form-group
+    .small-12.medium-4.large-3.columns.form-group
       #fee-block
         label.error data-check-error='fee' for='fee' Please enter a fee value
         label for='fee' =t('activerecord.attributes.r2_calc.labels.fee')
         .row.collapse.prefix-radius
-          .small-2.medium-2.large-3.columns
+          .small-2.medium-3.large-3.columns
             span.prefix
               label.inline for='fee' £
-          .small-10.medium-10.large-9.columns style="padding:0px;"
+          .small-10.medium-9.large-9.columns style="padding:0px;"
             input data-check='fee' id="fee" name="fee" type="number"
   .row
-    .small-12.medium-3.large-3.columns.form-group
+    .small-12.medium-8.large-5.columns.form-group
       #status-block
         label.error data-check-error='couple' Please select a marital status
         .row
@@ -28,7 +28,7 @@
               .option
                 label for='couple-yes'
                   input data-check='couple' id='couple-yes' name="couple" type="radio" value='true'
-                  |Part of a couple
+                  |Married or living with someone and sharing an income
 
   .row
     .small-12.medium-6.large-5.columns.form-group
@@ -40,15 +40,15 @@
             input data-check='children' id='children' type="number" min=0 value=""
 
   .row
-    .small-12.medium-3.large-3.columns.form-group
+    .small-12.medium-4.large-3.columns.form-group
       #income-block
         label.error data-check-error='income' for='income' Please enter an income
         label for='income' =t('activerecord.attributes.r2_calc.labels.income')
         .row.collapse.prefix-radius
-          .small-2.medium-2.large-3.columns
+          .small-2.medium-3.large-3.columns
             span.prefix
               label.inline for='income' £
-          .small-10.medium-10.large-9.columns
+          .small-10.medium-9.large-9.columns
             input data-check='income' name="income" id="income" type="number"
 
   .row

--- a/app/views/dwp_checks/new.html.slim
+++ b/app/views/dwp_checks/new.html.slim
@@ -2,7 +2,7 @@ h2 Check benefits
 
 = form_for(@dwp_checker, url: dwp_checks_lookup_path, method: 'post', html: { autocomplete: 'off' } ) do |f|
   .row
-    .small-12.medium-8.large-5.columns
+    .small-12.medium-7.large-4.columns
       .form-group
         = f.label :last_name, @dwp_checker.errors[:last_name].join(', '), class: 'error' if @dwp_checker.errors[:last_name].present?
         = f.label :last_name
@@ -10,7 +10,7 @@ h2 Check benefits
           span.hint.block = t('activerecord.attributes.dwp_check.last_name_hint')
         = f.text_field :last_name, autofocus:true, class: 'form-control'
   .row
-    .small-12.medium-8.large-5.columns
+    .small-12.medium-7.large-4.columns
       .form-group
         = f.label :dob, @dwp_checker.errors[:dob].join(', '), class: 'error' if @dwp_checker.errors[:dob].present?
         = f.label :dob
@@ -18,13 +18,13 @@ h2 Check benefits
           span.hint.block = t('activerecord.attributes.dwp_check.dob_hint')
         = f.text_field :dob, { class: 'form-control' }
   .row
-    .small-12.medium-8.large-5.columns
+    .small-12.medium-7.large-4.columns
       .form-group
         = f.label :ni_number, @dwp_checker.errors[:ni_number].join(', '), class: 'error' if @dwp_checker.errors[:ni_number].present?
         = f.label :ni_number
         = f.text_field :ni_number, { class: 'form-control transform-upper' }
   .row
-    .small-12.medium-8.large-5.columns
+    .small-12.medium-7.large-4.columns
       .form-group
         = f.label :date_to_check, @dwp_checker.errors[:date_to_check].join(', '), class: 'error' if @dwp_checker.errors[:date_to_check].present?
         = f.label :date_to_check
@@ -32,7 +32,7 @@ h2 Check benefits
           span.hint.block = t('activerecord.attributes.dwp_check.date_to_check_hint')
         = f.text_field :date_to_check, { class: 'form-control' }
   .row
-    .small-12.medium-8.large-5.columns
+    .small-12.medium-7.large-4.columns
       .form-group
         = f.submit 'Check', :id => 'save', class: 'button primary'
 

--- a/app/views/users/invitations/edit.html.slim
+++ b/app/views/users/invitations/edit.html.slim
@@ -3,4 +3,4 @@ h2 = t 'devise.invitations.edit.header'
   = f.hidden_field :invitation_token
   =render(partial: '/users/shared/change_password', locals: { f: f })
   .actions
-    = f.submit t("devise.invitations.edit.submit_button"), class: 'button btn tiny'
+    = f.submit t("devise.invitations.edit.submit_button"), class: 'button'

--- a/app/views/users/invitations/new.html.slim
+++ b/app/views/users/invitations/new.html.slim
@@ -6,15 +6,15 @@ h2
     .row
       .columns.small-12.medium-8.large-5
         .form-group
-          = f.label field
-          = f.label field, @user.errors[field].join(', ').html_safe, class: 'error' if @user.errors[field].present?
-          = f.text_field field
-    .row
-      .columns.small-12.medium-8.large-5
-        .form-group
           = f.label :name
           = f.label :name, @user.errors[:name].join(', ').html_safe, class: 'error' if @user.errors[:name].present?
           = f.text_field :name, { class: 'form-control' }
+    .row
+      .columns.small-12.medium-8.large-5
+        .form-group
+          = f.label field
+          = f.label field, @user.errors[field].join(', ').html_safe, class: 'error' if @user.errors[field].present?
+          = f.text_field field
   .row
     .small-12.columns
       .form-group
@@ -33,4 +33,4 @@ h2
             -elsif current_user.manager?
               = f.hidden_field :office_id, value: current_user.office.id
   p
-    = f.submit t("devise.invitations.new.submit_button"), class: 'button btn tiny'
+    = f.submit t("devise.invitations.new.submit_button"), class: 'button'

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -16,4 +16,4 @@ h2 =t('devise.invitations.edit.header')
         = f.label :password_confirmation, resource.errors[:password_confirmation].join(', ').html_safe, class: 'error' if resource.errors[:password_confirmation].present?
         = f.password_field :password_confirmation, autofocus: true, autocomplete: "off"
   .actions
-    = f.submit t('devise.invitations.edit.submit_button'), class: 'button btn tiny'
+    = f.submit t('devise.invitations.edit.submit_button'), class: 'button'

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -8,6 +8,6 @@ h2 = t 'devise.passwords.new.header'
         = f.label :email, resource.errors[:email].join('').html_safe, class: 'error' if resource.errors[:email].present?
         = f.text_field :email, { class: 'form-control' }
   .actions
-    = f.submit t('devise.passwords.new.submit_button'), class: 'button btn tiny'
+    = f.submit t('devise.passwords.new.submit_button'), class: 'button'
 hr
 = render "users/shared/links"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -17,6 +17,6 @@
           = f.check_box :remember_me
           = f.label :remember_me
   .actions
-    = f.submit "Log in", class: 'button btn tiny'
+    = f.submit "Sign in", class: 'button'
 hr
 = render "users/shared/links"


### PR DESCRIPTION
- Before the button sizes were very small and hard to read, now they
are larger and easier to read.

- Before the column widths for the benefits check and income check were
narrow and didn’t match the prototype. Now the column widths are wider
and match the prototype and other form pages.

- Before the form label text colour was light and very similar to the
hint text colour. Now the form label text colour is darker and there is
more distinction from the hint text colour.