### PR TITLE
I18n cleanup in User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ActiveRecord::Base
     with: email_regex,
     on: [:create, :update],
     allow_nil: true,
-    message: I18n.t('dictionary.invalid_email', email: Settings.mail.tech_support)
+    message: :invalid_email, email: Settings.mail.tech_support
   }
   validates :role, inclusion: {
     in: ROLES,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,8 +36,6 @@ en-GB:
       moved_offices: "%{user} moved to %{office}, you will need to contact %{contact} there if this was done in error"
     jurisdictions:
       none_in_office: 'Ask your manager to assign jurisdictions to your office.'
-  dictionary:
-    invalid_email: "You’re not able to create an account with this email address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help, <a href='mailto:%{email}'>contact us</a>"
   feedback:
     rating_1: 'No'
     rating_2: 'I used an accessibility tool such as a screen reader'
@@ -210,6 +208,7 @@ en-GB:
               blank: 'Enter your email address'
               not_found: Your email address has not been recognised. First check that you've typed it correctly. For more help <a href='mailto:trial.feedback@digital.justice.gov.uk'>contact us</a>
               taken: This email has already been taken
+              invalid_email: "You’re not able to create an account with this email address. Only 'name@hmcts.gsi.gov.uk' emails can be used. For more help, <a href='mailto:%{email}'>contact us</a>"
             name:
               blank: You must enter a name for the user
             current_password:

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -67,6 +67,7 @@ describe User, type: :model do
         context 'non white listed emails' do
           let(:invalid_email) { 'email.that.rocks@gmail.com' }
           before(:each) { user.email = invalid_email }
+          error_message = I18n.t('activerecord.errors.models.user.attributes.email.invalid_email', email: Settings.mail.tech_support)
 
           it 'will not accept non white listed emails' do
             expect(user).to be_invalid
@@ -74,7 +75,7 @@ describe User, type: :model do
 
           it 'has an informative error message for non white listed emails' do
             user.valid?
-            expect(user.errors.messages[:email].first).to match I18n.t('dictionary.invalid_email', email: Settings.mail.tech_support)
+            expect(user.errors.messages[:email].first).to match error_message
           end
         end
       end


### PR DESCRIPTION
The model shouldn't know the full path to the locale error messages,
they should be derived upon validation.