### PR TITLE
Redirect non-signed in users to login page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,5 @@
 class HomeController < ApplicationController
+  before_action :authenticate_user!, only: [:index]
   before_action :load_dwp_data, only: [:index], if: 'user_signed_in? && current_user.manager?'
   before_action :load_graph_data, only: [:index], if: 'user_signed_in? && current_user.admin?'
 

--- a/app/views/home/_manager.html.slim
+++ b/app/views/home/_manager.html.slim
@@ -1,16 +1,17 @@
 .row
   .small-12.medium-8.large-5.columns
-    div.pad-top-thirty-px
-    p =link_to 'Staff overview', users_path
-    p =link_to 'Your Office', current_user.office
-    
-    h3 Process an application for help with fees 
+    h3.pad-top-thirty-px.bold Process application 
     p You'll need:
     ul 
       li the help with fees application form (EX160)
       li the court or tribunal form related to the application
     .actions
       =link_to 'Start now', new_application_path, class: 'button success'
+
+    h3.pad-top-thirty-px.bold Manage your office 
+    p =link_to 'Staff overview', users_path
+    p =link_to 'Your Office', current_user.office
+     
   
   .small-12.medium-8.large-5.columns
     .info-box

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -8,7 +8,7 @@
     =render 'home/manager'
   -else
     .small-12.medium-8.large-5.columns
-      div.pad-top-thirty-px
+      h2.pad-top-thirty-px.bold Process application
       p You'll need:
       ul 
         li the help with fees application form (EX160) 

--- a/app/views/layouts/_welcome_banner.html.slim
+++ b/app/views/layouts/_welcome_banner.html.slim
@@ -1,4 +1,5 @@
 - if current_user
   .row
     .small-12.medium-12.large-12.columns#welcome_banner
-      h1 Process applications for help with fees
+      h1 Help with fees
+      p Use this service to process the <strong>'Apply for help with fees'</strong> EX160 applications

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -72,12 +72,8 @@ RSpec.describe HomeController, type: :controller do
         get :index
       end
 
-      it 'returns http success' do
-        expect(response).to have_http_status(:success)
-      end
-
-      it 'renders the index view' do
-        expect(response).to render_template :index
+      it 'redirects to sign in page' do
+        expect(response).to redirect_to(:new_user_session)
       end
     end
   end

--- a/spec/features/applications/application_form_stories_spec.rb
+++ b/spec/features/applications/application_form_stories_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.feature 'Completing the application details', type: :feature do
@@ -324,7 +325,7 @@ RSpec.feature 'Completing the application details', type: :feature do
                       before { click_button 'Back to start' }
 
                       scenario 'the home page is shown' do
-                        expect(page).to have_text 'Process applications for help with fees'
+                        expect(page).to have_text 'Process application'
                       end
                     end
                   end

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "home/index.html.slim", type: :view do
     end
 
     it 'displays title' do
-      expect(rendered).to have_text 'Process applications for help with fees'
+      expect(rendered).to have_text 'Process application'
     end
 
     it 'shows the start button' do


### PR DESCRIPTION
When the user is not signed in & visits the home page they should be
redirected to log in. 

Why? Because this is how Kellie designed it to work.