### PR TITLE
Handle increased limits for partner applications

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -91,6 +91,9 @@ span.hint {
   ul {
     margin-bottom: 0rem;
   }
+  .panel-indent {
+    margin-bottom: 0rem;
+  }
 }
 .actions {
   margin-top: 32px;

--- a/app/controllers/applications/build_controller.rb
+++ b/app/controllers/applications/build_controller.rb
@@ -22,8 +22,10 @@ class Applications::BuildController < ApplicationController
     redirect_to wizard_path(steps.first, application_id: @application.id)
   end
 
-  def show
+  def show # rubocop:disable CyclomaticComplexity
     case step
+    when :benefits
+      jump_to(:summary) unless @application.savings_investment_result?
     when :benefits_result
       jump_to(:income) unless @application.benefits
     when :income
@@ -62,7 +64,7 @@ class Applications::BuildController < ApplicationController
 
   def application_params
     all_params            = [:status]
-    savings_investments   = [:threshold_exceeded, :over_61]
+    savings_investments   = [:threshold_exceeded, :over_61, :high_threshold_exceeded]
     benefits              = [:benefits]
     income                = [:dependents, :income, :children]
 

--- a/app/controllers/applications/build_controller.rb
+++ b/app/controllers/applications/build_controller.rb
@@ -25,7 +25,7 @@ class Applications::BuildController < ApplicationController
   def show # rubocop:disable CyclomaticComplexity
     case step
     when :benefits
-      jump_to(:summary) unless @application.savings_investment_result?
+      jump_to(:summary) unless @application.savings_investment_valid?
     when :benefits_result
       jump_to(:income) unless @application.benefits
     when :income

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -52,7 +52,6 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   with_options if: proc { active_or_status_is? 'savings_investments' } do
     validates :threshold_exceeded, inclusion: { in: [true, false] }
     validates :over_61, inclusion: { in: [true, false] }, if: :threshold_exceeded
-    validates :over_61, inclusion: { in: [nil] }, unless: :threshold_exceeded
     validates :high_threshold_exceeded, inclusion: { in: [true, false] }, if: :over_61
   end
   # End step 3 validation
@@ -101,15 +100,25 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
 
   def threshold_exceeded=(val)
     super
-    self.over_61 = nil unless val == true
+    self.over_61 = nil unless threshold_exceeded?
+    if threshold_exceeded? && !over_61
+      self.application_type = 'none'
+      self.application_outcome = 'none'
+    end
   end
 
   def high_threshold_exceeded=(val)
     super
-    self.application_outcome = (high_threshold_exceeded? ? 'none' : nil)
+    if high_threshold_exceeded?
+      self.application_type = 'none'
+      self.application_outcome = 'none'
+    else
+      self.application_type = nil
+      self.application_outcome = nil
+    end
   end
 
-  def savings_investment_result?
+  def savings_investment_valid?
     result = false
     if threshold_exceeded == false ||
        (threshold_exceeded && (over_61 && high_threshold_exceeded == false))

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -105,7 +105,10 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
 
   def savings_investment_result?
     result = false
-    if threshold_exceeded == false || (threshold_exceeded && over_61 == false)
+    if threshold_exceeded == false ||
+       (
+         threshold_exceeded && (over_61 == false || over_61 && high_threshold_exceeded == false)
+       )
       result = true
     end
     result

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -53,6 +53,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     validates :threshold_exceeded, inclusion: { in: [true, false] }
     validates :over_61, inclusion: { in: [true, false] }, if: :threshold_exceeded
     validates :over_61, inclusion: { in: [nil] }, unless: :threshold_exceeded
+    validates :high_threshold_exceeded, inclusion: { in: [true, false] }, if: :over_61
   end
   # End step 3 validation
 
@@ -103,12 +104,15 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     self.over_61 = nil unless val == true
   end
 
+  def high_threshold_exceeded=(val)
+    super
+    self.application_outcome = (high_threshold_exceeded? ? 'none' : nil)
+  end
+
   def savings_investment_result?
     result = false
     if threshold_exceeded == false ||
-       (
-         threshold_exceeded && (over_61 == false || over_61 && high_threshold_exceeded == false)
-       )
+       (threshold_exceeded && (over_61 && high_threshold_exceeded == false))
       result = true
     end
     result

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -127,6 +127,11 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     result
   end
 
+  def benefits=(val)
+    super
+    self.application_type = benefits? ? 'benefit' : 'income'
+  end
+
   def full_name
     [title, first_name, last_name].join(' ')
   end
@@ -150,7 +155,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   end
 
   def last_benefit_check
-    benefit_checks.last
+    benefit_checks.order(:id).last
   end
 
   private
@@ -187,6 +192,19 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
           parameter_hash: build_hash
         )
       )
