### PR TITLE
Partial views for results

### DIFF
--- a/app/assets/stylesheets/dwp_checks.scss
+++ b/app/assets/stylesheets/dwp_checks.scss
@@ -17,11 +17,14 @@
     color: $page-colour;
     margin: 0;
   }
-  &.not-received, &.no {
+  &.not-received, &.no, &.callout-none {
     background-color: $error-colour;
   }
-  &.received, &.yes {
+  &.received, &.yes, &.callout-full {
     background-color: $turquoise;
+  }
+  &.callout-part {
+    background: $orange;
   }
   p
   {

--- a/app/models/evidence/views/overview.rb
+++ b/app/models/evidence/views/overview.rb
@@ -2,7 +2,8 @@ module Evidence
   module Views
     class Overview
 
-      APPLICATION_ATTRS = %i[date_of_birth reference full_name ni_number date_received form_name]
+      APPLICATION_ATTRS = %i[date_of_birth reference full_name ni_number
+                             date_received form_name amount_to_pay]
       APPLICATION_ATTRS.each do |attr|
         define_method(attr) do
           @evidence.application.send(attr)
@@ -60,6 +61,10 @@ module Evidence
           'true' => '&#10003; Passed',
           'false' => '&#10007; Failed'
         }[@evidence.application.savings_investment_valid?.to_s]
+      end
+
+      def result
+        @evidence.application.application_outcome
       end
     end
   end

--- a/app/views/evidence/show.html.slim
+++ b/app/views/evidence/show.html.slim
@@ -4,7 +4,7 @@ h2 Waiting for evidence
   .small-12.medium-6.columns
     .panel
       h4 Process evidence
-      # You'll need the applicant's evidence of income
+      #note You'll need the applicant's evidence of income
       a.button.success href='#' Start now
 
   .summary-section
@@ -71,3 +71,5 @@ h2 Waiting for evidence
     .row
       .small-12.medium-5.large-4.columns.subheader Total monthly income
       .small-12.medium-7.large-8.columns £#{@overview.total_monthly_income}
+
+  =render(partial: 'shared/remission_type', locals: { source: @overview })

--- a/app/views/shared/_remission_type.html.slim
+++ b/app/views/shared/_remission_type.html.slim
@@ -1,0 +1,2 @@
+#result.callout class="callout-#{source.result}"
+  h3.bold =t("remissions.#{source.result}", amount_to_pay: source.amount_to_pay).html_safe

--- a/spec/models/evidence/views/overview_spec.rb
+++ b/spec/models/evidence/views/overview_spec.rb
@@ -107,4 +107,24 @@ RSpec.describe Evidence::Views::Overview do
       it { expect(overview.savings).to eq '&#10007; Failed' }
     end
   end
+
+  describe '#result' do
+    context 'when the application is a full remission' do
+      before { allow(application).to receive(:application_outcome).and_return('full') }
+
+      it { expect(overview.result).to eq 'full' }
+    end
+
+    context 'when the application is a part remission' do
+      before { allow(application).to receive(:application_outcome).and_return('part') }
+
+      it { expect(overview.result).to eq 'part' }
+    end
+
+    context 'when the application is a full remission' do
+      before { allow(application).to receive(:application_outcome).and_return('none') }
+
+      it { expect(overview.result).to eq 'none' }
+    end
+  end
 end


### PR DESCRIPTION
Added the result partials.
I also extended the overview class to add amount_to_pay
(needed for a partial remission) and a required_partial
method.   This allows the view to render a partial depending
on the data in the application model within the overview.

It always passes in the amount to pay because,
if it's not needed it is ignored, but in a partial it merges it.