### PR TITLE
Remove spaces from NI number

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -17,6 +17,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   MIN_AGE = 16
 
   after_save :run_auto_checks
+  before_validation :format_ni_number
 
   # Step 1 - Personal detail validation
   with_options if: proc { active_or_status_is? 'personal_information' } do
@@ -292,5 +293,9 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
         I18n.t('activerecord.attributes.dwp_check.dob_too_young', min_age: MIN_AGE)
       )
     end
+  end
+
+  def format_ni_number
+    ni_number.gsub!(' ', '') unless ni_number.nil?
   end
 end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -85,11 +85,11 @@ RSpec.describe Application, type: :model do
         end
 
         it 'does not update remission type' do
-          expect { application.save } .to_not change { application.application_type }
+          expect { application.save }.to_not change { application.application_type }
         end
 
         it 'does not update amount_to_pay' do
-          expect { application.save } .to_not change { application.amount_to_pay }
+          expect { application.save }.to_not change { application.amount_to_pay }
         end
       end
 
@@ -103,11 +103,11 @@ RSpec.describe Application, type: :model do
         end
 
         it 'updates remission type' do
-          expect { application.save } .to change { application.application_type }
+          expect { application.save }.to change { application.application_type }
         end
 
         it 'updates amount_to_pay' do
-          expect { application.save } .to change { application.amount_to_pay }
+          expect { application.save }.to change { application.amount_to_pay }
         end
       end
     end
@@ -132,14 +132,14 @@ RSpec.describe Application, type: :model do
     describe 'auto running benefit checks' do
       context 'when saved without required fields' do
         it 'does not run a benefit check' do
-          expect { application.save } .to_not change { application.benefit_checks.count }
+          expect { application.save }.to_not change { application.benefit_checks.count }
         end
       end
 
       context 'when the final item required is saved' do
         before { application.last_name = 'TEST' }
         it 'runs a benefit check ' do
-          expect { application.save } .to change { application.benefit_checks.count }.by 1
+          expect { application.save }.to change { application.benefit_checks.count }.by 1
         end
 
         it 'sets application_type to benefit' do
@@ -155,7 +155,7 @@ RSpec.describe Application, type: :model do
           end
 
           it 'does not perform another benefit check' do
-            expect { application.save } .to_not change { application.benefit_checks.count }
+            expect { application.save }.to_not change { application.benefit_checks.count }
           end
         end
 
@@ -176,7 +176,7 @@ RSpec.describe Application, type: :model do
           end
 
           it 'runs a benefit check' do
-            expect { application.save } .to change { application.benefit_checks.count }.by 1
+            expect { application.save }.to change { application.benefit_checks.count }.by 1
           end
 
           it 'sets the new benefit check date' do
@@ -202,7 +202,7 @@ RSpec.describe Application, type: :model do
           end
 
           it 'runs a benefit check' do
-            expect { application.save } .to change { application.benefit_checks.count }.by 1
+            expect { application.save }.to change { application.benefit_checks.count }.by 1
           end
         end
       end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -17,221 +17,259 @@ RSpec.describe Application, type: :model do
   it { is_expected.to validate_presence_of(:reference) }
   it { is_expected.to validate_uniqueness_of(:reference) }
 
-  before do
-    stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
-    {
-      birth_date: (Time.zone.today - 18.years).strftime('%Y%m%d'),
-      entitlement_check_date: (Time.zone.today - 1.month).strftime('%Y%m%d'),
-      id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
-      ni_number: 'AB123456A',
-      surname: 'TEST'
-    }).to_return(status: 200, body: '', headers: {})
+  context 'with running benefit check' do
+    before do
+      stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
+      {
+        birth_date: (Time.zone.today - 18.years).strftime('%Y%m%d'),
+        entitlement_check_date: (Time.zone.today - 1.month).strftime('%Y%m%d'),
+        id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
+        ni_number: 'AB123456A',
+        surname: 'TEST'
+      }).to_return(status: 200, body: '', headers: {})
 