+      update(
+        application_type: 'benefit',
+        application_outcome: outcome_from_dwp_result
+      )
+    end
+  end
+
+  def outcome_from_dwp_result
+    case last_benefit_check.dwp_result
+    when 'Yes'
+      'full'
+    when 'No'
+      'none'
     end
   end
 

--- a/app/views/applications/build/savings_investments.html.slim
+++ b/app/views/applications/build/savings_investments.html.slim
@@ -30,6 +30,8 @@
 
   -if @application.known_over_61?
     =f.hidden_field :over_61, value: 'true'
+  -elsif !@application.married?
+    =f.hidden_field :over_61, value: 'false'
   -else
     #over-61-only.start-hidden
       .row
@@ -42,12 +44,26 @@
                 .options.radio
                   .option
                     label for='application_over_61_false'
-                      = f.radio_button :over_61, 'false'
+                      = f.radio_button :over_61, 'false', { class: 'show-hide-section', data: { section: 'high-threshold', show: 'false' } }
                       = t('no')
                   .option
                     label for='application_over_61_true'
-                      = f.radio_button :over_61, 'true'
+                      = f.radio_button :over_61, 'true', { class: 'show-hide-section', data: { section: 'high-threshold', show: 'true' } }
                       = t('yes')
+                #high-threshold-only.start-hidden
+                  .row
+                    .small-12.medium-12.large-12.columns
+                      .panel-indent
+                        =f.label :high_threshold_exceeded
+                        .options.radio
+                          .option
+                            label for="application_high_threshold_exceeded_false"
+                              = f.radio_button :high_threshold_exceeded, 'false'
+                              = t('activerecord.attributes.application.page_3.savings.less_than_high')
+                          .option
+                            label for="application_high_threshold_exceeded_true"
+                              = f.radio_button :high_threshold_exceeded, 'true'
+                              = t('activerecord.attributes.application.page_3.savings.more_than_high')
 
   = f.hidden_field :status
   = f.submit 'Next', :class => 'button primary'

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -72,7 +72,7 @@
         .small-12.medium-7.large-8.columns.summary-result.success =t('activerecord.attributes.application.summary.passed').html_safe
       -else
         .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe
-  -else
+  -elsif @application.income.present?
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.income')
       -if @application.application_outcome == 'none'
@@ -91,5 +91,4 @@
     .small-12.columns
       .row.collapse.medium-10.large-8
           #calculator.callout class="callout-#{@application.application_outcome ? @application.application_outcome : 'error'}"
-            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay.floor, precision: 0))
-
+            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency( @application.amount_to_pay.present? ? @application.amount_to_pay.floor : 0, precision: 0)).html_safe

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -65,14 +65,20 @@
       .small-12.medium-7.large-8.columns.summary-result.success =t('activerecord.attributes.application.summary.passed').html_safe
     -else
       .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe
-  -if @application.benefits
+  -case @application.application_type
+  -when 'benefit'
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.benefits')
       -if @application.last_benefit_check && @application.last_benefit_check.benefits_valid
         .small-12.medium-7.large-8.columns.summary-result.success =t('activerecord.attributes.application.summary.passed').html_safe
       -else
         .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe
-  -elsif @application.income.present?
+    .row
+      .small-12.columns
+        .row.collapse.medium-10.large-8
+          #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
+            h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
+  -when 'income'
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.income')
       -if @application.application_outcome == 'none'
@@ -86,9 +92,23 @@
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.income')
       .small-12.medium-7.large-8.columns =number_to_currency(@application.income.floor, precision: 0)
-
-  .row
-    .small-12.columns
-      .row.collapse.medium-10.large-8
+    .row
+      .small-12.columns
+        .row.collapse.medium-10.large-8
           #calculator.callout class="callout-#{@application.application_outcome ? @application.application_outcome : 'error'}"
