### PR TITLE
Update static page rake task

### DIFF
--- a/lib/tasks/static_pages.rake
+++ b/lib/tasks/static_pages.rake
@@ -24,7 +24,7 @@ namespace :static_pages do
       if resp == 200
         File.delete(outpath) if File.exist?(outpath)
         File.open(outpath, 'w') do |f|
-          f.write(app.response.body)
+          f.write(app.response.body.sub!('http://www.example.com', ''))
         end
       else
         puts "Error generating #{output}!"


### PR DESCRIPTION
The static pages were being generated with www.example.com because
(as they are static!) they did not have access to root_url.

This replaces http://www.example.com with /, thus taking users
to the root page of the current site, regardless of environment.
