### PR TITLE
Add Email link to feedback display

### DIFF
--- a/app/views/feedback/index.html.slim
+++ b/app/views/feedback/index.html.slim
@@ -15,7 +15,7 @@ h2 Feedback received
       tbody
       -@feedback.each do |f|
         tr
-          td =f.user.name
+          td =mail_to f.user.email, f.user.name, target: 'blank'
           td =f.experience
           td =f.ideas
           td =f.rating

--- a/spec/views/feedback/display.html.slim_spec.rb
+++ b/spec/views/feedback/display.html.slim_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'feedback/index', type: :view do
+  include Devise::TestHelpers
+
+  let(:admin) { create :admin_user }
+
+  before do
+    assign(:feedback, create_list(:feedback, 2, user: admin, office: admin.office))
+    sign_in admin
+    render
+  end
+
+  it 'identifys the user' do
+    expect(rendered).to have_xpath("//td[contains(., '#{admin.name}')]")
+  end
+
+  it 'provides the users email' do
+    expect(rendered).to have_xpath("//a[@href='mailto:#{admin.email}']")
+  end
+
+end


### PR DESCRIPTION
This will allow admins to contact users directly
without having to search for users and copy/paste
email addresses from the user table.