### PR TITLE
Update application form income page

### DIFF
--- a/app/assets/javascripts/income.coffee
+++ b/app/assets/javascripts/income.coffee
@@ -1,21 +1,20 @@
 root = exports ? this
 
 IncomeModule =
-
-  showChildrenAndIncomeInputs: ->
-    $('#application_dependents_true').on 'click', ->
-      $('#children-and-income').show()
-
-  hideChildrenAndIncomeInputs: ->
-    $('#application_dependents_false').on 'click', ->
-      $('#children').val('')
-      $('#income').val(0)
-      $('#children-and-income').hide()
+  showIncomeInput: ->
+    $('input[id*="application_dependents"]').on 'click', ->
+      $('#income-input').show()
 
   setup: ->
-    $('#children-and-income').hide()
-    IncomeModule.showChildrenAndIncomeInputs()
-    IncomeModule.hideChildrenAndIncomeInputs()
+    if $('input[id*="application_dependents"]').is(':checked')
+      if $('#application_dependents_true').is(':checked')
+        $('#children-only').show()
+      $('#income-input').show()
+    else
+      $('#children-only').hide()
+      $('#income-input').hide()
+
+    IncomeModule.showIncomeInput()
 
 root.IncomeModule = IncomeModule
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -66,6 +66,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     validates :dependents, inclusion: { in: [true, false] }
     validates :income, numericality: true
     validates :children, numericality: true
+    validate :children_numbers
   end
   # End step 5 validation
 
@@ -75,6 +76,10 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     else
       self[:ni_number] = val.upcase if val.present?
     end
+  end
+
+  def children=(val)
+    self[:children] = dependents? ? val : 0
   end
 
   def ni_number_display
@@ -132,6 +137,21 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   end
 
   private
+
+  def children_numbers
+    errors.add(
+      :children,
+      I18n.t('activerecord.errors.models.application.attributes.children.not_a_number')
+    ) if dependents? && no_children?
+  end
+
+  def no_children?
+    children_present? && children == 0
+  end
+
+  def children_present?
+    children.present?
+  end
 
   def run_benefit_check # rubocop:disable MethodLength
     if can_check_benefits? && new_benefit_check_needed?

--- a/app/views/applications/build/income.html.slim
+++ b/app/views/applications/build/income.html.slim
@@ -4,34 +4,36 @@ h2 Income
   .row
     .small-12.medium-8.large-5.columns
       .form-group
-        .options.radio
-          .option
-            label for='application_dependents_false'
-              = f.radio_button :dependents, 'false'
-              = t('activerecord.attributes.application.income_false')
-          .option
-            label for='application_dependents_true'
-              = f.radio_button :dependents, 'true'
-              = t('activerecord.attributes.application.income_true')
+        .row.collapse
+          .columns.small-12
+            = f.label :dependents
+            = f.label :dependents, @application.errors[:dependents].join(', '), class: 'error' if @application.errors[:dependents].present?
+            .options.radio
+              .option
+                label for='application_dependents_false'
+                  = f.radio_button :dependents, 'false', { class: 'show-hide-section', data: { section: 'children', show: 'false' } }
+                  = t('activerecord.attributes.application.income_false')
+              .option
+                label for='application_dependents_true'
+                  = f.radio_button :dependents, 'true', { class: 'show-hide-section', data: { section: 'children', show: 'true' } }
+                  = t('activerecord.attributes.application.income_true')
 
-  .row.collapse#children-and-income
-    .small-12.medium-6.large-5.columns.form-group.panel-indent
-      .row
-        .columns.small-12
-          label for='children' Number of children
+      .row.collapse.panel-indent#children-only
+        .small-12.medium-6.large-6.columns.form-group
+          = f.label :children
           = f.label :children, @application.errors[:children].join(', '), class: 'error' if @application.errors[:children].present?
           .row.collapse
             .columns.small-4.medium-4.large-4
               = f.text_field :children
-      .row
-        .columns.small-12
-          label for='income' Total monthly income
+      .row.collapse.panel-indent#income-input
+        .small-12.medium-6.large-6.columns.form-group
+          = f.label :income
           = f.label :income, @application.errors[:income].join(', '), class: 'error' if @application.errors[:income].present?
           .row.collapse.prefix-radius
             .small-2.medium-4.large-3.columns
               span.prefix
                 label.inline for='income' £
