### PR TITLE
Admin user delete

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,18 +30,17 @@ class UsersController < ApplicationController
   end
 
   def update
-    update_successfull = @user.update_attributes(user_params)
-    if update_successfull && manager_setup.in_progress?
+    update_successful = @user.update_attributes(user_params)
+    if update_successful && manager_setup.in_progress?
       redirect_to root_path
     else
-      flash[:notice] = 'User updated' if update_successfull
-      flash[:notice] = user_transfer_message if no_longer_manages?
+      flash_notices_for_update(update_successful)
       user_or_redirect
     end
   end
 
   def destroy
-    if user_themselves?
+    if UserManagement.new(current_user, @user).user_themselves?
       flash[:alert] = 'You cannot delete your own account'
       redirect_to user_path(@user)
     else
@@ -57,26 +56,23 @@ class UsersController < ApplicationController
 
   protected
 
+  def flash_notices_for_update(update_successful)
+    flash[:notice] = 'User updated' if update_successful
+    flash[:notice] = user_transfer_notice if UserManagement.new(current_user, @user).transferred?
+  end
+
   def user_params
     all_params   = [:name, :office_id, :jurisdiction_id, :role]
     all_but_role = [:name, :office_id, :jurisdiction_id]
 
-    if current_user.admin? || manager_doesnt_escalate_to_admin?
+    if UserManagement.new(current_user, @user).manager_cant_escalate_to_admin?(params[:user][:role])
       params.require(:user).permit(all_params)
     else
       params.require(:user).permit(all_but_role)
     end
   end
 
