### PR TITLE
Implement JS feature tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :test do
   gem "codeclimate-test-reporter", require: nil
   gem 'webmock'
   gem 'capybara'
+  gem 'database_cleaner'
   gem 'launchy'
   gem 'capybara-webkit'
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
+    database_cleaner (1.4.1)
     date_validator (0.7.1)
       activemodel
     debug_inspector (0.0.2)
@@ -361,6 +362,7 @@ DEPENDENCIES
   chartkick
   codeclimate-test-reporter
   coffee-rails (~> 4.1.0)
+  database_cleaner
   date_validator
   devise
   devise_invitable
@@ -397,3 +399,6 @@ DEPENDENCIES
   webmock
   wicked
   will_paginate
+
+BUNDLED WITH
+   1.10.6

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -104,6 +104,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     if threshold_exceeded? && !over_61
       self.application_type = 'none'
       self.application_outcome = 'none'
+      self.dependents = nil
     end
   end
 
@@ -112,6 +113,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     if high_threshold_exceeded?
       self.application_type = 'none'
       self.application_outcome = 'none'
+      self.dependents = nil
     else
       self.application_type = nil
       self.application_outcome = nil

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -77,7 +77,7 @@
       .small-12.columns
         .row.collapse.medium-10.large-8
           #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
-            h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
+            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}").html_safe
   -when 'income'
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.income')

--- a/lib/income_calculator.rb
+++ b/lib/income_calculator.rb
@@ -1,7 +1,7 @@
 module IncomeCalculator
 
   def can_calculate?
-    [children, fee, !married.nil?, income].all?
+    [children, fee, !married.nil?, income, !dependents.nil?].all?
   end
 
   def calculate

--- a/spec/controllers/applications/build_controller_spec.rb
+++ b/spec/controllers/applications/build_controller_spec.rb
@@ -145,7 +145,10 @@ RSpec.describe Applications::BuildController, type: :controller do
       end
 
       context 'summary' do
-        before { get :show, application_id: application.id, id: :summary }
+        before do
+          application.update(application_type: 'none')
+          get :show, application_id: application.id, id: :summary
+        end
 
         it 'displays the summary view' do
           expect(response).to render_template :summary

--- a/spec/controllers/users_controller/admin_user_spec.rb
+++ b/spec/controllers/users_controller/admin_user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/shared_examples/default_user_shared'
 
 RSpec.describe UsersController, type: :controller do
   render_views

--- a/spec/controllers/users_controller/manager_user_spec.rb
+++ b/spec/controllers/users_controller/manager_user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/shared_examples/default_user_shared'
 
 RSpec.describe UsersController, type: :controller do
   render_views

--- a/spec/controllers/users_controller/standard_user_spec.rb
+++ b/spec/controllers/users_controller/standard_user_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'support/shared_examples/default_user_shared'
 
 RSpec.describe UsersController, type: :controller do
   render_views