-    application.date_of_birth = Time.zone.today - 18.years
-    application.date_received = Time.zone.today - 1.month
-    application.ni_number = 'AB123456A'
-  end
-
-  describe 'income calculation' do
-    it 'includes can_calculate?' do
-      expect(application).to respond_to :can_calculate?
+      application.date_of_birth = Time.zone.today - 18.years
+      application.date_received = Time.zone.today - 1.month
+      application.ni_number = 'AB123456A'
     end
 
-    it 'includes calculate' do
-      expect(application).to respond_to :calculate
+    describe 'income calculation' do
+      it 'includes can_calculate?' do
+        expect(application).to respond_to :can_calculate?
+      end
+
+      it 'includes calculate' do
+        expect(application).to respond_to :calculate
+      end
+
+      context 'can_calculate?' do
+        context 'when required fields are complete' do
+          before do
+            application.dependents = true
+            application.fee = 300
+            application.married = true
+            application.income = 1000
+            application.children = 1
+            application.valid?
+          end
+
+          before { application.valid? }
+          it 'returns true' do
+            expect(application.can_calculate?).to eq true
+          end
+        end
+        context 'when required fields are missing' do
+          before do
+            application.fee = nil
+            application.married = true
+            application.income = 1000
+            application.children = 1
+            application.valid?
+          end
+
+          it 'returns false' do
+            expect(application.can_calculate?).to eq false
+          end
+        end
+      end
     end
 
-    context 'can_calculate?' do
-      context 'when required fields are complete' do
+    describe 'auto running calculator' do
+      context 'without required fields' do
+        before do
+          application.dependents = true
+          application.fee = nil
+          application.married = true
+          application.income = 1000
+          application.children = 1
+        end
+
+        it 'does not update remission type' do
+          expect { application.save } .to_not change { application.application_type }
+        end
+
+        it 'does not update amount_to_pay' do
+          expect { application.save } .to_not change { application.amount_to_pay }
+        end
+      end
+
+      context 'with required fields' do
         before do
           application.dependents = true
           application.fee = 300
           application.married = true
           application.income = 1000
           application.children = 1
-          application.valid?
         end
 
-        before { application.valid? }
-        it 'returns true' do
-          expect(application.can_calculate?).to eq true
-        end
-      end
-      context 'when required fields are missing' do
-        before do
-          application.fee = nil
-          application.married = true
-          application.income = 1000
-          application.children = 1
-          application.valid?
+        it 'updates remission type' do
+          expect { application.save } .to change { application.application_type }
         end
 
-        it 'returns false' do
-          expect(application.can_calculate?).to eq false
+        it 'updates amount_to_pay' do
+          expect { application.save } .to change { application.amount_to_pay }
         end
       end
     end
-  end
 
