### PR TITLE
Split overview with partials

### DIFF
--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -1,0 +1,34 @@
+module SummaryHelper
+
+  def build_section(summary_text, object, fields)
+    content_tag(:div, class: 'summary-section') do
+      content = build_header summary_text
+      fields.each do |row|
+        content << build_data_row(object, row)
+      end
+      content
+    end
+  end
+
+  private
+
+  def build_header(summary_name)
+    content_tag(:div, class: 'row') do
+      content_tag(:div, class: 'small-12 medium-7 large-8 columns') do
+        content_tag(:h4, "#{summary_name}")
+      end
+    end
+  end
+
+  def build_data_row(object, field)
+    label = I18n.t("activemodel.attributes.#{object.class.name.underscore}.#{field}")
+    value = object.send(field)
+
+    rows = content_tag(:div, label, class: 'small-12 medium-5 large-4 columns subheader')
+    rows << content_tag(:div, "#{value}".html_safe, class: 'small-12 medium-7 large-8 columns')
+
+    content_tag(:div, class: 'row') do
+      rows
+    end
+  end
+end

--- a/app/models/evidence/views/overview.rb
+++ b/app/models/evidence/views/overview.rb
@@ -37,7 +37,7 @@ module Evidence
       end
 
       def fee
-        @evidence.application.fee.round
+        "£#{@evidence.application.fee.round}"
       end
 
       def number_of_children
@@ -45,7 +45,7 @@ module Evidence
       end
 
       def total_monthly_income
-        @evidence.application.income.round
+        "£#{@evidence.application.income.round}"
       end
 
       def income

--- a/app/views/evidence/show.html.slim
+++ b/app/views/evidence/show.html.slim
@@ -7,69 +7,9 @@ h2 Waiting for evidence
       #note You'll need the applicant's evidence of income
       a.button.success href='#' Start now
 
-  .summary-section
-    .row
-      .small-12.medium-7.large-8.columns
-        h4 Processing details
-    .row
-      .small-12.medium-5.large-4.columns.subheader Reference
-      .small-12.medium-7.large-8.columns =@overview.reference
-    .row
-      .small-12.medium-5.large-4.columns.subheader Processed by
-      .small-12.medium-7.large-8.columns =@overview.processed_by
-    .row
-      .small-12.medium-5.large-4.columns.subheader Expires
-      .small-12.medium-7.large-8.columns =@overview.expires
-
-  .summary-section
-    .row
-      .small-12.medium-7.large-8.columns
-        h4 Personal details
-    .row
-      .small-12.medium-5.large-4.columns.subheader Full name
-      .small-12.medium-7.large-8.columns =@overview.full_name
-    .row
-      .small-12.medium-5.large-4.columns.subheader Date of birth
-      .small-12.medium-7.large-8.columns =@overview.date_of_birth
-    .row
-      .small-12.medium-5.large-4.columns.subheader NI number
-      .small-12.medium-7.large-8.columns =@overview.ni_number
-    .row
-      .small-12.medium-5.large-4.columns.subheader Status
-      .small-12.medium-7.large-8.columns =@overview.status
-
-  .summary-section
-    .row
-      .small-12.medium-7.large-8.columns
-        h4 Application details
-    .row
-      .small-12.medium-5.large-4.columns.subheader Fee
-      .small-12.medium-7.large-8.columns  £#{@overview.fee}
-    .row
-      .small-12.medium-5.large-4.columns.subheader Jurisdiction
-      .small-12.medium-7.large-8.columns =@overview.jurisdiction
-    .row
-      .small-12.medium-5.large-4.columns.subheader Date application received
-      .small-12.medium-7.large-8.columns =@overview.date_received
-    .row
-      .small-12.medium-5.large-4.columns.subheader Form name or number
-      .small-12.medium-7.large-8.columns =@overview.form_name
-
-  .summary-section
-    .row
-      .small-12.medium-7.large-8.columns
-        h4 Assessment
-    .row
-      .small-12.medium-5.large-4.columns.subheader Savings and investments
-      .small-12.medium-7.large-8.columns =@overview.savings.html_safe
-    .row
-      .small-12.medium-5.large-4.columns.subheader Income
-      .small-12.medium-7.large-8.columns =@overview.income.html_safe
-    .row
-      .small-12.medium-5.large-4.columns.subheader Number of Children
-      .small-12.medium-7.large-8.columns =@overview.number_of_children
-    .row
-      .small-12.medium-5.large-4.columns.subheader Total monthly income
-      .small-12.medium-7.large-8.columns £#{@overview.total_monthly_income}
+  =build_section 'Processing details', @overview, %w[reference processed_by expires]
+  =build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status]
+  =build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name]
+  =build_section 'Assessment', @overview, %w[savings income number_of_children total_monthly_income]
 
   =render(partial: 'shared/remission_type', locals: { source: @overview })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -153,6 +153,22 @@ en-GB:
         <p>%{user_name}</p>
   activemodel:
     attributes:
+      evidence/views/overview:
+        reference: Reference
+        processed_by: Processed by
+        expires: Expires
+        full_name: Full name
+        date_of_birth: Date of birth
+        ni_number: NI Number
+        status: Status
+        fee: Fee
+        jurisdiction: Jurisdiction
+        date_received: Date received
+        form_name: Form name or number
+        savings: Savings and investments
+        income: Income
+        number_of_children: Number of Children
+        total_monthly_income: Total monthly income
       applikation/forms/benefit:
         benefits: Is the applicant receiving one of the benefits listed in question 9?
       applikation/forms/income:

--- a/spec/helpers/summary_helper_spec.rb
+++ b/spec/helpers/summary_helper_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe SummaryHelper, type: :helper do
+
+  it { expect(helper).to be_a described_class }
+
+  describe '#build_section' do
+    context 'when passed a name and an overview object' do
+      let(:name) { 'Section name' }
+      let(:evidence) { build_stubbed(:evidence_check) }
+      let(:overview) { Evidence::Views::Overview.new(evidence) }
+      it 'returns the correct html' do
+        expected = '<div class="summary-section"><div class="row"><div class="small-12 medium-7 large-8 columns"><h4>section name</h4></div></div><div class="row"><div class="small-12 medium-5 large-4 columns subheader">Fee</div><div class="small-12 medium-7 large-8 columns">£310</div></div></div>'
+        expect(helper.build_section('section name', overview, %w[fee])).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/models/evidence/views/overview_spec.rb
+++ b/spec/models/evidence/views/overview_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Evidence::Views::Overview do
       let(:fee_amount) { 100.49 }
 
       it 'formats the fee amount correctly' do
-        expect(overview.fee).to eq 100
+        expect(overview.fee).to eq '£100'
       end
     end
 
@@ -65,7 +65,7 @@ RSpec.describe Evidence::Views::Overview do
       let(:fee_amount) { 0.49 }
 
       it 'formats the fee amount correctly' do
-        expect(overview.fee).to eq 0
+        expect(overview.fee).to eq '£0'
       end
     end
   end


### PR DESCRIPTION
To improve re-usability and simplify the views, the
evidence overview page has been refactored into 
a helper.

This required setting up new locale entries for the
overview object.