--- a/spec/features/applications/application_form_application_details_spec.rb
+++ b/spec/features/applications/application_form_application_details_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+RSpec.feature 'Completing the application details page of an application form', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions)      { create_list :jurisdiction, 3 }
+  let!(:office)             { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)               { create(:user, jurisdiction_id: nil, office: office) }
+  let!(:user_jurisdiction)  { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+  let(:persona)             { single_under_61 }
+
+  before do
+    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
+    json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
+                  "confirmation_ref": "T1426267181940",
+                  "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
+    stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+      to_return(status: 200, body: json, headers: {})
+    Capybara.current_driver = :webkit
+  end
+
+  after { Capybara.use_default_driver }
+
+  context 'as a signed in user with default jurisdiction', js: true do
+    before do
+      login_as user_jurisdiction
+      visit applications_new_path
+      complete_page_as 'personal_information', persona, true
+    end
+
+    it 'renders the page' do
+      expect(page).to have_xpath('//h2', text: 'Application details')
+    end
+
+    context 'submitting the form empty' do
+      before { click_button 'Next' }
+
+      scenario 'renders error' do
+        expect(page).to have_xpath('//label[@class="error"]', count: '2')
+      end
+    end
+
+    context 'before expanding optional fields' do
+      it 'are hidden' do
+        expect(page).to_not have_xpath('//input[@id="application_deceased_name"]')
+        expect(page).to_not have_xpath('//input[@id="application_date_fee_paid"]')
+      end
+
+      context 'expanding probate' do
+        before { check 'application_probate' }
+
+        it 'shows the probate section' do
+          expect(page).to have_xpath('//input[@id="application_deceased_name"]')
+        end
+
+        context 'submitting empty' do
+          before { click_button 'Next' }
+
+          scenario 'renders errors' do
+            expect(page).to have_xpath('//label[@class="error"]', count: '4')
+          end
+        end
+      end
+
+      context 'expanding refund' do
+        before { check 'application_refund' }
+
+        it 'shows the refund section' do
+          expect(page).to have_xpath('//input[@id="application_date_fee_paid"]')
+        end
+
+        context 'submitting empty' do
+          before { click_button 'Next' }
+
+          scenario 'renders errors' do
+            expect(page).to have_xpath('//label[@class="error"]', count: '3')
+          end
+        end
+      end
+    end
+
+    context 'completing the mandatory fields' do
+      before { complete_page_as 'application_details', persona, true }
+
+      context 'and submitting the form' do
+        scenario 'renders the next page' do
+          expect(page).to have_xpath('//h2', text: 'Savings and investments')
+        end
+      end
+    end
+  end
+
+  context 'as a signed in user without default jurisdiction ', js: true do
+    before do
+      login_as user
+      visit applications_new_path
+      complete_page_as 'personal_information', persona, true
+    end
+
+    it 'renders the page' do
+      expect(page).to have_xpath('//h2', text: 'Application details')
+    end
+
+    context 'submitting the form empty' do
+      before { click_button 'Next' }
+
+      scenario 'renders error' do
+        expect(page).to have_xpath('//label[@class="error"]', count: '3')
+      end
+    end
+  end
+end

--- a/spec/features/applications/application_form_personal_details_spec.rb
+++ b/spec/features/applications/application_form_personal_details_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.feature 'Starting an application form', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions) { create_list :jurisdiction, 3 }
+  let!(:office)        { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)          { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+
+  before do
+    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
+    Capybara.current_driver = :webkit
+  end
+
+  after { Capybara.use_default_driver }
+
+  context 'as a signed in user', js: true do
+    before do
+      login_as user
+      visit applications_new_path
+    end
+
+    it 'renders the page' do
+      expect(page).to have_xpath('//h2', text: 'Personal details')
+    end
+
+    context 'submitting the form empty' do
+      before { click_button 'Next' }
+
+      scenario 'renders 3 errors' do
+        expect(page).to have_xpath('//label[@class="error"]', count: '3')
+      end
+    end
+
+    Personae.all_personae.each do |persona|
+      context "completing the fields as #{persona.persona_name}" do
+        before { complete_page_as 'personal_information', persona, false }
+
+        context 'and submitting the form' do
+          before { click_button 'Next' }
+          scenario 'renders the next page' do
+            expect(page).to have_xpath('//h2', text: 'Application details')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/applications/application_form_stories_spec.rb
+++ b/spec/features/applications/application_form_stories_spec.rb
@@ -1,0 +1,322 @@
+require 'rails_helper'
+
+RSpec.feature 'Completing the application details', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions)      { create_list :jurisdiction, 3 }
+  let!(:office)             { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)  { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+
+  before do
+    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
+    Capybara.current_driver = :webkit
+  end
+
+  after { Capybara.use_default_driver }
+
+  context 'as a signed in user with default jurisdiction', js: true do
+    before { login_as user }
+
+    context 'the applicant is single and under 61' do
+      context 'after completing the personal details page' do
+        before do
+          visit applications_new_path
+
+          fill_in 'application_last_name', with: 'Smith'
+          fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
+          fill_in 'application_ni_number', with: 'AB123456A'
+          choose 'application_married_false'
+          click_button 'Next'
+        end
+
+        scenario 'application details is shown' do
+          expect(page).to have_xpath('//h2', text: 'Application details')
+        end
+
+        context 'when the dwp says the applicant is not on benefits' do
+          before do
+            json = '{"original_client_ref": "unique", "benefit_checker_status": "No",
+             "confirmation_ref": "T1426267181940",
+             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
+            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+              to_return(status: 200, body: json, headers: {})
+          end
+          context 'after completing the application_details page' do
+            before do
+              find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+              fill_in 'application_fee', with: 300
+              fill_in 'application_date_received', with: Time.zone.yesterday
+              click_button 'Next'
+            end
+
+            scenario 'savings and investments is shown' do
+              expect(page).to have_xpath('//h2', text: 'Savings and investments')
+            end
+
+            context 'when the applicant exceeds the savings threshold' do
+              before do
+                choose 'application_threshold_exceeded_true'
+                click_button 'Next'
+              end
+
+              scenario 'the summary page is shown with correct display' do
+                expect(page).to have_xpath('//h2', text: 'Check details')
+                expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Savings and investments')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Benefits')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Income')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Number of children')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Total monthly income')
+                expect(page).to have_xpath('//div[contains(@class,"summary-result success")]', text: '✓ Passed', count: 0)
+                expect(page).to have_xpath('//div[contains(@class,"summary-result partial")]', text: '✓ Passed', count: 0)
+                expect(page).to have_xpath('//div[contains(@class,"summary-result fail")]', text: '✗ Failed', count: 1)
+                expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "no")]/h3[@class="bold"]', text: '✗ The applicant must pay the full fee')
+              end
+            end
+
+            context 'when the applicant passes the savings threshold' do
+              before do
+                choose 'application_threshold_exceeded_false'
+                click_button 'Next'
+              end
+
+              scenario 'benefits is shown' do
+                expect(page).to have_xpath('//h2', text: 'Benefits')
+              end
+
+              context 'when the applicant says they are on benefits' do
+                before do
+                  choose 'application_benefits_true'
+                  click_button 'Next'
+                end
+
+                scenario 'benefit results is shown with fail message' do
+                  expect(page).to have_xpath('//h2', text: 'Benefits')
+                  expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "no")]/h3[@class="bold"]', text: '✗ The applicant is not receiving benefits')
+                end
+
+                context 'when benefits confirmed' do
+                  before { click_button 'Next' }
+
+                  scenario 'the summary page is shown with correct display' do
+                    expect(page).to have_xpath('//h2', text: 'Check details')
+                    expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Savings and investments')
+                    expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Benefits')
+                    expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Income')
+                    expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Number of children')
+                    expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Total monthly income')
+                    expect(page).to have_xpath('//div[contains(@class,"summary-result success")]', text: '✓ Passed', count: 1)
+                    expect(page).to have_xpath('//div[contains(@class,"summary-result partial")]', text: '✓ Passed', count: 0)
+                    expect(page).to have_xpath('//div[contains(@class,"summary-result fail")]', text: '✗ Failed', count: 1)
+                    expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "no")]/h3[@class="bold"]', text: '✗ The applicant must pay the full fee')
+                  end
+                end
+              end
+
+              context 'when the applicant says they are not on benefits' do
+                before do
+                  choose 'application_benefits_false'
+                  click_button 'Next'
+                end
+
+                scenario 'income is shown' do
+                  expect(page).to have_xpath('//h2', text: 'Income')
+                end
+
+                context 'when the applicant has children' do
+                  before do
+                    choose 'application_dependents_true'
+                  end
+
+                  scenario 'shows children and income inputs' do
+                    expect(page).to have_xpath('//input[@id="application_income"]')
+                    expect(page).to have_xpath('//input[@id="application_children"]')
+                  end
+
+                  context 'after completing income page' do
+                    before do
+                      fill_in 'application_children', with: 2
+                      fill_in 'application_income', with: 1750
+                      click_button 'Next'
+                    end
+
+                    scenario 'income result is shown with partial message' do
+                      expect(page).to have_xpath('//h2', text: 'Income')
+                      expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-part")]/h3[@class="bold"]', text: 'The applicant must pay £85 towards the fee')
+                    end
+
+                    context 'after confirming income result' do
+                      before { click_button 'Next' }
+
+                      scenario 'the summary page is shown with correct display' do
+                        expect(page).to have_xpath('//h2', text: 'Check details')
+                        expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Savings and investments')
+                        expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Benefits')
+                        expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Income')
+                        expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Number of children')
+                        expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Total monthly income')
+                        expect(page).to have_xpath('//div[contains(@class,"summary-result success")]', text: '✓ Passed', count: 1)
+                        expect(page).to have_xpath('//div[contains(@class,"summary-result partial")]', text: '✓ Passed', count: 1)
+                        expect(page).to have_xpath('//div[contains(@class,"summary-result fail")]', text: '✗ Failed', count: 0)
+                        expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-part")]/h3[@class="bold"]', text: 'The applicant must pay £85 towards the fee')
+                      end
+
+                      context 'when the user returns to the savings threshold' do
+                        before { click_link 'Change savings and investments' }
+
+                        scenario 'savings and investments is shown' do
+                          expect(page).to have_xpath('//h2', text: 'Savings and investments')
+                        end
+
+                        context 'and changes the threshold to exceeded' do
+                          before do
+                            choose 'application_threshold_exceeded_true'
+                            click_button 'Next'
+                          end
+
+                          scenario 'the summary page is shown with correct display' do
+                            expect(page).to have_xpath('//h2', text: 'Check details')
+                            expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Savings and investments')
+                            expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Benefits')
+                            expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Income')
+                            expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Number of children')
+                            expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Total monthly income')
+                            expect(page).to have_xpath('//div[contains(@class,"summary-result success")]', text: '✓ Passed', count: 0)
+                            expect(page).to have_xpath('//div[contains(@class,"summary-result partial")]', text: '✓ Passed', count: 0)
+                            expect(page).to have_xpath('//div[contains(@class,"summary-result fail")]', text: '✗ Failed', count: 1)
+                            expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "no")]/h3[@class="bold"]', text: '✗ The applicant must pay the full fee')
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+
+                context 'when the applicant does not have children' do
+                  before do
+                    choose 'application_dependents_false'
+                  end
+
+                  scenario 'shows income input' do
+                    expect(page).to have_xpath('//input[@id="application_income"]')
+                  end
+                end
+              end
+            end
+          end
+        end
+
+        context 'when the dwp says the applicant is on benefits' do
+          before do
+            json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
+             "confirmation_ref": "T1426267181940",
+             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
+            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+              to_return(status: 200, body: json, headers: {})
+          end
+          context 'after completing the application_details page' do
+            before do
+              find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+              fill_in 'application_fee', with: 300
+              fill_in 'application_date_received', with: Time.zone.yesterday
+              click_button 'Next'
+            end
+
+            scenario 'savings and investments is shown' do
+              expect(page).to have_xpath('//h2', text: 'Savings and investments')
+            end
+
+            context 'when the applicant exceeds the savings threshold' do
+              before do
+                choose 'application_threshold_exceeded_true'
+                click_button 'Next'
+              end
+
+              scenario 'the summary page is shown with correct display' do
+                expect(page).to have_xpath('//h2', text: 'Check details')
+                expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Savings and investments')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Benefits')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Income')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Number of children')
+                expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Total monthly income')
+                expect(page).to have_xpath('//div[contains(@class,"summary-result success")]', text: '✓ Passed', count: 0)
+                expect(page).to have_xpath('//div[contains(@class,"summary-result partial")]', text: '✓ Passed', count: 0)
+                expect(page).to have_xpath('//div[contains(@class,"summary-result fail")]', text: '✗ Failed', count: 1)
+                expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "no")]/h3[@class="bold"]', text: '✗ The applicant must pay the full fee')
+              end
+            end
+
+            context 'when the applicant passes the savings threshold' do
+              before do
+                choose 'application_threshold_exceeded_false'
+                click_button 'Next'
+              end
+
+              scenario 'benefits is shown' do
+                expect(page).to have_xpath('//h2', text: 'Benefits')
+              end
+
+              context 'when the applicant says they are on benefits' do
+                before do
+                  choose 'application_benefits_true'
+                  click_button 'Next'
+                end
+
+                scenario 'benefit results is shown with pass message' do
+                  expect(page).to have_xpath('//h2', text: 'Benefits')
+                  expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "yes")]/h3[@class="bold"]', text: '✓ The applicant is receiving the correct benefits')
+                end
+
+                context 'when benefits confirmed' do
+                  before { click_button 'Next' }
+
+                  scenario 'the summary page is shown with correct display' do
+                    expect(page).to have_xpath('//h2', text: 'Check details')
+                    expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Savings and investments')
+                    expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Benefits')
+                    expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Income')
+                    expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Number of children')
+                    expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Total monthly income')
+                    expect(page).to have_xpath('//div[contains(@class,"summary-result success")]', text: '✓ Passed', count: 2)
+                    expect(page).to have_xpath('//div[contains(@class,"summary-result partial")]', text: '✓ Passed', count: 0)
+                    expect(page).to have_xpath('//div[contains(@class,"summary-result fail")]', text: '✗ Failed', count: 0)
+                    expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "yes")]/h3[@class="bold"]', text: '✓ The applicant doesn’t have to pay the fee')
+                  end
+
+                  context 'when the user returns to the savings threshold' do
+                    before { click_link 'Change savings and investments' }
+
+                    scenario 'savings and investments is shown' do
+                      expect(page).to have_xpath('//h2', text: 'Savings and investments')
+                    end
+
+                    context 'and changes the threshold to exceeded' do
+                      before do
+                        choose 'application_threshold_exceeded_true'
+                        click_button 'Next'
+                      end
+
+                      scenario 'the summary page is shown with correct display' do
+                        expect(page).to have_xpath('//h2', text: 'Check details')
+                        expect(page).to have_xpath('//div[contains(@class,"subheader")]', text: 'Savings and investments')
+                        expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Benefits')
+                        expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Income')
+                        expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Number of children')
+                        expect(page).to_not have_xpath('//div[contains(@class,"subheader")]', text: 'Total monthly income')
+                        expect(page).to have_xpath('//div[contains(@class,"summary-result success")]', text: '✓ Passed', count: 0)
+                        expect(page).to have_xpath('//div[contains(@class,"summary-result partial")]', text: '✓ Passed', count: 0)
+                        expect(page).to have_xpath('//div[contains(@class,"summary-result fail")]', text: '✗ Failed', count: 1)
+                        expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "no")]/h3[@class="bold"]', text: '✗ The applicant must pay the full fee')
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Application, type: :model do
     context 'can_calculate?' do
       context 'when required fields are complete' do
         before do