-  describe 'auto running calculator' do
-    context 'without required fields' do
-      before do
-        application.dependents = true
-        application.fee = nil
-        application.married = true
-        application.income = 1000
-        application.children = 1
-      end
-
-      it 'does not update remission type' do
-        expect { application.save } .to_not change { application.application_type }
-      end
-
-      it 'does not update amount_to_pay' do
-        expect { application.save } .to_not change { application.amount_to_pay }
-      end
-    end
-
-    context 'with required fields' do
-      before do
-        application.dependents = true
-        application.fee = 300
-        application.married = true
-        application.income = 1000
-        application.children = 1
-      end
-
-      it 'updates remission type' do
-        expect { application.save } .to change { application.application_type }
-      end
-
-      it 'updates amount_to_pay' do
-        expect { application.save } .to change { application.amount_to_pay }
-      end
-    end
-  end
-
-  describe 'calculator' do
-    CalculatorTestData.seed_data.each do |src|
-      it "scenario \##{src[:id]} passes" do
-        application.update(
-          fee: src[:fee],
-          married: src[:married_status],
-          dependents: src[:children].to_i > 0,
-          children: src[:children],
-          income: src[:income]
-        )
-        expect(application.application_type).to eq 'income'
-        expect(application.application_outcome).to eq src[:type]
-        expect(application.amount_to_pay).to eq src[:they_pay].to_i
-      end
-    end
-  end
-
-  describe 'auto running benefit checks' do
-    context 'when saved without required fields' do
-      it 'does not run a benefit check' do
-        expect { application.save } .to_not change { application.benefit_checks.count }
-      end
-    end
-
-    context 'when the final item required is saved' do
-      before { application.last_name = 'TEST' }
-      it 'runs a benefit check ' do
-        expect { application.save } .to change { application.benefit_checks.count }.by 1
-      end
-
-      it 'sets application_type to benefit' do
-        application.save
-        expect(application.application_type).to eq 'benefit'
-      end
-
-      context 'when other fields are changed' do
-        before do
-          application.last_name = 'TEST'
-          application.save
-          application.fee = 300
+    describe 'calculator' do
+      CalculatorTestData.seed_data.each do |src|
+        it "scenario \##{src[:id]} passes" do
+          application.update(
+            fee: src[:fee],
+            married: src[:married_status],
+            dependents: src[:children].to_i > 0,
+            children: src[:children],
+            income: src[:income]
+          )
+          expect(application.application_type).to eq 'income'
+          expect(application.application_outcome).to eq src[:type]
+          expect(application.amount_to_pay).to eq src[:they_pay].to_i
         end
+      end
+    end
 
-        it 'does not perform another benefit check' do
+    describe 'auto running benefit checks' do
+      context 'when saved without required fields' do
+        it 'does not run a benefit check' do
           expect { application.save } .to_not change { application.benefit_checks.count }
         end
       end
 
-      context 'when date_fee_paid is updated' do
-        before do
-          stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
-          {
-            birth_date: (Time.zone.today - 18.years).strftime('%Y%m%d'),
-            entitlement_check_date: (Time.zone.today - 2.weeks).strftime('%Y%m%d'),
-            id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
-            ni_number: 'AB123456A',
-            surname: 'TEST'
-          }).to_return(status: 200, body: '', headers: {})
-
-          application.last_name = 'TEST'
-          application.save
-          application.date_fee_paid = Time.zone.today - 2.weeks
-        end
-
-        it 'runs a benefit check' do
+      context 'when the final item required is saved' do
+        before { application.last_name = 'TEST' }
+        it 'runs a benefit check ' do
           expect { application.save } .to change { application.benefit_checks.count }.by 1
         end
 
-        it 'sets the new benefit check date' do
+        it 'sets application_type to benefit' do
           application.save
-          expect(application.last_benefit_check.date_to_check).to eq Time.zone.today - 2.weeks
+          expect(application.application_type).to eq 'benefit'
+        end
+
+        context 'when other fields are changed' do
+          before do
+            application.last_name = 'TEST'
+            application.save
+            application.fee = 300
+          end
+
+          it 'does not perform another benefit check' do
+            expect { application.save } .to_not change { application.benefit_checks.count }
+          end
+        end
+
+        context 'when date_fee_paid is updated' do
+          before do
+            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
+            {
+              birth_date: (Time.zone.today - 18.years).strftime('%Y%m%d'),
+              entitlement_check_date: (Time.zone.today - 2.weeks).strftime('%Y%m%d'),
+              id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
+              ni_number: 'AB123456A',
+              surname: 'TEST'
+            }).to_return(status: 200, body: '', headers: {})
+
+            application.last_name = 'TEST'
+            application.save
+            application.date_fee_paid = Time.zone.today - 2.weeks
+          end
+
+          it 'runs a benefit check' do
+            expect { application.save } .to change { application.benefit_checks.count }.by 1
+          end
+
+          it 'sets the new benefit check date' do
+            application.save
+            expect(application.last_benefit_check.date_to_check).to eq Time.zone.today - 2.weeks
+          end
+        end
+
+        context 'when a benefit check field is changed' do
+          before do
+            stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
+            {
+              birth_date: (Time.zone.today - 18.years).strftime('%Y%m%d'),
+              entitlement_check_date: (Time.zone.today - 1.month).strftime('%Y%m%d'),
+              id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
+              ni_number: 'AB123456A',
+              surname: 'NEW NAME'
+            }).to_return(status: 200, body: '', headers: {})
+
+            application.last_name = 'TEST'
+            application.save
+            application.last_name = 'New name'
+          end
+
+          it 'runs a benefit check' do
+            expect { application.save } .to change { application.benefit_checks.count }.by 1
+          end
         end
       end
