### PR TITLE
Update the homepage to include sign in link and info to contact manager

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -14,4 +14,12 @@
       |&nbsp;to see if an applicant can get help with their fees based on their income.
       br You'll also be able to calculate part-remissions.
 -else
-  .pad-top-fifteen-px This system is restricted to authorised staff only, please contact #{link_to 'support', "mailto:#{Settings.mail_tech_support}"} if you feel you should have access.
+  .pad-top-fifteen-px 
+    = link_to t('functions.log_in'), new_user_session_path, class: 'button'
+    h4  
+      |Get help
+    div.bold Don't have an account
+    div Contact your manager to set up your account. You will then receive an email to sign in.
+    div.bold Having technical issues
+    div Contact support
+    div Email: #{link_to Settings.mail_tech_support, "mailto:#{Settings.mail_tech_support}"}

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -16,12 +16,9 @@
 -else
   .pad-top-thirty-pix 
     = link_to t('functions.log_in'), new_user_session_path, class: 'button'
-  h4
-    .pad-top-thirty-pix 
-      |Get help
-      div.bold Don't have an account
-      div Contact your manager to set up your account. You will then receive an email to sign in.
-  div.bold.pad-top-fifteen-px 
- Having technical issues
+  h4.pad-top-thirty-pix Get help
+  div.bold Don't have an account
+  div Contact your manager to set up your account. You will then receive an email to sign in.
+  div.bold.pad-top-fifteen-px Having technical issues
   div Contact support
   div Email: #{link_to Settings.mail_tech_support, "mailto:#{Settings.mail_tech_support}"}

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -14,12 +14,14 @@
       |&nbsp;to see if an applicant can get help with their fees based on their income.
       br You'll also be able to calculate part-remissions.
 -else
-  .pad-top-fifteen-px 
+  .pad-top-thirty-pix 
     = link_to t('functions.log_in'), new_user_session_path, class: 'button'
-    h4  
+  h4
+    .pad-top-thirty-pix 
       |Get help
-    div.bold Don't have an account
-    div Contact your manager to set up your account. You will then receive an email to sign in.
-    div.bold Having technical issues
-    div Contact support
-    div Email: #{link_to Settings.mail_tech_support, "mailto:#{Settings.mail_tech_support}"}
+      div.bold Don't have an account
+      div Contact your manager to set up your account. You will then receive an email to sign in.
+  div.bold.pad-top-fifteen-px 
+ Having technical issues
+  div Contact support
+  div Email: #{link_to Settings.mail_tech_support, "mailto:#{Settings.mail_tech_support}"}

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -30,7 +30,7 @@ html[lang="en"]
                     = link_to 'Sign out', destroy_user_session_path, :method => :delete
                 - else
                   .inline
-                    = link_to 'Sign in', new_user_session_path
+                    = link_to t('functions.log_in'), new_user_session_path
     =render 'layouts/toolbar'
     .row
       .large-12.columns

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe "home/index.html.slim", type: :view do
   let(:admin)     { create :admin_user }
 
   context 'public access' do
-    it 'shows a restriction message' do
+    it 'shows a get help message' do
       render
-      expect(rendered).to have_xpath('//div', text: /This system is restricted/)
+      expect(rendered).to have_xpath('//h4', text: /Get help/)
     end
   end
 


### PR DESCRIPTION
- Before users would not see the sign in link in the top right and
would click the support link in the body.
- Now a sign in button has been added to the body and information about
contacting their manager before contacting support.