-            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency( @application.amount_to_pay.present? ? @application.amount_to_pay.floor : 0, precision: 0)).html_safe
+            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay? ? @application.amount_to_pay.floor: 0, precision: 0)).html_safe
+  -when 'none'
+    .row
+      .small-12.columns
+        .row.collapse.medium-10.large-8
+          #calculator.callout.callout-none
+            h3.bold =t('remissions.none').html_safe
+  -else
+    .row
+      .small-12.columns
+        .row.collapse.medium-10.large-8
+          #calculator.callout.callout-none
+            h3.bold No application_type has been set
+    .row
+      .small-12.columns
+        h5 =@application.inspect

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -61,7 +61,7 @@
     .small-12.medium-5.large-4.columns.text-right =link_to 'Change savings and investments', wizard_path(:savings_investments)
   .row
     .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.savings_investments')
-    -if @application.savings_investment_result?
+    -if @application.savings_investment_valid?
       .small-12.medium-7.large-8.columns.summary-result.success =t('activerecord.attributes.application.summary.passed').html_safe
     -else
       .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe

--- a/app/views/applications/partials/_deleted.html.slim
+++ b/app/views/applications/partials/_deleted.html.slim
@@ -1,0 +1,3 @@
+=render('applications/partials/base/dwp_check')
+
+=render('applications/partials/base/does_not_match')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -216,6 +216,7 @@ en-GB:
         dependents: Are there any financially dependent children?
         children: Number of children
         income: Total monthly income
+        high_threshold_exceeded: The applicant and their partner have
         page_1:
           date_of_birth_hint: For example 01/11/1980
           married_false: Single
@@ -229,6 +230,8 @@ en-GB:
             married: The applicant and their partner have
             less_than: Less than this amount
             more_than: More than this amount
+            less_than_high: Less than £16,000
+            more_than_high: More than £16,000
         page_4:
           benefits_false: 'No'
           benefits_true: 'Yes'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,8 @@ en-GB:
       heading: '&#10003; &nbsp; The applicant is receiving the correct benefits'
     :no:
       heading: '&#10007; &nbsp; The applicant is not receiving benefits'
+    deleted:
+      heading: The applicant is not receiving benefits
     deceased:
       heading: The personal details entered belong to someone who has died
     undetermined:

--- a/db/migrate/20150817083012_add_high_threshold_exceeded_to_application.rb
+++ b/db/migrate/20150817083012_add_high_threshold_exceeded_to_application.rb
@@ -1,0 +1,5 @@
+class AddHighThresholdExceededToApplication < ActiveRecord::Migration
+  def change
+    add_column :applications, :high_threshold_exceeded, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150812114215) do
+ActiveRecord::Schema.define(version: 20150817083012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,8 +25,8 @@ ActiveRecord::Schema.define(version: 20150812114215) do
     t.boolean  "married"
     t.decimal  "fee"
     t.string   "status"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.integer  "jurisdiction_id"
     t.date     "date_received"
     t.string   "form_name"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20150812114215) do
     t.string   "application_type"
     t.string   "application_outcome"
     t.integer  "amount_to_pay"
+    t.boolean  "high_threshold_exceeded"
   end
 
   add_index "applications", ["office_id"], name: "index_applications_on_office_id", using: :btree

--- a/spec/controllers/applications/build_controller_spec.rb
+++ b/spec/controllers/applications/build_controller_spec.rb
@@ -48,10 +48,29 @@ RSpec.describe Applications::BuildController, type: :controller do
       end
 
       context 'benefits' do
-        before { get :show, application_id: application.id, id: :benefits }
+        context 'when savings_investment_valid? is false' do
+          before do
+            application.threshold_exceeded = true
+            application.over_61 = false
+            application.save
+            get :show, application_id: application.id, id: :benefits
+          end
 
-        it 'displays the benefits view' do
-          expect(response).to render_template :benefits
+          it 'redirects' do
+            expect(response).to have_http_status(:redirect)
+          end
+
+          it 'redirects to the summary page' do
+            expect(response).to redirect_to(application_build_path(application_id: assigns(:application).id, id: :summary))
+          end
+        end
+
+        context 'when savings_investment_valid? is true' do
+          before { get :show, application_id: application.id, id: :benefits }
+
+          it 'displays the benefits view' do
+            expect(response).to render_template :benefits
+          end
         end
       end
 
