### PR TITLE
Fix for migration error

### DIFF
--- a/db/migrate/20150910151042_add_expires_at_to_spotcheck.rb
+++ b/db/migrate/20150910151042_add_expires_at_to_spotcheck.rb
@@ -2,10 +2,12 @@ class AddExpiresAtToSpotcheck < ActiveRecord::Migration
   def up
     add_column :spotchecks, :expires_at, :datetime
 
-    EvidenceCheck.all.each do |spotcheck|
-      expires_at = spotcheck.created_at + Settings.spotcheck.expires_in_days.days
-      spotcheck.update(expires_at: expires_at)
-    end
+    migrate_sql = <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE spotchecks
+      |SET expires_at =
+      |  created_at + CAST('#{Settings.evidence_check.expires_in_days} days' AS INTERVAL);
+    SQL
+    execute(migrate_sql)
 
     change_column_null :spotchecks, :expires_at, false
   end


### PR DESCRIPTION
Previous migration script ran a per object script
A the object was renamed, it could not resolve the object to
the database. I switched it to a sql script to run purely
agains the table and it now works on local machines.

Lets see how branch builder does...