+          application.dependents = true
           application.fee = 300
           application.married = true
           application.income = 1000
@@ -64,6 +65,7 @@ RSpec.describe Application, type: :model do
   describe 'auto running calculator' do
     context 'without required fields' do
       before do
+        application.dependents = true
         application.fee = nil
         application.married = true
         application.income = 1000
@@ -81,6 +83,7 @@ RSpec.describe Application, type: :model do
 
     context 'with required fields' do
       before do
+        application.dependents = true
         application.fee = 300
         application.married = true
         application.income = 1000

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ require 'webmock/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
@@ -70,7 +70,7 @@ RSpec.configure do |config|
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = true
+  config.use_transactional_fixtures = false
 
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
@@ -86,4 +86,27 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+
+  config.include ApplicationFormMacros, type: :feature
+  config.include Personae, type: :feature
+
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, :js => true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/support/application_form_macros.rb
+++ b/spec/support/application_form_macros.rb
@@ -1,0 +1,31 @@
+module ApplicationFormMacros
+  include Warden::Test::Helpers
+
+  def complete_page_as(page, persona, submit)
+    send("complete_#{page}", persona)
+
+    submit ||= false
+    click_button 'Next' if submit
+  end
+
+  private
+
+  def complete_personal_information(persona)
+    fill_in 'application_last_name', with: persona.last_name
+    fill_in 'application_date_of_birth', with: persona.date_of_birth
+    fill_in 'application_ni_number', with: persona.ni_number if persona.ni_number.present?
+    if persona.married
+      choose 'application_married_true'
+    else
+      choose 'application_married_false'
+    end
+  end
+
+  def complete_application_details(persona)
+    fill_in 'application_fee', with: 300
+    find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+    fill_in 'application_date_received', with: Time.zone.yesterday
+    fill_in 'application_form_name', with: persona.form_name if persona.form_name.present?
+    fill_in 'application_case_number', with: persona.case_number if persona.case_number.present?
+  end
+end