-  def no_longer_manages?
-    current_user.manager? && not_their_office?
-  end
-
-  def not_their_office?
-    current_user.office != @user.office
-  end
-
-  def user_transfer_message
+  def user_transfer_notice
     office = @user.office
     t('error_messages.user.moved_offices',
       user: @user.name,
@@ -103,7 +99,7 @@ class UsersController < ApplicationController
   end
 
   def user_or_redirect
-    if admin_manager_or_user_themselves?
+    if UserManagement.new(current_user, @user).admin_manager_or_user_themselves?
       respond_with(@user)
     elsif current_user.manager?
       redirect_to users_path
@@ -114,22 +110,6 @@ class UsersController < ApplicationController
 
   def redirect_after_restore
     User.only_deleted.count > 0 ? deleted_users_path : users_path
-  end
-
-  def admin_manager_or_user_themselves?
-    current_user.admin? || manages_user? || user_themselves?
-  end
-
-  def user_themselves?
-    current_user.id == @user.id
-  end
-
-  def manages_user?
-    current_user.manager? && current_user.office == @user.office
-  end
-
-  def manager_doesnt_escalate_to_admin?
-    manages_user? && params[:user][:role] != 'admin'
   end
 
   def manager_setup

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,6 +10,7 @@ class Ability
       can [:manage], User do |staff_member|
         can_manage_user?(user, staff_member)
       end
+      cannot [:list_deleted], User
       can [:edit, :update], Office, id: user.office_id
       users_can
     else

--- a/app/services/user_management.rb
+++ b/app/services/user_management.rb
@@ -1,0 +1,37 @@
+class UserManagement
+
+  def initialize(current_user, user)
+    @current_user = current_user
+    @user = user
+  end
+
+  def deletion_permitted?
+    @current_user.elevated? && !user_themselves?
+  end
+
+  def user_themselves?
+    @current_user.id == @user.id
+  end
+
+  def transferred?
+    @current_user.manager? && not_their_office?
+  end
+
+  def admin_manager_or_user_themselves?
+    @current_user.admin? || manages_user? || user_themselves?
+  end
+
+  def manager_cant_escalate_to_admin?(role)
+    @current_user.admin? || manages_user? && role != 'admin'
+  end
+
+  private
+
+  def manages_user?
+    @current_user.manager? && @current_user.office == @user.office
+  end
+
+  def not_their_office?
+    @current_user.office != @user.office
+  end
+end

--- a/app/views/users/deleted.html.slim
+++ b/app/views/users/deleted.html.slim
@@ -1,1 +1,23 @@
 h2 Deleted staff
+
+table
+  tr
+    th Full name
+    th Role
+    th Office
+    th email
+    th Deleted on
+    th &nbsp;
+
+  -@users.each do |user|
+    tr
+      td =user.name
+      td =user.role.humanize
+      td =user.office.name if user.office.present?
+      td =user.email
+      td =user.deleted_at
+      td =link_to 'Restore staff member', restore_user_path(user), method: :patch
+
+.row.pad-top-fifteen-px
+  .columns.small-12
+    =link_to 'Back to list of staff', users_path

--- a/app/views/users/deleted.html.slim
+++ b/app/views/users/deleted.html.slim
@@ -1,0 +1,1 @@
+h2 Deleted staff

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -19,4 +19,11 @@ table
       td =user.jurisdiction.display if user.jurisdiction.present?
       td =link_to 'Change details', edit_user_path(user)
 
-=link_to 'Add staff', new_user_invitation_path
+.row.pad-top-fifteen-px
+  .columns.small-12
+    =link_to 'Add staff', new_user_invitation_path
+
+-if current_user.admin?
+  .row.pad-top-fifteen-px
+    .columns.small-12
+      =link_to 'List deleted users', deleted_users_path

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -33,7 +33,7 @@ h2 Staff details
   .row.pad-top-fifteen-px
     .columns.small-12
       = link_to "Change your password", edit_user_registration_path(@user)
--if current_user.elevated? && current_user != @user
+-if UserManagement.new(current_user, @user).deletion_permitted?
   .row.pad-top-fifteen-px
     .columns.small-12
       =link_to 'Remove staff member', user_path(@user), method: :delete

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
     get "static/#{error}" => "static##{error}"
   end
 
+  get 'users/deleted' => 'users#deleted', as: 'deleted_users'
+  patch 'users/:id/restore' => 'users#restore', as: 'restore_user'
   devise_for :users, skip: :registrations, controllers: { invitations: 'users/invitations' }
   resources :users
   as :user do

--- a/spec/controllers/users_controller/admin_user_spec.rb
+++ b/spec/controllers/users_controller/admin_user_spec.rb
@@ -158,6 +158,29 @@ RSpec.describe UsersController, type: :controller do
       end
     end
 
+    describe 'GET #deleted' do
+      before(:each) { get :deleted }
+
+      it 'returns a success code' do
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'renders the index view' do
+        expect(response).to render_template :deleted
+      end
+    end
+
+    describe 'PATCH #restore' do
+      let!(:deleted_user) { create :user, deleted_at: Time.zone.now }
+      before do
+        patch :restore, id: deleted_user.to_param
+      end
+
+      it 'returns a redirect code' do
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+
     describe 'DELETE #destroy' do
       context 'when viewing themselves' do
         before(:each) { get :destroy, id: admin_user.to_param }

--- a/spec/controllers/users_controller/manager_user_spec.rb
+++ b/spec/controllers/users_controller/manager_user_spec.rb
@@ -100,6 +100,14 @@ RSpec.describe UsersController, type: :controller do
       end
     end
 
+    describe 'GET #deleted' do
+      it 'raises a CanCan error' do
+        expect {
+          get :deleted
+        }.to raise_error CanCan::AccessDenied, 'You are not authorized to access this page.'
+      end
+
+    end
     describe 'PUT #update' do
 
       context 'role escalation' do

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -26,5 +26,13 @@ RSpec.describe UsersController, type: :routing do
     it 'routes to #update' do
       expect(put: '/users/1').to route_to('users#update', id:  '1')
     end
+
+    it 'routes to #deleted' do
+      expect(get: '/users/deleted').to route_to('users#deleted')
+    end
+
+    it 'routes to #restore' do
+      expect(patch: '/users/1/restore').to route_to('users#restore', id: '1')
+    end
   end
 end

--- a/spec/services/user_management_spec.rb
+++ b/spec/services/user_management_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe UserManagement do
+  let(:check) { described_class.new(current_user, staff_member) }
+  let(:current_user) { create :admin_user }
+
+  describe '#deletion_permitted?' do
+    let(:staff_member) { create :user }
+
+    context 'the current user is elevated' do
+      context 'the current_user is not the staff member' do
+        it { expect(check.deletion_permitted?).to be true }
+      end
+
+      context 'the current_user is the staff member' do
+        let(:check) { described_class.new(current_user, current_user) }
+
+        it { expect(check.deletion_permitted?).to be false }
+      end
+    end
+
+    context 'the current user is not an elevated user' do
+      let(:current_user) { create :user }
+      it { expect(check.deletion_permitted?).to be false }
+    end
+  end
+
+  describe '#user_themselves?' do
+    context 'the current_user is not the staff member' do
+      let(:staff_member) { create :user }
+      it { expect(check.user_themselves?).to be false }
+    end
+    context 'the current_user is the staff member' do
+      let(:check) { described_class.new(current_user, current_user) }
+
+      it { expect(check.user_themselves?).to be true }
+    end
+  end
+
+  describe '#transferred?' do
+    context 'current_user is a manager' do
+      let(:current_user) { create :manager }
+
+      context 'user is in a different office' do
+        let(:staff_member) { create :user }
+
+        it { expect(check.transferred?).to be true }
+      end
+
+      context 'user is in the same office as current_user' do
+        let(:staff_member) { create :user, office: current_user.office }
+
+        it { expect(check.transferred?).to be false }
+      end
+    end
+
+  end
+
+  describe '#admin_manager_or_user_themselves?' do
+    let(:check) { described_class.new(current_user, nil) }
+
+    context 'current_user is admin' do
+      let(:current_user) { create :admin_user }
+
+      it { expect(check.admin_manager_or_user_themselves?).to be true }
+    end
+
+    context 'current_user is manager' do
+      let(:current_user) { create :manager }
+      let(:staff_member) { create :user, office: current_user.office }
+      let(:check) { described_class.new(current_user, current_user) }
+
+      it { expect(check.admin_manager_or_user_themselves?).to be true }
+    end
+
+    context 'current_user is staff member ' do
+      let(:current_user) { create :user }
+      let(:check) { described_class.new(current_user, current_user) }
+
+      it { expect(check.admin_manager_or_user_themselves?).to be true }
+    end
+
+  end
+
+  describe '#manager_cant_escalate_to_admin?' do
+    context 'current_user is a manager' do
+      let(:current_user) { create :manager }
+
+      context 'and manages the staff member' do
+        let(:staff_member) { create :user, office: current_user.office }
+
+        context 'and submits manager as a role' do
+          it { expect(check.manager_cant_escalate_to_admin?('manager')).to be true }
+        end
+      end
+    end
+  end
+end

--- a/spec/views/users/deleted.html.slim_spec.rb
+++ b/spec/views/users/deleted.html.slim_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'users/deleted', type: :view do
+
+  include Devise::TestHelpers
+
+  let!(:user) { create :user, deleted_at: Time.zone.now }
+
+  describe 'when viewed' do
+    context 'as an admin' do
+      let(:admin) { create :admin_user }
+      before do
+        create_list(:user, 2, deleted_at: Time.zone.now)
+        assign(:users, User.only_deleted)
+        sign_in admin
+        render
+      end
+
+      it 'renders a link to the user index page' do
+        expect(rendered).to have_xpath("//a[@href='#{users_path}']")
+      end
+
+      it 'shows users email addresses' do
+        expect(rendered).to have_xpath("//td[contains(., '#{user.email}')]")
+      end
+
+      it 'has links to restore users' do
+        expect(rendered).to have_xpath("//a[@href='#{restore_user_path(user)}' and @data-method='patch']")
+      end
+    end
+  end
+end

--- a/spec/views/users/index.html.slim_spec.rb
+++ b/spec/views/users/index.html.slim_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'users/index', type: :view do
+
+  include Devise::TestHelpers
+
+  before { assign(:users, create_list(:user, 2)) }
+
+  describe 'when viewed' do
+    context 'as an admin' do
+      let(:admin) { create :admin_user }
+      before do
+        sign_in admin
+        render
+      end
+
+      it 'renders a link to the delete page' do
+        expect(rendered).to have_link('List deleted users')
+      end
+    end
+
+    context 'as a manager' do
+      let(:manager) { create :manager }
+      before do
+        sign_in manager
+        render
+      end
+
+      it 'does not render a link to the delete page' do
+        expect(rendered).not_to have_link('List deleted users')
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was a need for admins to undelete users.

This adds a new users/deleted view that only lists deleted users
The table has a per user restore function

As part of the work, I refactored some of the complexity to a new UserManagement 
service class.  This is called from the UserController and the show view to determine
eligibility to delete.