### PR TITLE
Copy change on confirmation page

### DIFF
--- a/app/views/applications/build/confirmation.html.slim
+++ b/app/views/applications/build/confirmation.html.slim
@@ -18,8 +18,9 @@ h2 Application processed
       ul
         -if @application.application_outcome == 'full'
           li Complete the remission register with the application details
-          li Write the reference number form the remission register on the top right corner of the paper form
-          li Write to the applicant and send back all the documents
+          li Write the reference number on the top right corner of the paper form
+          li Copy the reference number into the case management system
+          li The applicant’s process can now be issued
         -elsif @application.application_outcome == 'part'
           li Write to the applicant with details of how much they have to pay
           li Complete the remission register with the application details

--- a/spec/features/applications/remission_confirmation_spec.rb
+++ b/spec/features/applications/remission_confirmation_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.feature 'Confirmation page for remission', type: :feature do
@@ -57,8 +58,9 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
       let(:application) { create(:application_full_remission) }
       let(:full_remission_copy) do
         ['Complete the remission register with the application details',
-         'Write the reference number form the remission register on the top right corner of the paper form',
-         'Write to the applicant and send back all the documents']
+         'Write the reference number on the top right corner of the paper form',
+         'Copy the reference number into the case management system',
+         'The applicant’s process can now be issued']
       end
 
       context 'after user continues to confirmation page' do


### PR DESCRIPTION
Changed the copy for full remissionon on the confirmation page.
Why? Got told to do it and the content person writes the copy.

Also :bug: [102568132](https://www.pivotaltracker.com/story/show/102568132).