### PR TITLE
Evidence income form view

### DIFF
--- a/app/models/evidence/forms/income.rb
+++ b/app/models/evidence/forms/income.rb
@@ -1,0 +1,16 @@
+module Evidence
+  module Forms
+    class Income < ::FormObject
+
+      def self.permitted_attributes
+        {
+          income: String
+        }
+      end
+
+      define_attributes
+
+      validates :income, presence: true
+    end
+  end
+end

--- a/app/models/evidence/forms/income.rb
+++ b/app/models/evidence/forms/income.rb
@@ -4,14 +4,14 @@ module Evidence
 
       def self.permitted_attributes
         {
-          income: String
+          amount: String
         }
       end
 
       define_attributes
 
-      validates :income, presence: true
-      validates :income, numericality: { greater_than_or_equal_to: 0 }
+      validates :amount, presence: true
+      validates :amount, numericality: { greater_than_or_equal_to: 0 }
     end
   end
 end

--- a/app/models/evidence/forms/income.rb
+++ b/app/models/evidence/forms/income.rb
@@ -2,6 +2,8 @@ module Evidence
   module Forms
     class Income < ::FormObject
 
+      include ActiveModel::Validations::Callbacks
+
       def self.permitted_attributes
         {
           amount: String
@@ -10,8 +12,16 @@ module Evidence
 
       define_attributes
 
-      validates :amount, presence: true
+      before_validation :format_amount
+
       validates :amount, numericality: { greater_than_or_equal_to: 0 }
+
+      private
+
+      def format_amount
+        self.amount = amount.to_f.round
+      end
+
     end
   end
 end

--- a/app/models/evidence/forms/income.rb
+++ b/app/models/evidence/forms/income.rb
@@ -11,6 +11,7 @@ module Evidence
       define_attributes
 
       validates :income, presence: true
+      validates :income, numericality: { greater_than_or_equal_to: 0 }
     end
   end
 end

--- a/spec/models/evidence/forms/income_spec.rb
+++ b/spec/models/evidence/forms/income_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Evidence::Forms::Income do
+  params_list = %i[income]
+
+  let(:income) { { income: '500' } }
+  subject { described_class.new(income) }
+
+  describe '.permitted_attributes' do
+    it 'returns a list of attributes' do
+      expect(described_class.permitted_attributes.keys).to match_array(params_list)
+    end
+  end
+
+  describe 'validation' do
+    it { is_expected.to validate_presence_of(:income) }
+  end
+end

--- a/spec/models/evidence/forms/income_spec.rb
+++ b/spec/models/evidence/forms/income_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Evidence::Forms::Income do
-  params_list = %i[income]
+  params_list = %i[amount]
 
-  let(:income) { { income: '500' } }
+  let(:income) { { amount: '500' } }
   subject { described_class.new(income) }
 
   describe '.permitted_attributes' do
@@ -13,22 +13,22 @@ RSpec.describe Evidence::Forms::Income do
   end
 
   describe 'validation' do
-    it { is_expected.to validate_presence_of(:income) }
+    it { is_expected.to validate_presence_of(:amount) }
 
     context 'when the income is 0' do
-      let(:income) { { income: '0' } }
+      let(:income) { { amount: '0' } }
 
       it { expect(subject.valid?).to be true }
     end
 
     context 'when the income is negative' do
-      let(:income) { { income: '-1' } }
+      let(:income) { { amount: '-1' } }
 
       it { expect(subject.valid?).to be false }
     end
 
     context 'when the income is string' do
-      let(:income) { { income: 'a string' } }
+      let(:income) { { amount: 'a string' } }
 
       it { expect(subject.valid?).to be false }
     end

--- a/spec/models/evidence/forms/income_spec.rb
+++ b/spec/models/evidence/forms/income_spec.rb
@@ -14,5 +14,23 @@ RSpec.describe Evidence::Forms::Income do
 
   describe 'validation' do
     it { is_expected.to validate_presence_of(:income) }
+
+    context 'when the income is 0' do
+      let(:income) { { income: '0' } }
+
+      it { expect(subject.valid?).to be true }
+    end
+
+    context 'when the income is negative' do
+      let(:income) { { income: '-1' } }
+
+      it { expect(subject.valid?).to be false }
+    end
+
+    context 'when the income is string' do
+      let(:income) { { income: 'a string' } }
+
+      it { expect(subject.valid?).to be false }
+    end
   end
 end

--- a/spec/models/evidence/forms/income_spec.rb
+++ b/spec/models/evidence/forms/income_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe Evidence::Forms::Income do
   end
 
   describe 'validation' do
-    it { is_expected.to validate_presence_of(:amount) }
-
     context 'when the income is 0' do
       let(:income) { { amount: '0' } }
 
@@ -27,10 +25,29 @@ RSpec.describe Evidence::Forms::Income do
       it { expect(subject.valid?).to be false }
     end
 
+    context 'when income is a Float' do
+      before(:each) { subject.valid? }
+
+      context 'round up' do
+        let(:income) { { amount: '0.5' } }
+
+        it { expect(subject.amount).to eq '1' }
+      end
+
+      context 'round down' do
+        let(:income) { { amount: '0.49' } }
+
+        it { expect(subject.amount).to eq '0' }
+      end
+    end
+
     context 'when the income is string' do
+      before { subject.valid? }
       let(:income) { { amount: 'a string' } }
 
-      it { expect(subject.valid?).to be false }
+      it 'turns the string into 0' do
+        expect(subject.amount).to eq '0'
+      end
     end
   end
 end


### PR DESCRIPTION
Despite what the branch name says, this is the Income form object.
It's to be used to validate the Income amount the user provides when assessing the evidence based check.