### PR TITLE
Using 'rake db:schema:load' for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
     repo_token: 9d2abe9e2bdfe62892cf37ae25ff3e825b07dad9401025adcb6f387ac82a35a8
 script:
 - bundle exec rake rubocop
-- bundle exec rake db:create
-- bundle exec rake db:migrate
+- bundle exec rake db:create db:schema:load
 - DISPLAY=localhost:1.0 xvfb-run bundle exec rake spec
 - bundle exec rake teaspoon


### PR DESCRIPTION
Since Rails 4.1 this line in rails_helper:

    ActiveRecord::Migration.maintain_test_schema!

checks if there are any pending migrations and complains if there are.

Otherwise just load the schema.