### PR TITLE
Update copy on the office and user sections

### DIFF
--- a/app/views/offices/edit.html.slim
+++ b/app/views/offices/edit.html.slim
@@ -1,4 +1,4 @@
-h2 Editing office
+h2 Change office details
 
 == render 'form'
 
@@ -8,4 +8,4 @@ h2 Editing office
 -unless current_user.manager?
   .row.pad-top-fifteen-px
     .columns.small-12
-      =link_to 'Back to office list', offices_path
+      =link_to 'Back to list of offices', offices_path

--- a/app/views/offices/index.html.slim
+++ b/app/views/offices/index.html.slim
@@ -1,10 +1,10 @@
-h2 Listing offices
+h2 Offices
 
 table
   thead
     tr
-      th Name
-      th Jurisdiction(s)
+      th Name of office
+      th Jurisdictions
       th &nbsp;
 
   tbody
@@ -13,7 +13,7 @@ table
         td = link_to office.name, office
         td.center = office.jurisdictions.count
         - if can? :update, :office
-          td = link_to 'Edit', edit_office_path(office)
+          td = link_to 'Change details', edit_office_path(office)
 
 br
 

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -52,7 +52,7 @@ h2 Change details
             .options.radio
               label for="user_jurisdiction_id"
                 input type="radio" value="" name="user[jurisdiction_id]" id="user_jurisdiction_id" checked="true"
-                  |No default jurisdiction
+                  |No main jurisdiction
               =collection_radio_buttons(:user, :jurisdiction_id, @jurisdictions, :id, :display_full ) do |b|
                 = b.label do
                   = b.radio_button(class: 'form-control')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,4 @@
-h2 User details
+h2 Staff details
 
 #result_table
   .row

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'User profile', type: :feature do
     context 'show view' do
       scenario 'view their profile' do
         click_link "#{user.name}"
-        expect(page).to have_text 'User details'
+        expect(page).to have_text 'Staff details'
         expect(page).to have_text "#{user.email}"
         expect(page).to have_text "#{user.role}"
       end

--- a/spec/views/offices/index.html.slim_spec.rb
+++ b/spec/views/offices/index.html.slim_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "offices/index", type: :view do
     end
 
     it 'see the edit and destroy links' do
-      expect(rendered).to have_css('a', text: 'Edit', count: 2)
+      expect(rendered).to have_css('a', text: 'Change details', count: 2)
     end
   end
 end


### PR DESCRIPTION
Before said ‘edit’, now says ‘change’
Before said ‘default’, now says ‘main’
Before said ‘user’, now says ‘staff’