@@ -81,7 +100,7 @@ RSpec.describe Applications::BuildController, type: :controller do
           end
 
           it 'redirects to the summary page' do
-            expect(response).to redirect_to redirect_to(application_build_path(application_id: assigns(:application).id, id: :summary))
+            expect(response).to redirect_to(application_build_path(application_id: assigns(:application).id, id: :summary))
           end
         end
       end
@@ -120,7 +139,7 @@ RSpec.describe Applications::BuildController, type: :controller do
           end
 
           it 'redirects to the income page' do
-            expect(response).to redirect_to redirect_to(application_build_path(application_id: assigns(:application).id, id: :income))
+            expect(response).to redirect_to(application_build_path(application_id: assigns(:application).id, id: :income))
           end
         end
       end

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     benefits true
     children 1
     income 500
+    threshold_exceeded false
 
     factory :probate_application do
       probate true

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -97,9 +97,9 @@ RSpec.describe Application, type: :model do
     end
   end
 
-  describe 'calculator scenarios' do
+  describe 'calculator' do
     CalculatorTestData.seed_data.each do |src|
-      it "run scenario #{src[:id]}" do
+      it "scenario \##{src[:id]} passes" do
         application.update(
           fee: src[:fee],
           married: src[:married_status],
@@ -107,6 +107,7 @@ RSpec.describe Application, type: :model do
           children: src[:children],
           income: src[:income]
         )
+        expect(application.application_type).to eq 'income'
         expect(application.application_outcome).to eq src[:type]
         expect(application.amount_to_pay).to eq src[:they_pay].to_i
       end
@@ -124,6 +125,11 @@ RSpec.describe Application, type: :model do
       before { application.last_name = 'TEST' }
       it 'runs a benefit check ' do
         expect { application.save } .to change { application.benefit_checks.count }.by 1
+      end
+
+      it 'sets application_type to benefit' do
+        application.save
+        expect(application.application_type).to eq 'benefit'
       end
 
       context 'when other fields are changed' do

--- a/spec/models/applications/benefits_result_spec.rb
+++ b/spec/models/applications/benefits_result_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe Application, type: :model do
       end
 
       context 'when at more than one check has been made' do
-        before { application.benefit_checks.new }
+        before do
+          application.benefit_checks.new
+          application.save
+        end
 
         it 'returns a benefit check' do
           expect(application.last_benefit_check).to be_a BenefitCheck

--- a/spec/models/applications/benefits_spec.rb
+++ b/spec/models/applications/benefits_spec.rb
@@ -26,6 +26,31 @@ RSpec.describe Application, type: :model do
             expect(application.errors[:benefits]).to eq ['You must answer the benefits question']
           end
         end
+
+        describe 'validation' do
+          context 'when user selects yes for benefits' do
+            before do
+              application.income = nil
+              application.benefits = true
+              application.save
+            end
+
+            it 'sets application_type to benefits' do
+              expect(application.application_type).to eq 'benefit'
+            end
+          end
+
+          context 'when user selects no for benefits' do
+            before do
+              application.benefits = false
+              application.save
+            end
+
+            it 'sets application_type to income' do
+              expect(application.application_type).to eq 'income'
+            end
+          end
+        end
       end
     end
   end

--- a/spec/models/applications/savings_investments_spec.rb
+++ b/spec/models/applications/savings_investments_spec.rb
@@ -12,6 +12,30 @@ RSpec.describe Application, type: :model do
 
     describe 'methods' do
       describe 'savings_investment_result' do
+        context 'high_threshold_exceeded is true' do
+          before do
+            application.threshold_exceeded = true
+            application.over_61 = true
+            application.high_threshold_exceeded = true
+          end
+
+          it 'returns false' do
+            expect(application.savings_investment_result?).to eq false
+          end
+        end
+
+        context 'high_threshold_exceeded is true' do
+          before do
+            application.threshold_exceeded = true
+            application.over_61 = true
+            application.high_threshold_exceeded = false
+          end
+
+          it 'returns true' do
+            expect(application.savings_investment_result?).to eq true
+          end
+        end
+
         context 'threshold_exceeded is true' do
           before { application.threshold_exceeded = true }
 
@@ -176,6 +200,22 @@ RSpec.describe Application, type: :model do
               expect(application).to be_valid
             end
           end
