### PR TITLE
Next 16000

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -101,7 +101,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   def threshold_exceeded=(val)
     super
     self.over_61 = nil unless threshold_exceeded?
-    if threshold_exceeded? && !over_61
+    if threshold_exceeded? && (!over_61 || known_over_61?)
       self.application_type = 'none'
       self.application_outcome = 'none'
       self.dependents = nil

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -52,7 +52,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   with_options if: proc { active_or_status_is? 'savings_investments' } do
     validates :threshold_exceeded, inclusion: { in: [true, false] }
     validates :over_61, inclusion: { in: [true, false] }, if: :threshold_exceeded
-    validates :high_threshold_exceeded, inclusion: { in: [true, false] }, if: :over_61
+    validates :high_threshold_exceeded, inclusion: { in: [true, false] }, if: :check_high_threshold?
   end
   # End step 3 validation
 
@@ -140,6 +140,10 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
 
   def known_over_61?
     applicant_age >= 61
+  end
+
+  def check_high_threshold?
+    over_61? && !known_over_61?
   end
 
   def applicant_age

--- a/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
+++ b/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
@@ -1,0 +1,56 @@
+# coding: utf-8
+require 'rails_helper'
+
+RSpec.feature 'Completing the application details', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions)      { create_list :jurisdiction, 3 }
+  let!(:office)             { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)  { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+
+  before do
+    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
+    Capybara.current_driver = :webkit
+    Capybara.page.driver.allow_url('http://www.google.com/jsapi')
+  end
+
+  after { Capybara.use_default_driver }
+
+  context 'where the applicant is over 61', js: true do
+    before do
+      json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
+             "confirmation_ref": "T1426267181940",
+             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
+      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+        to_return(status: 200, body: json, headers: {})
+
+      login_as user
+      visit applications_new_path
+      fill_in 'application_last_name', with: 'SMITH'
+      fill_in 'application_date_of_birth', with: Time.zone.today - 65.years
+      fill_in 'application_ni_number', with: 'JL953007D'
+      choose 'application_married_false'
+      click_button 'Next'
+      find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+      fill_in 'application_fee', with: 410
+      fill_in 'application_date_received', with: Time.zone.yesterday
+      click_button 'Next'
+      choose 'application_threshold_exceeded_false'
+      click_button 'Next'
+      choose 'application_benefits_false'
+      click_button 'Next'
+      choose 'application_dependents_true'
+      fill_in 'application_children', with: '3'
+      fill_in 'application_income', with: '1900'
+      click_button 'Next'
+      click_button 'Next'
+    end
+
+    scenario 'shows the proper summary page' do
+      expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-part")]/h3[@class="bold"]', text: 'The applicant must pay £40 towards the fee')
+    end
+
+  end
+end

--- a/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
+++ b/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
@@ -51,6 +51,43 @@ RSpec.feature 'Completing the application details', type: :feature do
     scenario 'shows the proper summary page' do
       expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-part")]/h3[@class="bold"]', text: 'The applicant must pay £40 towards the fee')
     end
+  end
 
+  context 'when user returns and selects savings threshold exceeded', js: true do
+    before do
+      json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
+             "confirmation_ref": "T1426267181940",
+             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
+      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+        to_return(status: 200, body: json, headers: {})
+
+      login_as user
+      visit applications_new_path
+      fill_in 'application_last_name', with: 'SMITH'
+      fill_in 'application_date_of_birth', with: Time.zone.today - 65.years
+      fill_in 'application_ni_number', with: 'JL953007D'
+      choose 'application_married_false'
+      click_button 'Next'
+      find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+      fill_in 'application_fee', with: 410
+      fill_in 'application_date_received', with: Time.zone.yesterday
+      click_button 'Next'
+      choose 'application_threshold_exceeded_false'
+      click_button 'Next'
+      choose 'application_benefits_false'
+      click_button 'Next'
+      choose 'application_dependents_true'
+      fill_in 'application_children', with: '3'
+      fill_in 'application_income', with: '1900'
+      click_button 'Next'
+      click_button 'Next'
+      click_link 'Change savings and investments'
+      choose 'application_threshold_exceeded_true'
+      click_button 'Next'
+    end
+
+    scenario 'shows the proper summary page' do
+      expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-none")]/h3[@class="bold"]', text: '✗ The applicant must pay the full fee')
+    end
   end
 end


### PR DESCRIPTION
'Next' button doesn't work on savings and investment page [Ticket](https://www.pivotaltracker.com/story/show/103322556)

---
Fix to allow progression past savings investments when applicant is over 61

