### PR TITLE
Styling evidence summary pages

### DIFF
--- a/app/assets/stylesheets/summary.scss
+++ b/app/assets/stylesheets/summary.scss
@@ -4,4 +4,17 @@ div.summary-section {
   border-bottom: solid 1px $grey-2;
   margin-bottom: 1em;
   padding-bottom: .5em;
+
+  .summary-result{
+    font-weight: bold;
+    &.full {
+      color: $turquoise;
+    }
+    &.part {
+      color: $orange;
+    }
+    &.none {
+      color: $error-colour;
+    }
+  }
 }

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -24,11 +24,18 @@ module SummaryHelper
     label = I18n.t("activemodel.attributes.#{object.class.name.underscore}.#{field}")
     value = object.send(field)
 
+    value_classes = 'small-12 medium-7 large-8 columns'
+    value_classes << " summary-result #{object.result}" if value_needs_styling?(value)
+
     rows = content_tag(:div, label, class: 'small-12 medium-5 large-4 columns subheader')
-    rows << content_tag(:div, "#{value}".html_safe, class: 'small-12 medium-7 large-8 columns')
+    rows << content_tag(:div, value, class: value_classes)
 
     content_tag(:div, class: 'row') do
       rows
     end
+  end
+
+  def value_needs_styling?(value)
+    %w[✓ ✗].any? { |char| value.to_s.include? char }
   end
 end

--- a/app/models/evidence/views/overview.rb
+++ b/app/models/evidence/views/overview.rb
@@ -50,16 +50,16 @@ module Evidence
 
       def income
         {
-          'full' => '&#10003; Passed',
-          'part' => '&#10003; Passed',
-          'none' => '&#10007; Failed'
+          'full' => I18n.t('activerecord.attributes.application.summary.passed'),
+          'part' => I18n.t('activerecord.attributes.application.summary.passed'),
+          'none' => I18n.t('activerecord.attributes.application.summary.failed')
         }[@evidence.application.application_outcome]
       end
 
       def savings
         {
-          'true' => '&#10003; Passed',
-          'false' => '&#10007; Failed'
+          'true' => I18n.t('activerecord.attributes.application.summary.passed'),
+          'false' => I18n.t('activerecord.attributes.application.summary.failed')
         }[@evidence.application.savings_investment_valid?.to_s]
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,9 +52,9 @@ en-GB:
       wrong_office: You are not authorized to manage this user.
   benefit_checks:
     :yes:
-      heading: '&#10003; &nbsp; The applicant is receiving the correct benefits'
+      heading: '✓ &nbsp; The applicant is receiving the correct benefits'
     :no:
-      heading: '&#10007; &nbsp; The applicant is not receiving benefits'
+      heading: '✗ &nbsp; The applicant is not receiving benefits'
     details_missing:
       heading: DWP check couldn't be performed, please make sure you've provided all personal details including National Insurance number
     deleted:
@@ -85,9 +85,9 @@ en-GB:
       explain: There’s a technical fault with the Department for Work and Pensions checker. Complete processing and check again later.
       progress: <span class="bold">Emergency application?</span> You can also ask the applicant to provide evidence confirming that they’re receiving benefits.
   remissions:
-    full: '&#10003; &nbsp; The applicant doesn’t have to pay the fee'
+    full: '✓ &nbsp; The applicant doesn’t have to pay the fee'
     part: The applicant must pay %{amount_to_pay} towards the fee
-    none: '&#10007; &nbsp; The applicant must pay the full fee'
+    none: '✗ &nbsp; The applicant must pay the full fee'
     error: An error occured in the calculation
   evidence_check:
     callout: This application has been chosen for investigation. You’ll need to ask for supporting evidence.
@@ -385,8 +385,8 @@ en-GB:
         income_page:
           header: Application result
         summary:
-          passed: '&#10003; Passed'
-          failed: '&#10007; Failed'
+          passed: '✓ Passed'
+          failed: '✗ Failed'
           savings_investments: Savings and investments
           benefits: Benefits
           income: Income

--- a/spec/models/evidence/views/overview_spec.rb
+++ b/spec/models/evidence/views/overview_spec.rb
@@ -76,19 +76,19 @@ RSpec.describe Evidence::Views::Overview do
     context 'when the application is a full remission' do
       let(:outcome) { 'full' }
 
-      it { expect(overview.income).to eq '&#10003; Passed' }
+      it { expect(overview.income).to eq '✓ Passed' }
     end
 
     context 'when the application is a part remission' do
       let(:outcome) { 'part' }
 
-      it { expect(overview.income).to eq '&#10003; Passed' }
+      it { expect(overview.income).to eq '✓ Passed' }
     end
 
     context 'when the application is a non remission' do
       let(:outcome) { 'none' }
 
-      it { expect(overview.income).to eq '&#10007; Failed' }
+      it { expect(overview.income).to eq '✗ Failed' }
     end
   end
 
@@ -98,13 +98,13 @@ RSpec.describe Evidence::Views::Overview do
     context 'when the application has valid savings and investments' do
       let(:result) { true }
 
-      it { expect(overview.savings).to eq '&#10003; Passed' }
+      it { expect(overview.savings).to eq '✓ Passed' }
     end
 
     context 'when the application does not have valid savings and investments' do
       let(:result) { false }
 
-      it { expect(overview.savings).to eq '&#10007; Failed' }
+      it { expect(overview.savings).to eq '✗ Failed' }
     end
   end
 


### PR DESCRIPTION
Added css styling to the new summary page to match
the design.

Checks for ✓ or ✗ in the value and applies the current 
result (full, part or none) to the value row.

The styles are updated to ensure that the names match
the (current) outcomes.