### PR TITLE
Fix xss on office model

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,8 @@ class UsersController < ApplicationController
   before_action :populate_jurisdictions, only: [:edit, :update]
   load_and_authorize_resource
 
+  include FlashMessageHelper
+
   def index
     if current_user.admin?
       @users = User.sorted_by_email
@@ -61,7 +63,7 @@ class UsersController < ApplicationController
     t('error_messages.user.moved_offices',
       user: @user.name,
       office: office.name,
-      contact: office.managers_email)
+      contact: format_managers_contacts(office.managers))
   end
 
   def find_user

--- a/app/helpers/flash_message_helper.rb
+++ b/app/helpers/flash_message_helper.rb
@@ -1,0 +1,11 @@
+module FlashMessageHelper
+  def format_managers_contacts(managers)
+    if managers.empty?
+      'a manager'
+    else
+      managers.map do |m|
+        "<a href=\"mailto:#{m.email}\">#{m.name}</a>"
+      end.join(', ')
+    end
+  end
+end

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -12,13 +12,4 @@ class Office < ActiveRecord::Base
   def managers
     users.where(office_id: id, role: 'manager')
   end
-
-  def managers_email
-    return 'a manager' unless managers.present?
-    emails = []
-    managers.each do |m|
-      emails << "<a href=\"mailto:#{m.email}\">#{m.name}</a>".html_safe
-    end
-    emails.join(', ')
-  end
 end

--- a/spec/controllers/users_controller/manager_user_spec.rb
+++ b/spec/controllers/users_controller/manager_user_spec.rb
@@ -195,9 +195,7 @@ RSpec.describe UsersController, type: :controller do
           end
 
           it 'displays an alert containing contact details for the new manager' do
-            err_msg = I18n.t('error_messages.user.moved_offices', user: user_on_my_team.name, office: new_office.name, contact: new_office.managers_email)
             expect(flash[:notice]).to be_present
-            expect(flash[:notice]).to eql(err_msg)
           end
         end
       end

--- a/spec/features/manager_transfers_user_spec.rb
+++ b/spec/features/manager_transfers_user_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Manager transfers user', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  context 'Manager' do
+    let(:manager) { create :manager, office: office }
+
+    let(:office) { create :office}
+    let(:manager) { create :manager, office: office }
+    let(:user) { create :user, office: office }
+
+    let!(:another_office) { create :office}
+    let!(:another_manager) { create :manager, office: another_office }
+
+    scenario 'transfers user from his office to another' do
+      login_as(manager)
+      visit edit_user_path(user.id)
+
+      select(another_office.name, from: 'user_office_id')
+      click_button 'Save changes'
+
+      alert = page.find('.alert-box')
+      expect(alert).to have_content("#{user.name} moved to #{another_office.name}")
+      expect(alert).to have_link(another_manager.name, href: "mailto:#{another_manager.email}")
+    end
+  end
+end

--- a/spec/features/manager_transfers_user_spec.rb
+++ b/spec/features/manager_transfers_user_spec.rb
@@ -8,11 +8,11 @@ RSpec.feature 'Manager transfers user', type: :feature do
   context 'Manager' do
     let(:manager) { create :manager, office: office }
 
-    let(:office) { create :office}
+    let(:office) { create :office }
     let(:manager) { create :manager, office: office }
     let(:user) { create :user, office: office }
 
-    let!(:another_office) { create :office}
+    let!(:another_office) { create :office }
     let!(:another_manager) { create :manager, office: another_office }
 
     scenario 'transfers user from his office to another' do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -72,29 +72,4 @@ RSpec.describe Office, type: :model do
       expect(office.managers.count).to eql 1
     end
   end
-
-  describe 'managers_email' do
-    let(:office)      { FactoryGirl.create :office }
-
-    context 'managers are empty' do
-      before(:each) { User.delete_all }
-
-      it 'returns a text prompt' do
-        FactoryGirl.create_list :user, 3, office: office
-        expect(office.managers_email).to eql('a manager')
-      end
-    end
-
-    context 'managers are populated' do
-      before(:each) { User.delete_all }
-      let(:manager1) { FactoryGirl.create :manager, office: office }
-      let(:manager2) { FactoryGirl.create :manager, office: office }
-
-      it 'returns an html string of emails of users in the manager role' do
-        [manager1, manager2].each do |manager|
-          expect(office.managers_email).to include "<a href=\"mailto:#{manager.email}\">#{manager.name}</a>"
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
This removes the `html_safe` call from `Office` model and moves that particular presentation logic to a helper. 