-            .small-10.medium-9.large-9.columns
+            .small-10.medium-8.large-9.columns
               = f.text_field :income
 
   = f.submit 'Next', class: 'button primary'

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -73,3 +73,10 @@
           .small-12.medium-7.large-8.columns.summary-result.success =t('activerecord.attributes.application.summary.passed').html_safe
         -else
           .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe
+    -else
+      .row
+        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.children')
+        .small-12.medium-7.large-8.columns =@application.children
+      .row
+        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.income')
+        .small-12.medium-7.large-8.columns =number_to_currency(@application.income.floor, precision: 0)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,7 +153,7 @@ en-GB:
               inclusion: Please confirm the ages
             benefits:
               inclusion: You must answer the benefits question
-            children:
+            dependents:
               inclusion: 'You must answer the dependent children question'
     attributes:
       user:
@@ -201,6 +201,9 @@ en-GB:
         date_fee_paid: Date fee paid
         over_61: "Is the applicant's partner 61 or over?"
         benefits: Is the applicant receiving one of the benefits listed in question 9?
+        dependents: Are there any financially dependent children?
+        children: Number of children
+        income: Total monthly income
         page_1:
           date_of_birth_hint: For example 01/11/1980
           married_false: Single

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,11 @@ en-GB:
               inclusion: You must answer the benefits question
             dependents:
               inclusion: 'You must answer the dependent children question'
+            children:
+              not_a_number: Choose number of children
+            income:
+              blank: Enter the total monthly income
+              not_a_number: Enter the total monthly income
     attributes:
       user:
         current_password: Current password

--- a/spec/javascripts/income_spec.coffee
+++ b/spec/javascripts/income_spec.coffee
@@ -1,60 +1,99 @@
-//= require income
+#= require radio_buttons_module
+#= require income
 
 describe "IncomeModule", ->
   element = null
   beforeEach ->
     element = $("""
-    <div id="application_dependents_true"/>
-    <div id="application_dependents_false"/>
-    <section id="test-section">
-      <div id="children-and-income">
-        <input data-check="children" id="children" min="0" value="" type="number">
-        <input data-check="income" id="income" name="income" value="0" type="number">
+    <div class="small-12 medium-8 large-5 columns">
+      <div class="form-group">
+        <div class="options radio">
+          <div class="option">
+            <label for="application_dependents_false">
+              <input class="show-hide-section" data-section="children" data-show="false" type="radio" value="false" name="application[dependents]" id="application_dependents_false">
+              No
+            </label>
+          </div>
+          <div class="option">
+            <label for="application_dependents_true">
+              <input class="show-hide-section" data-section="children" data-show="true" type="radio" value="true" name="application[dependents]" id="application_dependents_true">
+              Yes
+            </label>
+          </div>
+        </div>
       </div>
-    </section>
+      <div class="row collapse panel-indent" id="children-only">
+        <div class="small-12 medium-6 large-5 columns form-group">
+          <label for="application_children">Children</label>
+          <div class="row collapse">
+            <div class="columns small-4 medium-4 large-4">
+              <input type="text" name="application[children]" id="application_children">
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="row collapse panel-indent" id="income-input">
+        <div class="small-12 medium-6 large-5 columns form-group">
+          <label for="application_income">Income</label>
+          <div class="row collapse prefix-radius">
+            <div class="small-2 medium-4 large-3 columns">
+              <span class="prefix"><label class="inline" for="income">£</label></span>
+            </div>
+            <div class="small-10 medium-8 large-9 columns">
+              <input type="text" name="application[income]" id="application_income">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
     """)
     $(document.body).append(element)
-    @detail = $('#test-section')
     IncomeModule.setup()
+    window.RadioButtonsModule.setup()
 
-  describe 'initial hiding', ->
-    it 'hides "#children-and-income"', ->
-      expect($('#children-and-income').is(':visible')).toBe(false)
+  describe 'on initial load', ->
+    describe 'when children is checked', ->
+      beforeEach ->
+        $('#application_dependents_true').prop('checked', true)
+        window.RadioButtonsModule.setup()
+
+      it 'shows children field', ->
+        expect($('#application_children').is(':visible')).toBe(true)
+
+  describe 'on initial load', ->
+    beforeEach ->
+      $('#application_dependents_false').prop('checked', false)
+      $('#application_dependents_true').prop('checked', false)
+      window.RadioButtonsModule.setup()
+
+    describe 'no choice is made', ->
+      describe 'sets initial value', ->
+        it 'income amount to empty ', ->
+          expect($('#application_income').val()).toBe('')
+
+        it 'number of children to empty', ->
+          expect($('#application_children').val()).toBe('')
+
+      it 'hides income field', ->
+        expect($('#application_income').is(':visible')).toBe(false)
+
+      it 'hides children field', ->
+        expect($('#application_children').is(':visible')).toBe(false)
 
   describe 'when the user selects "Yes" answer for dependant children question', ->