+    end
 
-      context 'when a benefit check field is changed' do
+    describe '#spotcheck?' do
+      subject { application.spotcheck? }
+
+      context 'when the application has spotcheck model associated' do
         before do
-          stub_request(:post, "#{ENV['DWP_API_PROXY']}/api/benefit_checks").with(body:
-          {
-            birth_date: (Time.zone.today - 18.years).strftime('%Y%m%d'),
-            entitlement_check_date: (Time.zone.today - 1.month).strftime('%Y%m%d'),
-            id: "#{user.name.gsub(' ', '').downcase.truncate(27)}@#{application.created_at.strftime('%y%m%d%H%M%S')}.#{application.id}",
-            ni_number: 'AB123456A',
-            surname: 'NEW NAME'
-          }).to_return(status: 200, body: '', headers: {})
-
-          application.last_name = 'TEST'
-          application.save
-          application.last_name = 'New name'
+          create :spotcheck, application: application
         end
 
-        it 'runs a benefit check' do
-          expect { application.save } .to change { application.benefit_checks.count }.by 1
-        end
+        it { is_expected.to be true }
+      end
+
+      context 'when the application does not have spotcheck model associated' do
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '.spotcheckable' do
+      subject { described_class.spotcheckable }
+
+      let!(:application_1) { create :application_part_remission }
+      let!(:application_2) { create :application_full_remission }
+      let!(:application_3) { create :application_no_remission }
+
+      it 'includes only part and full remission applications' do
+        is_expected.to match_array([application_1, application_2])
       end
     end
   end
 
-  describe '#spotcheck?' do
-    subject { application.spotcheck? }
+  describe 'ni_number' do
+    let(:expected_ni_number) { 'JN010203A' }
+    let(:application) { build :application, user: user, ni_number: ni_number }
 
-    context 'when the application has spotcheck model associated' do
-      before do
-        create :spotcheck, application: application
+    before do
+      allow(BenefitCheckService).to receive(:new)
+      allow(application).to receive(:outcome_from_dwp_result).and_return('none')
+
+      application.save
+    end
+
+    context 'with spaces' do
+      let(:ni_number) { 'JN 01 02 03 A' }
+
+      it 'is stripped of all spaces before stored' do
+        expect(application.ni_number).to eql(expected_ni_number)
       end
-
-      it { is_expected.to be true }
     end
 
-    context 'when the application does not have spotcheck model associated' do
-      it { is_expected.to be false }
+    context 'without spaces' do
+      let(:ni_number) { expected_ni_number }
+
+      it 'is stored as inputted' do
+        expect(application.ni_number).to eql(expected_ni_number)
+      end
     end
-  end
 
-  describe '.spotcheckable' do
-    subject { described_class.spotcheckable }
+    context 'when nil' do
+      let(:ni_number) { nil }
 
-    let!(:application_1) { create :application_part_remission }
-    let!(:application_2) { create :application_full_remission }
-    let!(:application_3) { create :application_no_remission }
-
-    it 'includes only part and full remission applications' do
-      is_expected.to match_array([application_1, application_2])
+      it 'is nil' do
+        expect(application.ni_number).to be nil
+      end
     end
   end
 end


### PR DESCRIPTION
When entering a national insurance number with spaces, an error is shown. 

This PR fixes that by removing the whitespace before validation.

delivers [#103088140](https://www.pivotaltracker.com/story/show/103088140)