### PR TITLE
Eased out benefits page to a form object

### DIFF
--- a/app/controllers/applications/build_controller.rb
+++ b/app/controllers/applications/build_controller.rb
@@ -97,7 +97,7 @@ class Applications::BuildController < ApplicationController
   end
 
   def application_params
-    all_params = %i[status benefits dependents income children]
+    all_params = %i[status dependents income children]
     params.require(:application).permit(all_params.flatten)
   end
 

--- a/app/controllers/applications/build_controller.rb
+++ b/app/controllers/applications/build_controller.rb
@@ -17,7 +17,7 @@ class Applications::BuildController < ApplicationController
     :summary,
     :confirmation
 
-  FORM_OBJECTS = %i[personal_information application_details savings_investments]
+  FORM_OBJECTS = %i[personal_information application_details savings_investments benefits]
 
   def create
     application_builder = ApplicationBuilder.new(current_user)

--- a/app/models/forms/benefit.rb
+++ b/app/models/forms/benefit.rb
@@ -1,0 +1,11 @@
+module Forms
+  class Benefit < Base
+    def self.permitted_attributes
+      { benefits: Boolean }
+    end
+
+    define_attributes
+
+    validates :benefits, inclusion: { in: [true, false] }
+  end
+end

--- a/app/views/applications/build/benefits.html.slim
+++ b/app/views/applications/build/benefits.html.slim
@@ -1,13 +1,14 @@
 h2 Benefits
 
-= form_for @application, url: wizard_path, method: :put, html: { autocomplete: 'off' } do |f|
+= form_for @form, as: :application, url: wizard_path, method: :put, html: { autocomplete: 'off' } do |f|
   .row
     .small-12.medium-8.large-5.columns
       .form-group
         .row.collapse
           .columns.small-12
             = f.label :benefits
-            = f.label :benefits, @application.errors[:benefits].join(', '), class: 'error' if @application.errors[:benefits].present?
+            = f.label :benefits, @form.errors[:benefits].join(', '), class: 'error' if @form.errors[:benefits].present?
+            = f.hidden_field :benefits, value: nil
             .options.radio
               .option
                 label for='application_benefits_false'
@@ -18,7 +19,6 @@ h2 Benefits
                   = f.radio_button :benefits, 'true'
                   = t('activerecord.attributes.application.page_4.benefits_true')
 
-  = f.hidden_field :status
   = f.submit 'Next', :class => 'button primary'
 
 .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -152,6 +152,9 @@ en-GB:
 
         <p>%{user_name}</p>
   activemodel:
+    attributes:
+      forms/benefit:
+        benefits: Is the applicant receiving one of the benefits listed in question 9?
     errors:
       models:
         forms/application_detail:
@@ -181,6 +184,10 @@ en-GB:
               not_a_date: Enter the date in this format 01/01/2015
               invalid: Enter the date in this format day month, year DD/MM/YYYY
               before: The date of death cannot be a future date
+        forms/benefit:
+          attributes:
+            benefits:
+              inclusion: You must answer the benefits question
   activerecord:
     errors:
       models:

--- a/spec/models/forms/benefit_spec.rb
+++ b/spec/models/forms/benefit_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Forms::Benefit do
+  params_list = %i[benefits]
+
+  let(:hash) { {} }
+
+  subject { described_class.new(hash) }
+
+  describe '.permitted_attributes' do
+    it 'returns a list of attributes' do
+      expect(described_class.permitted_attributes.keys).to match_array(params_list)
+    end
+  end
+
+  describe 'validations' do
+    let(:benefit) { described_class.new(hash) }
+
+    describe 'benefits' do
+      context 'when true' do
+        before { benefit[:benefits] = true }
+
+        it { expect(benefit.valid?).to be true }
+      end
+
+      context 'when false' do
+        before { benefit[:benefits] = false }
+
+        it { expect(benefit.valid?).to be true }
+      end
+
+      context 'when not a boolean value' do
+        before { benefit[:benefits] = 'string' }
+
+        it { expect(benefit.valid?).to be false }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Created Benefit model which only handles the benefit page form. This is
done as part of the refactoring task on the monolithic Application
model.

Also removed the 'status' attribute from the benefits page and addded a
hidden field, this is because otherwise the form would not submit any of
the fields from the radio buttons.