### PR TITLE
Fix for rubocop blocking vagrant provision

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,6 +1,8 @@
 if %w[development test].include? Rails.env
-  require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
+  unless ENV['DOCKER_STATE'] == 'vagrant'
+    require 'rubocop/rake_task'
+    RuboCop::RakeTask.new
 
-  task(:default).prerequisites << task(:rubocop)
+    task(:default).prerequisites << task(:rubocop)
+  end
 end


### PR DESCRIPTION
When the vagrant box was started locally, the rubocop rake task 
would block __any__rake task.  This prevented rake db:migrate
running.

This fix prevents rubocop running when DOCKER_STATE = 'vagrant', 
but still runs if rake is used locally.