### PR TITLE
DWP stub trim

### DIFF
--- a/spec/features/applications/application_form_application_details_spec.rb
+++ b/spec/features/applications/application_form_application_details_spec.rb
@@ -13,11 +13,7 @@ RSpec.feature 'Completing the application details page of an application form', 
 
   before do
     WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
-    json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-                  "confirmation_ref": "T1426267181940",
-                  "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-    stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-      to_return(status: 200, body: json, headers: {})
+    dwp_api_response 'Yes'
     Capybara.current_driver = :webkit
   end
 

--- a/spec/features/applications/application_form_stories_spec.rb
+++ b/spec/features/applications/application_form_stories_spec.rb
@@ -38,13 +38,8 @@ RSpec.feature 'Completing the application details', type: :feature do
         end
 
         context 'when the dwp says the applicant is not on benefits' do
-          before do
-            json = '{"original_client_ref": "unique", "benefit_checker_status": "No",
-             "confirmation_ref": "T1426267181940",
-             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-              to_return(status: 200, body: json, headers: {})
-          end
+          before { dwp_api_response 'No' }
+
           context 'after completing the application_details page' do
             before do
               find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
@@ -210,13 +205,8 @@ RSpec.feature 'Completing the application details', type: :feature do
         end
 
         context 'when the dwp says the applicant is on benefits' do
-          before do
-            json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-             "confirmation_ref": "T1426267181940",
-             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-              to_return(status: 200, body: json, headers: {})
-          end
+          before { dwp_api_response 'Yes' }
+
           context 'after completing the application_details page' do
             before do
               find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click

--- a/spec/features/applications/application_savings_and_investments_spec.rb
+++ b/spec/features/applications/application_savings_and_investments_spec.rb
@@ -38,13 +38,7 @@ RSpec.feature 'Application for savings and investments bug', type: :feature do
         end
 
         context 'when the dwp says the applicant is not on benefits' do
-          before do
-            json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-             "confirmation_ref": "T1426267181940",
-             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-              to_return(status: 200, body: json, headers: {})
-          end
+          before { dwp_api_response 'Yes' }
 
           context 'after completing the application_details page' do
             before do

--- a/spec/features/applications/benefit_results_are_rendered_spec.rb
+++ b/spec/features/applications/benefit_results_are_rendered_spec.rb
@@ -11,17 +11,7 @@ RSpec.feature 'Benefit Results', type: :feature do
 
     before do
       WebMock.disable_net_connect!(allow: 'codeclimate.com')
-      json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-                  "confirmation_ref": "T1426267181940",
-                  "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
-        {
-          birth_date: application.date_of_birth.strftime('%Y%m%d'),
-          entitlement_check_date: application.date_received.strftime('%Y%m%d'),
-          id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
-          ni_number: application.ni_number,
-          surname: application.last_name.upcase
-        }).to_return(status: 200, body: json, headers: {})
+      dwp_api_response 'Yes'
     end
 
     before do

--- a/spec/features/applications/change_from_r1_to_r2_spec.rb
+++ b/spec/features/applications/change_from_r1_to_r2_spec.rb
@@ -20,11 +20,7 @@ RSpec.feature 'Completing the application details', type: :feature do
 
   context 'complete r2 path as a signed in user with default jurisdiction', js: true do
     before do
-      json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-             "confirmation_ref": "T1426267181940",
-             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-        to_return(status: 200, body: json, headers: {})
+      dwp_api_response 'Yes'
 
       login_as user
       visit applications_new_path

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -12,17 +12,7 @@ RSpec.feature 'Confirmation page', type: :feature do
     before do
       WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
       Capybara.current_driver = :webkit
-      json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-                  "confirmation_ref": "T1426267181940",
-                  "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
-      {
-        birth_date: application.date_of_birth.strftime('%Y%m%d'),
-        entitlement_check_date: application.date_received.strftime('%Y%m%d'),
-        id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
-        ni_number: application.ni_number,
-        surname: application.last_name.upcase
-      }).to_return(status: 200, body: json, headers: {})
+      dwp_api_response 'Yes'
       login_as user
     end
 

--- a/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
+++ b/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
@@ -20,11 +20,7 @@ RSpec.feature 'Completing the application details', type: :feature do
 
   context 'where the applicant is over 61', js: true do
     before do
-      json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-             "confirmation_ref": "T1426267181940",
-             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-        to_return(status: 200, body: json, headers: {})
+      dwp_api_response 'Yes'
 
       login_as user
       visit applications_new_path
@@ -55,11 +51,7 @@ RSpec.feature 'Completing the application details', type: :feature do
 
   context 'when user returns and selects savings threshold exceeded', js: true do
     before do
-      json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-             "confirmation_ref": "T1426267181940",
-             "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-        to_return(status: 200, body: json, headers: {})
+      dwp_api_response 'Yes'
 
       login_as user
       visit applications_new_path

--- a/spec/features/applications/remission_confirmation_spec.rb
+++ b/spec/features/applications/remission_confirmation_spec.rb
@@ -17,17 +17,7 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
     before do
       WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
       Capybara.current_driver = :webkit
-      json = '{"original_client_ref": "unique", "benefit_checker_status": "No",
-                  "confirmation_ref": "T1426267181940",
-                  "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
-      {
-        birth_date: application.date_of_birth.strftime('%Y%m%d'),
-        entitlement_check_date: application.date_received.strftime('%Y%m%d'),
-        id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
-        ni_number: application.ni_number,
-        surname: application.last_name.upcase
-      }).to_return(status: 200, body: json, headers: {})
+      dwp_api_response 'Yes'
       login_as user
     end
 

--- a/spec/features/perform_benefit_check_spec.rb
+++ b/spec/features/perform_benefit_check_spec.rb
@@ -10,13 +10,7 @@ RSpec.feature 'Undertake benefit check', type: :feature do
   context 'as user' do
 
     context 'with valid data' do
-      before do
-        json = '{"original_client_ref": "unique", "benefit_checker_status": "Yes",
-                 "confirmation_ref": "T1426267181940",
-                 "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check"}'
-        stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
-          to_return(status: 200, body: json, headers: {})
-      end
+      before { dwp_api_response 'Yes' }
 
       pending 'generates a result page' do
 

--- a/spec/support/dwp_api_response.rb
+++ b/spec/support/dwp_api_response.rb
@@ -1,5 +1,5 @@
 
-def dwp_response(response)
+def dwp_api_response(response)
   json = { "original_client_ref": "unique",
            "benefit_checker_status": "#{response}",
            "confirmation_ref": "T1426267181940",

--- a/spec/support/dwp_response.rb
+++ b/spec/support/dwp_response.rb
@@ -1,0 +1,9 @@
+
+def dwp_response(response)
+  json = { "original_client_ref": "unique",
+           "benefit_checker_status": "#{response}",
+           "confirmation_ref": "T1426267181940",
+           "@xmlns": "https://lsc.gov.uk/benefitchecker/service/1.0/API_1.0_Check" }.to_json
+  stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").
+    to_return(status: 200, body: json, headers: {})
+end


### PR DESCRIPTION
Trimmed away at a stub request that is used frequently.

There are other instances of this stub being used, but they have more detailed responses configured. It might be an option to look at them and see if they need to be trimmed down.