-    it 'shows #children-and-income', ->
+    beforeEach ->
       $('#application_dependents_true').trigger('click')
-      expect($('#children-and-income').is(':visible')).toBe(true)
+
+    it 'shows children field', ->
+      expect($('#application_children').is(':visible')).toBe(true)
+    it 'shows the income field', ->
+      expect($('#application_income').is(':visible')).toBe(true)
 
   describe 'when the user selects "No" answer for dependant children question', ->
-    it 'hides #children-and-income', ->
-      $('#children-and-income').show()
+    beforeEach ->
       $('#application_dependents_false').trigger('click')
-      expect($('#children-and-income').is(':visible')).toBe(false)
 
-  describe 'input form values', ->
-    describe 'initial values', ->
-      it 'income amount', ->
-        expect($('#income').val()).toBe('0')
-
-      it 'number of children', ->
-        expect($('#children').val()).toBe('')
-
-    describe 'when the "Yes" option is chosen', ->
-      beforeEach ->
-        $('#application_dependents_true').trigger('click')
-
-      describe 'and the number of children & income is declared', ->
-        beforeEach ->
-          $('#income').val(5000)
-          $('#children').val(1)
-
-        describe 'and the "No" option is chosen', ->
-          beforeEach ->
-            $('#application_dependents_false').trigger('click')
-
-          it 'blanks out income value', ->
-            expect($('#income').val()).toBe('0')
-
-          it 'blanks out children value', ->
-            expect($('#children').val()).toBe('')
+    it 'hides children field', ->
+      expect($('#application_children').is(':visible')).toBe(false)
+    it 'shows the income field', ->
+      expect($('#application_income').is(':visible')).toBe(true)

--- a/spec/models/applications/income_spec.rb
+++ b/spec/models/applications/income_spec.rb
@@ -12,46 +12,86 @@ RSpec.describe Application, type: :model do
 
     describe 'validations' do
       describe 'dependents' do
-        before do
-          application.dependents = nil
-          application.valid?
-        end
-
-        it 'must be entered' do
-          expect(application).to be_invalid
-        end
-      end
-
-      describe 'income' do
-        describe 'presence' do
+        context 'when nil' do
           before do
-            application.income = nil
+            application.dependents = nil
             application.valid?
           end
 
           it 'must be entered' do
             expect(application).to be_invalid
           end
-
-          it 'returns an error if missing' do
-            expect(application.errors[:income]).to eq ['is not a number']
-          end
         end
-      end
 
-      describe 'children' do
-        describe 'presence' do
+        context 'when true' do
           before do
-            application.children = nil
+            application.dependents = true
             application.valid?
           end
 
-          it 'must be entered' do
-            expect(application).to be_invalid
+          context 'children equals zero' do
+            before do
+              application.children = 0
+              application.valid?
+            end
+
+            it 'returns an error' do
+              expect(application.errors[:children]).to eq ['Choose number of children']
+            end
+
+            it 'invalidates the object' do
+              expect(application).to be_invalid
+            end
+          end
+        end
+
+        context 'when false' do
+          before do
+            application.dependents = false
+            application.valid?
           end
 
-          it 'returns an error if missing' do
-            expect(application.errors[:children]).to eq ['is not a number']
+          context 'children greater than zero' do
+            before do
+              application.children = 1
+              application.valid?
+            end
+
+            it 'resets children to 0' do
+              expect(application.children).to eq 0
+            end
+          end
+        end
+
+        context 'when either true or false' do
+          [true, false].each do |val|
+            before { application.dependents = val }
+
+            context 'income is set' do
+              before do
+                application.income = '300'
+                application.valid?
+              end
+
+              it 'is valid' do
+                expect(application).to be_valid
+              end
+            end
+
+            context 'income is empty' do
+              before do
+                application.income = nil
+                application.valid?
+              end
+
+              it 'invalidates the object' do
+                expect(application).to be_invalid
+              end
+
+              it 'adds an error message' do
+                expect(application.errors[:income]).to eq ['Enter the total monthly income']
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
Updates to the income page inline with the prototype
* re-uses the coffeescript for handling radio button show hide
* updates labels and error massages to use the locale file
* updated the view to always show the income field and make the 
children question optional depending on the dependents response