--- a/spec/support/personae.rb
+++ b/spec/support/personae.rb
@@ -1,0 +1,88 @@
+module Personae
+  class Persona < OpenStruct
+  end
+
+  def married_under_61
+    data = personal_details(1, married: true, over_61: false)
+    Persona.new(data)
+  end
+
+  def single_under_61
+    data = personal_details(
+      1,
+      last_name: 'Smith',
+      married: false,
+      over_61: false,
+      ni_number: 'AB123456A',
+      savings_exceeded: true
+    )
+    Persona.new(data)
+  end
+
+  def single_under_61_complete
+    data = personal_details(1, married: false, over_61: false)
+    Persona.new(data)
+  end
+
+  module_function
+
+  def all_personae
+    result = []
+    opts = {}
+    opts[:married] = [true, false]
+    opts[:over_61] = [true, false]
+    opts[:ni_number] = ['', 'AB123456A']
+    opts[:threshold_exceeded] = [true, false]
+
+    product_hash(opts).each_with_index do |outcome, index|
+      result << Persona.new(personal_details(index, outcome))
+    end
+    result
+  end
+
+  def product_hash(hsh)
+    attrs   = hsh.values
+    keys    = hsh.keys
+    product = attrs[0].product(*attrs[1..-1])
+    product.map { |p| Hash[keys.zip p] }
+  end
+
+  def personal_details(id, options = {})
+    now = Time.zone.now
+    {
+      id: id + 1,
+      persona_name: persona_name(options),
+      created_at: now,
+      title: 'Mr',
+      first_names: 'Placeholder',
+      ni_number: options[:ni_number],
+      last_name: 'Hirani',
+      married: options[:married],
+      threshold_exceeded: options[:threshold_exceeded],
+      date_of_birth: generate_dob(options[:over_61]),
+      over_61: options[:over_61],
+      date_received: now - 1.day,
+      our_api_token: "@#{now.strftime('%y%m%d%H%M%S')}.1"
+    }
+  end
+
+  def persona_name(options = {})
+    options.delete(:id)
+    matches = options.delete_if { |_k, v| v.to_s.nil? || v.to_s == 'false' }
+    result = matches.map do |k, v|
+      case v.to_s
+      when 'true'
+        "#{k}"
+      when v.to_s.empty?
+        "#{k} is empty"
+      else
+        "#{k} is #{v}"
+      end
+    end
+    result.to_sentence(last_word_connector: ' and ')
+  end
+
+  def generate_dob(over_61)
+    Time.zone.now - (over_61 == true ? 65 : 20).years
+  end
+end


### PR DESCRIPTION
To allow testing of on-page javascript as well as end-to-end testing of the application form
* Added database-cleaner and configured rails_helper to:-
  * remove transactional_fixtures
  * clean the database
  * auto-load support files
* Removed explicit loading of support files from previous tests
* Created persona files for future use and standard tests
* Created tests for the personal and application details pages in isolation
* Created end-to-end tests for some of the available paths through the form.
* added fixes for issues picked up by the e-to-e tests