### PR TITLE
Prevent the users from access '/dwp_check'

### DIFF
--- a/app/controllers/dwp_checks_controller.rb
+++ b/app/controllers/dwp_checks_controller.rb
@@ -1,5 +1,6 @@
 class DwpChecksController < ApplicationController
   before_action :authenticate_user!
+  before_action :redirect_to_home_page
   respond_to :html
   before_action :find_dwp_check, only: [:show]
   before_action :new_from_params, only: [:lookup]
@@ -40,5 +41,9 @@ class DwpChecksController < ApplicationController
 
   def find_dwp_check
     @dwp_checker = DwpCheck.find_by!(unique_number: params[:unique_number])
+  end
+
+  def redirect_to_home_page
+    redirect_to root_path
   end
 end

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -29,27 +29,41 @@ RSpec.describe DwpChecksController, type: :controller do
     before(:each) { sign_in user }
 
     describe 'GET #show' do
-      it 'assign the requested dwp_check as @dwp_check' do
+      let(:dwp_check) do
+        create(:dwp_check, created_by: user)
+      end
+
+      xit 'assign the requested dwp_check as @dwp_check' do
         dwp_check = create(:dwp_check, created_by: user)
         get :show, unique_number: dwp_check.unique_number
         expect(assigns(:dwp_checker)).to eq(dwp_check)
         expect(response).to render_template('dwp_checks/show')
       end
 
+      it 'redirects to home page' do
+        get :show, unique_number: dwp_check.unique_number
+        expect(response).to redirect_to root_path
+      end
+
       context 'when invalid request is made' do
         let(:invalid_number) { "'" }
 
-        it 'throws an error when invalid request is made' do
+        xit 'throws an error when invalid request is made' do
           expect { get :show, unique_number: invalid_number }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end
 
     describe 'GET #new' do
-      it 'render the expected view' do
+      xit 'render the expected view' do
         get :new, {}
         expect(response.status).to eql(200)
         expect(response).to render_template('dwp_checks/new')
+      end
+
+      it 'redirects to home page' do
+        get :new, {}
+        expect(response).to redirect_to root_path
       end
     end
 
@@ -67,14 +81,24 @@ RSpec.describe DwpChecksController, type: :controller do
             to_return(status: 200, body: json, headers: {})
         end
 
-        it "doesn't accepts d/m/yy date format" do
+        xit "doesn't accepts d/m/yy date format" do
           post :lookup, dwp_check: attributes_for(:dwp_check, dob: '1/1/80')
           expect(response).to render_template('dwp_checks/new')
         end
 
-        it 'accepts dd mmmm yyyy' do
+        it 'redirects to home page' do
+          post :lookup, dwp_check: attributes_for(:dwp_check, dob: '1/1/80')
+          expect(response).to redirect_to root_path
+        end
+
+        xit 'accepts dd mmmm yyyy' do
           post :lookup, dwp_check: attributes_for(:dwp_check, dob: '01 January 1980')
           expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
+        end
+
+        it 'redirects to home page' do
+          post :lookup, dwp_check: attributes_for(:dwp_check, dob: '01 January 1980')
+          expect(response).to redirect_to root_path
         end
       end
 
@@ -93,11 +117,11 @@ RSpec.describe DwpChecksController, type: :controller do
           expect(response.status).to eql(302)
         end
 
-        it 'redirects to the result page' do
+        xit 'redirects to the result page' do
           expect(response).to redirect_to dwp_checks_path(DwpCheck.last.unique_number)
         end
 
-        context 'when service encounters an error' do
+        pending 'when service encounters an error' do
 
           before(:each) do
             stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
@@ -120,9 +144,14 @@ RSpec.describe DwpChecksController, type: :controller do
       end
 
       context 'invalid request' do
-        it 're-renders the form' do
+        xit 're-renders the form' do
           post :lookup, dwp_check: attributes_for(:invalid_dwp_check)
           expect(response).to render_template(:new)
+        end
+
+        it 'redirects to home page' do
+          post :lookup, dwp_check: attributes_for(:invalid_dwp_check)
+          expect(response).to redirect_to root_path
         end
       end
     end
@@ -133,19 +162,31 @@ RSpec.describe DwpChecksController, type: :controller do
     before(:each) { sign_in admin_user }
 
     describe 'GET #show' do
-      it 'assign the requested dwp_check as @dwp_check' do
+      let(:dwp_check) { create(:dwp_check, created_by: user) }
+
+      xit 'assign the requested dwp_check as @dwp_check' do
         dwp_check = create(:dwp_check, created_by: user)
         get :show, unique_number: dwp_check.unique_number
         expect(assigns(:dwp_checker)).to eq(dwp_check)
         expect(response).to render_template('dwp_checks/show')
       end
+
+      it 'redirects to home page' do
+        get :show, unique_number: dwp_check.unique_number
+        expect(response).to redirect_to root_path
+      end
     end
 
     describe 'GET #new' do
-      it 'render the expected view' do
+      xit 'render the expected view' do
         get :new, {}
         expect(response.status).to eql(200)
         expect(response).to render_template('dwp_checks/new')
+      end
+
+      it 'redirects to home page' do
+        get :new, {}
+        expect(response).to redirect_to root_path
       end
     end
   end

--- a/spec/features/perform_benefit_check_spec.rb
+++ b/spec/features/perform_benefit_check_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Undertake benefit check', type: :feature do
           to_return(status: 200, body: json, headers: {})
       end
 
-      scenario 'generates a result page' do
+      pending 'generates a result page' do
 
         login_as user
         visit new_dwp_checks_path
@@ -33,7 +33,7 @@ RSpec.feature 'Undertake benefit check', type: :feature do
       end
     end
     context 'with invalid data' do
-      scenario 'returns to input page' do
+      pending 'returns to input page' do
         login_as user
         visit new_dwp_checks_path
 


### PR DESCRIPTION
The users should not be able to access '/dwp_check'.

I've left the examples by commenting them out: /it/(xit|pending)/,
because there will be a ticket in the backlog to deal with this
properly. This is just a band aid fix until tomorrow.