### PR TITLE
Remove rubocop exclusion

### DIFF
--- a/spec/models/form_object_spec.rb
+++ b/spec/models/form_object_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe FormObject do
 
-  # rubocop:disable ClassAndModuleChildren
   class FormTestClass < FormObject
     def self.permitted_attributes
       { id: Integer, fee: Integer }


### PR DESCRIPTION
This is not needed after a renaming of the object and
was generating a reubocop warning