### PR TITLE
Implement evidence calculation result

### DIFF
--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -19,6 +19,10 @@ class EvidenceController < ApplicationController
     income_form_save
   end
 
+  def result
+    evidence_result
+  end
+
   private
 
   def prepare_evidence
@@ -28,6 +32,11 @@ class EvidenceController < ApplicationController
   def evidence_overview
     prepare_evidence
     @overview = Evidence::Views::Overview.new(@evidence)
+  end
+
+  def evidence_result
+    prepare_evidence
+    @result = Evidence::Views::Result.new(@evidence)
   end
 
   def accuracy_form

--- a/app/models/evidence/views/result.rb
+++ b/app/models/evidence/views/result.rb
@@ -1,0 +1,18 @@
+module Evidence
+  module Views
+    class Result
+
+      def initialize(evidence)
+        @evidence = evidence
+      end
+
+      def result
+        %w[full part none].include?(@evidence.outcome) ? @evidence.outcome : 'error'
+      end
+
+      def amount_to_pay
+        "£#{@evidence.amount_to_pay.round}" if @evidence.amount_to_pay.present?
+      end
+    end
+  end
+end

--- a/app/views/evidence/result.html.slim
+++ b/app/views/evidence/result.html.slim
@@ -1,0 +1,7 @@
+.row
+  .columns.small-12
+    h2 Income
+
+=render(partial: 'shared/remission_type', locals: { source: @result })
+
+= link_to 'Next', 'evidence_summary_path_when_set', class: 'button success'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   post 'evidence/:id/accuracy_save', to: 'evidence#accuracy_save', as: :evidence_accuracy_save
   get 'evidence/:id/income', to: 'evidence#income', as: :evidence_income
   post 'evidence/:id/income_save', to: 'evidence#income_save', as: :evidence_income_save
+  get 'evidence/:id/result', to: 'evidence#result', as: :evidence_result
 
   resources :evidence_checks, only: :show
 

--- a/spec/factories/evidence_checks.rb
+++ b/spec/factories/evidence_checks.rb
@@ -2,5 +2,7 @@ FactoryGirl.define do
   factory :evidence_check do
     application
     expires_at { rand(3..7).days.from_now }
+    outcome nil
+    amount_to_pay nil
   end
 end

--- a/spec/models/evidence/views/result_spec.rb
+++ b/spec/models/evidence/views/result_spec.rb
@@ -1,0 +1,69 @@
+# coding: utf-8
+require 'rails_helper'
+
+RSpec.describe Evidence::Views::Result do
+
+  let(:application) { build_stubbed(:application) }
+  let(:evidence) { build_stubbed(:evidence_check) }
+  let(:review) { described_class.new(evidence) }
+
+  before { allow(evidence).to receive(:application).and_return(application) }
+
+  context 'required methods' do
+    symbols = %i[result amount_to_pay]
+
+    symbols.each do |symbol|
+      it 'has the method #{symbol}' do
+        expect(review.methods).to include(symbol)
+      end
+    end
+  end
+
+  describe '#amount_to_pay' do
+    before { allow(evidence).to receive(:amount_to_pay).and_return(amount) }
+
+    context 'rounds down' do
+      let(:amount) { 100.49 }
+
+      it 'formats the fee amount correctly' do
+        expect(review.amount_to_pay).to eq '£100'
+      end
+    end
+
+    context 'when its under £1' do
+      let(:amount) { 0.49 }
+
+      it 'formats the fee amount correctly' do
+        expect(review.amount_to_pay).to eq '£0'
+      end
+    end
+
+    context 'returns nil if amount_to_pay is nil' do
+      let(:amount) { nil }
+
+      it 'returns nil' do
+        expect(review.amount_to_pay).to eq nil
+      end
+    end
+  end
+
+  describe '#result' do
+    context 'when the application is a full remission' do
+      before { allow(evidence).to receive(:outcome).and_return('full') }
+
+      it { expect(review.result).to eq 'full' }
+    end
+
+    context 'when the application is a part remission' do
+      before { allow(evidence).to receive(:outcome).and_return('part') }
+
+      it { expect(review.result).to eq 'part' }
+    end
+
+    context 'when the application is a full remission' do
+      before { allow(evidence).to receive(:outcome).and_return('none') }
+
+      it { expect(review.result).to eq 'none' }
+    end
+  end
+end


### PR DESCRIPTION
Added a Result view model, it returns the EvidenceCheck.outcome 
and amount to pay.

This is rendered on the view using the remission partial.

The EvidenceCheck factory was updated to include the outcome
and amount_to_pay fields.