### PR TITLE
Set feedback to retain deleted users details

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,5 +1,5 @@
 class Feedback < ActiveRecord::Base
-  belongs_to :user
+  belongs_to :user, -> { with_deleted }
   belongs_to :office
   validates :user_id, :office_id, presence: true
 

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -81,12 +81,21 @@ RSpec.describe FeedbackController, type: :controller do
 
     describe 'GET #index' do
       before(:each) { get :index }
-      it 'returns http redirect' do
+      it 'returns http success' do
         expect(response).to have_http_status(:success)
       end
 
-      it 'redirects to the sign in page' do
+      it 'renders the correct template' do
         expect(response).to render_template(:index)
+      end
+
+      context 'when there is feedback from a deleted user' do
+        let(:user) { create :deleted_user, office: create(:office) }
+        before { create(:feedback, ideas: 'None', user: user, office: user.office) }
+
+        it 'renders the correct template' do
+          expect(response).to render_template(:index)
+        end
       end
     end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,5 +16,8 @@ FactoryGirl.define do
       email nil
       name nil
     end
+    factory :deleted_user do
+      deleted_at Time.zone.yesterday
+    end
   end
 end


### PR DESCRIPTION
When feedback was displayed, if a deleted user had left 
feedback the page would error.  This sets the association to 
include with_deleted to prevent the error.