### PR TITLE
Allow submission of 'empty' forms

### DIFF
--- a/app/views/applications/build/benefits.html.slim
+++ b/app/views/applications/build/benefits.html.slim
@@ -18,7 +18,9 @@ h2 Benefits
                   = f.radio_button :benefits, 'true'
                   = t('activerecord.attributes.application.page_4.benefits_true')
 
+  = f.hidden_field :status
   = f.submit 'Next', :class => 'button primary'
+
 .row
   .small-12.columns
     br

--- a/app/views/applications/build/savings_investments.html.slim
+++ b/app/views/applications/build/savings_investments.html.slim
@@ -49,6 +49,7 @@
                       = f.radio_button :over_61, 'true'
                       = t('yes')
 
+  = f.hidden_field :status
   = f.submit 'Next', :class => 'button primary'
 
 .row


### PR DESCRIPTION
Added status field to views, this allows the submission of the form 
with no other fields completed.  This means that validations will fire
and return an error enforcing the completion of the question.