### PR TITLE
Stub out the requests before each context

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -92,6 +92,9 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:all) do
     WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
   end
 


### PR DESCRIPTION
From my reading of:

https://www.relishapp.com/rspec/rspec-core/v/3-2/docs/hooks/before-and-after-hooks

it seems that having the stubs set before each context, fixes the
intermitten failures.