### PR TITLE
Configure capybara javascript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :test do
   gem "codeclimate-test-reporter", require: nil
   gem 'webmock'
   gem 'capybara'
+  gem 'database_cleaner'
   gem 'launchy'
   gem 'capybara-webkit'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.4.1)
     date_validator (0.7.1)
       activemodel
     debug_inspector (0.0.2)
@@ -361,6 +362,7 @@ DEPENDENCIES
   chartkick
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
+  database_cleaner
   date_validator
   devise
   devise_invitable
@@ -397,3 +399,6 @@ DEPENDENCIES
   webmock
   wicked
   will_paginate
+
+BUNDLED WITH
+   1.10.6

--- a/spec/controllers/users_controller/admin_user_spec.rb
+++ b/spec/controllers/users_controller/admin_user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/shared_examples/default_user_shared'
 
 RSpec.describe UsersController, type: :controller do
   render_views

--- a/spec/controllers/users_controller/manager_user_spec.rb
+++ b/spec/controllers/users_controller/manager_user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/shared_examples/default_user_shared'
 
 RSpec.describe UsersController, type: :controller do
   render_views

--- a/spec/controllers/users_controller/standard_user_spec.rb
+++ b/spec/controllers/users_controller/standard_user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/shared_examples/default_user_shared'
 
 RSpec.describe UsersController, type: :controller do
   render_views

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ require 'webmock/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -70,7 +70,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -86,4 +86,24 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end


### PR DESCRIPTION
Updated rails_helper
* adds Database Cleaner configuration to allow javascript feature tests
to use capybara-webkit
* pre load support files

Update user tests  to remove explicit loading


