### PR TITLE
Handle decimal fees

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -102,7 +102,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     if known_over_61?
       self.threshold = 16000
     else
-      self.threshold = FeeThreshold.new(self).band
+      self.threshold = FeeThreshold.new(self.fee).band
     end
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -102,7 +102,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     if known_over_61?
       self.threshold = 16000
     else
-      self.threshold = FeeThreshold.new(self.fee).band
+      self.threshold = FeeThreshold.new(fee).band
     end
   end
 

--- a/lib/fee_threshold.rb
+++ b/lib/fee_threshold.rb
@@ -28,7 +28,7 @@ class FeeThreshold
   private
 
   def fee
-    @application.fee
+    @application.fee.round
   end
 
   def find_band(line)

--- a/lib/fee_threshold.rb
+++ b/lib/fee_threshold.rb
@@ -11,14 +11,14 @@ class FeeThreshold
       { lower: 6001, upper: 7000, amount: 14000 }
     ]
 
-  def initialize(application)
-    @application = application
+  def initialize(fee)
+    return if fee.nil?
+    @fee = fee.round
   end
 
   def band
-    return if fee.nil?
-    return 3000 if fee <= 1000
-    return 16000 if fee >= 7001
+    return 3000 if @fee <= 1000
+    return 16000 if @fee >= 7001
     FEE_BANDS.each do |band|
       result = find_band band
       return result unless result.nil?
@@ -27,13 +27,9 @@ class FeeThreshold
 
   private
 
-  def fee
-    @application.fee.round
-  end
-
   def find_band(line)
     amount, lower, upper = get_band_values(line)
-    amount if fee.between?(lower, upper)
+    amount if @fee.between?(lower, upper)
   end
 
   def get_band_values(line)

--- a/lib/fee_threshold.rb
+++ b/lib/fee_threshold.rb
@@ -17,6 +17,7 @@ class FeeThreshold
   end
 
   def band
+    return if @fee.nil?
     return 3000 if @fee <= 1000
     return 16000 if @fee >= 7001
     FEE_BANDS.each do |band|

--- a/spec/lib/fee_threshold_spec.rb
+++ b/spec/lib/fee_threshold_spec.rb
@@ -14,21 +14,59 @@ RSpec.describe FeeThreshold do
       it 'returns 3000' do
         expect(subject.band).to eq 3000
       end
+
+      context 'when the fee includes pence' do
+        before { application.fee = 999.50 }
+
+        it 'returns 3000' do
+          expect(subject.band).to eq 3000
+        end
+      end
+    end
+
+    context 'the pence push the fee up a band' do
+      before { application.fee = 1000.50 }
+
+      it 'returns 4000' do
+        expect(subject.band).to eq 4000
+      end
     end
 
     described_class::FEE_BANDS.each do |band|
       context "when amount is between #{band[:lower]} and #{band[:upper]}" do
         before { application.fee = band[:lower] + 5 }
+
         it "returns #{band[:amount]}" do
           expect(subject.band).to eq band[:amount]
+        end
+      end
+
+      context 'when the fee is a float' do
+        context 'and it adds 50 pence to the upper band' do
+          before { application.fee = band[:upper].to_f + 0.50 }
+
+          it "returns amount that is higher than #{band[:amount]}" do
+            expect(subject.band).to be > band[:amount].to_i
+          end
         end
       end
     end
 
     context 'when fee > 7000' do
-      before { application.fee = 7001 }
-      it 'returns 16000' do
-        expect(subject.band).to eq 16000
+      context 'when the fee is just over 7000' do
+        before { application.fee = 7001 }
+
+        it 'returns 16000' do
+          expect(subject.band).to eq 16000
+        end
+      end
+
+      context 'when the fee is in pence' do
+        before { application.fee = 7000.50 }
+
+        it 'returns 16000' do
+          expect(subject.band).to eq 16000
+        end
       end
     end
   end

--- a/spec/lib/fee_threshold_spec.rb
+++ b/spec/lib/fee_threshold_spec.rb
@@ -1,52 +1,44 @@
 require 'rails_helper'
 
 RSpec.describe FeeThreshold do
-  let(:application) { create :application }
-  subject { described_class.new(application) }
-
-  context '.band' do
+  context '#band' do
     it 'returns a amount' do
-      expect(subject.band).to eq 3000
+      expect(described_class.new(0).band).to eq 3000
     end
 
     context 'when fee < 1000' do
-      before { application.fee = 999 }
       it 'returns 3000' do
-        expect(subject.band).to eq 3000
+        expect(described_class.new(999).band).to eq 3000
       end
 
       context 'when the fee includes pence' do
-        before { application.fee = 999.50 }
-
         it 'returns 3000' do
-          expect(subject.band).to eq 3000
+          expect(described_class.new(999.50).band).to eq 3000
         end
       end
     end
 
     context 'the pence push the fee up a band' do
-      before { application.fee = 1000.50 }
-
       it 'returns 4000' do
-        expect(subject.band).to eq 4000
+        expect(described_class.new(1000.50).band).to eq 4000
       end
     end
 
     described_class::FEE_BANDS.each do |band|
       context "when amount is between #{band[:lower]} and #{band[:upper]}" do
-        before { application.fee = band[:lower] + 5 }
+        let(:fee) { band[:lower] + 5 }
 
         it "returns #{band[:amount]}" do
-          expect(subject.band).to eq band[:amount]
+          expect(described_class.new(fee).band).to eq band[:amount]
         end
       end
 
       context 'when the fee is a float' do
         context 'and it adds 50 pence to the upper band' do
-          before { application.fee = band[:upper].to_f + 0.50 }
+          let(:fee) { band[:upper].to_f + 0.50 }
 
           it "returns amount that is higher than #{band[:amount]}" do
-            expect(subject.band).to be > band[:amount].to_i
+            expect(described_class.new(fee).band).to be > band[:amount].to_i
           end
         end
       end
@@ -54,18 +46,14 @@ RSpec.describe FeeThreshold do
 
     context 'when fee > 7000' do
       context 'when the fee is just over 7000' do
-        before { application.fee = 7001 }
-
         it 'returns 16000' do
-          expect(subject.band).to eq 16000
+          expect(described_class.new(7001).band).to eq 16000
         end
       end
 
       context 'when the fee is in pence' do
-        before { application.fee = 7000.50 }
-
         it 'returns 16000' do
-          expect(subject.band).to eq 16000
+          expect(described_class.new(7000.50).band).to eq 16000
         end
       end
     end


### PR DESCRIPTION
Added the ability to work out the fee threshold band even when the fee
is supplied as a decimal value. Previously it only handled whole
numbers.