+        end
+      end
+
+      context 'when high_threshold_exceeded is true' do
+        before { application.high_threshold_exceeded = true }
+
+        it 'sets the application_outcome to be none' do
+          expect(application.application_outcome).to eq 'none'
+        end
+      end
+
+      context 'when high_threshold_exceeded is false' do
+        before { application.high_threshold_exceeded = false }
+
+        it 'sets the application_outcome to be nil' do
+          expect(application.application_outcome).to eq nil
         end
       end
     end

--- a/spec/models/applications/savings_investments_spec.rb
+++ b/spec/models/applications/savings_investments_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Application, type: :model do
     before { application.status = 'savings_investments' }
 
     describe 'methods' do
-      describe 'savings_investment_result' do
-        context 'high_threshold_exceeded is true' do
+      describe 'savings_investment_valid?' do
+        context 'high threshold is exceeded' do
           before do
             application.threshold_exceeded = true
             application.over_61 = true
@@ -20,11 +20,11 @@ RSpec.describe Application, type: :model do
           end
 
           it 'returns false' do
-            expect(application.savings_investment_result?).to eq false
+            expect(application.savings_investment_valid?).to eq false
           end
         end
 
-        context 'high_threshold_exceeded is true' do
+        context 'high threshold is not exceeded' do
           before do
             application.threshold_exceeded = true
             application.over_61 = true
@@ -32,22 +32,22 @@ RSpec.describe Application, type: :model do
           end
 
           it 'returns true' do
-            expect(application.savings_investment_result?).to eq true
+            expect(application.savings_investment_valid?).to eq true
           end
         end
 
         context 'threshold_exceeded is true' do
           before { application.threshold_exceeded = true }
 
-          it 'returns failed' do
-            expect(application.savings_investment_result?).to eq false
+          it 'returns false' do
+            expect(application.savings_investment_valid?).to eq false
           end
 
           context 'over_61 is true' do
             before { application.over_61 = true }
 
-            it 'returns failed' do
-              expect(application.savings_investment_result?).to eq false
+            it 'returns false' do
+              expect(application.savings_investment_valid?).to eq false
             end
           end
         end
@@ -55,8 +55,8 @@ RSpec.describe Application, type: :model do
         context 'threshold_exceeded is false' do
           before { application.threshold_exceeded = false }
 
-          it 'returns passed' do
-            expect(application.savings_investment_result?).to eq true
+          it 'returns true' do
+            expect(application.savings_investment_valid?).to eq true
           end
         end
         context 'threshold_exceeded is true' do
@@ -65,8 +65,8 @@ RSpec.describe Application, type: :model do
           context 'over_61 is false' do
             before { application.over_61 = false }
 
-            it 'returns passed' do
-              expect(application.savings_investment_result?).to eq true
+            it 'returns false' do
+              expect(application.savings_investment_valid?).to eq false
             end
           end
         end
@@ -146,13 +146,30 @@ RSpec.describe Application, type: :model do
         before { application.threshold_exceeded = true }
 
         describe 'over_61' do
-          before do
-            application.over_61 = nil
-            application.valid?
+          context 'is missing' do
+            before do
+              application.over_61 = nil
+              application.valid?
+            end
+
+            it 'must be present' do
+              expect(application).to be_invalid
+            end
           end
 
-          it 'must be present' do
-            expect(application).to be_invalid
+          context 'is true' do
+            before do
+              application.over_61 = false
+              application.valid?
+            end
+
+            it 'sets the application_type to be none' do
+              expect(application.application_type).to eq 'none'
+            end
+
+            it 'sets the application_outcome to be none' do
+              expect(application.application_outcome).to eq 'none'
+            end
           end
         end
       end
@@ -205,6 +222,10 @@ RSpec.describe Application, type: :model do
 
       context 'when high_threshold_exceeded is true' do
         before { application.high_threshold_exceeded = true }
+
+        it 'sets the application_type to be none' do
+          expect(application.application_type).to eq 'none'
+        end
 
         it 'sets the application_outcome to be none' do
           expect(application.application_outcome).to eq 'none'


### PR DESCRIPTION
When an applicant has a partner and either of them is over 61
there is an increased savings threshold of £16,000.

This adds input questions to the savings_and_investments view,
processes the inputs in the model and updates the routing to, and
display of, the summary page.

It also improves the setting of outcome to ensure the summary is
correctly displayed.