### PR TITLE
Cleaned up WebMock usage

### DIFF
--- a/spec/controllers/applications/build_controller_spec.rb
+++ b/spec/controllers/applications/build_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Applications::BuildController, type: :controller do
   render_views
 
   include Devise::TestHelpers
-  before { WebMock.disable_net_connect!(allow: 'codeclimate.com') }
 
   let(:user)          { create :user }
 

--- a/spec/controllers/dwp_checks_controller_spec.rb
+++ b/spec/controllers/dwp_checks_controller_spec.rb
@@ -69,8 +69,6 @@ RSpec.describe DwpChecksController, type: :controller do
 
     describe 'POST #lookup' do
 
-      before { WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi']) }
-
       context 'date format' do
 
         before(:each) do

--- a/spec/features/applications/application_form_application_details_spec.rb
+++ b/spec/features/applications/application_form_application_details_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Completing the application details page of an application form', 
   let(:persona)             { single_under_61 }
 
   before do
-    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
     dwp_api_response 'Yes'
     Capybara.current_driver = :webkit
   end

--- a/spec/features/applications/application_form_personal_details_spec.rb
+++ b/spec/features/applications/application_form_personal_details_spec.rb
@@ -9,10 +9,7 @@ RSpec.feature 'Starting an application form', type: :feature do
   let!(:office)        { create(:office, jurisdictions: jurisdictions) }
   let!(:user)          { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
 
-  before do
-    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
-    Capybara.current_driver = :webkit
-  end
+  before { Capybara.current_driver = :webkit }
 
   after { Capybara.use_default_driver }
 

--- a/spec/features/applications/application_form_stories_spec.rb
+++ b/spec/features/applications/application_form_stories_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature 'Completing the application details', type: :feature do
   let!(:user)  { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
 
   before do
-    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
     Capybara.current_driver = :webkit
     Capybara.page.driver.allow_url('http://www.google.com/jsapi')
   end

--- a/spec/features/applications/benefit_results_are_rendered_spec.rb
+++ b/spec/features/applications/benefit_results_are_rendered_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.feature 'Benefit Results', type: :feature do
@@ -10,11 +11,7 @@ RSpec.feature 'Benefit Results', type: :feature do
   context 'as a signed in user' do
 
     before do
-      WebMock.disable_net_connect!(allow: 'codeclimate.com')
       dwp_api_response 'Yes'
-    end
-
-    before do
       login_as user
     end
 

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature 'Confirmation page', type: :feature do
 
   context 'as a signed in user', js: true do
     before do
-      WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
       Capybara.current_driver = :webkit
       dwp_api_response 'Yes'
       login_as user

--- a/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
+++ b/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature 'Completing the application details', type: :feature do
   let!(:user)  { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
 
   before do
-    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
     Capybara.current_driver = :webkit
     Capybara.page.driver.allow_url('http://www.google.com/jsapi')
   end

--- a/spec/features/applications/remission_confirmation_spec.rb
+++ b/spec/features/applications/remission_confirmation_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
 
   context 'as a signed in user', js: true do
     before do
-      WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
       Capybara.current_driver = :webkit
       dwp_api_response 'Yes'
       login_as user

--- a/spec/features/perform_an_income_check_spec.rb
+++ b/spec/features/perform_an_income_check_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature 'Undertake an income calculation', type: :feature do
   let(:user)          { create :user }
 
   before do
-    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
     Capybara.current_driver = :webkit
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
   end
 
   config.before(:each) do

--- a/spec/services/benefit_check_service_spec.rb
+++ b/spec/services/benefit_check_service_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 
 describe BenefitCheckService do
 
-  before { WebMock.disable_net_connect!(allow: 'codeclimate.com') }
-
   context 'called with invalid object' do
     it 'fails' do
       expect {

--- a/spec/services/health_status_spec.rb
+++ b/spec/services/health_status_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe HealthStatus do
 
-  before { WebMock.disable_net_connect!(allow: 'codeclimate.com') }
-
   describe '.current_status' do
     describe 'DWP API' do
       context "when it's down" do

--- a/spec/services/process_dwp_service_spec.rb
+++ b/spec/services/process_dwp_service_spec.rb
@@ -3,8 +3,6 @@ require 'rails_helper'
 
 describe ProcessDwpService do
 
-  before { WebMock.disable_net_connect!(allow: 'codeclimate.com') }
-
   context 'called with invalid object' do
     it 'fails' do
       expect {


### PR DESCRIPTION
Instead of enabling WebMock in individual specs, turn it on once for the
whole test suite. Less error prone and avoids the distraction in the
tests.