### PR TITLE
Waiting for evidence dashboard

### DIFF
--- a/app/assets/stylesheets/evidence_check.scss
+++ b/app/assets/stylesheets/evidence_check.scss
@@ -19,3 +19,7 @@
   background-color: $grey-4;
   padding: $gutter-half;
 }
+
+.waiting-for-evidence {
+  width: 100%;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,5 @@ class ApplicationController < ActionController::Base
   def evidence_check_enabled?
     Settings.evidence_check.enabled == true
   end
+  helper_method :evidence_check_enabled?
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,5 +22,4 @@ class ApplicationController < ActionController::Base
   def evidence_check_enabled?
     Settings.evidence_check.enabled == true
   end
-  helper_method :evidence_check_enabled?
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -23,7 +23,7 @@ class HomeController < ApplicationController
   end
 
   def load_applications_waiting_for_evidence
-    unless current_user.admin?
+    if evidence_check_enabled? && !current_user.admin?
       @waiting_for_evidence = current_user.office.applications.waiting_for_evidence
     end
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,8 +2,19 @@ class HomeController < ApplicationController
   before_action :authenticate_user!, only: [:index]
 
   def index
+    manager_setup_progress
+    load_graphs_for_admin
+    load_applications_waiting_for_evidence
+  end
+
+  private
+
+  def manager_setup_progress
     manager_setup = ManagerSetup.new(current_user, session)
     manager_setup.finish! if manager_setup.in_progress?
+  end
+
+  def load_graphs_for_admin
     if current_user.admin?
       load_graph_data
       @total_type_count = BenefitCheck.group(:dwp_result).count
@@ -11,7 +22,9 @@ class HomeController < ApplicationController
     end
   end
 
-  private
+  def load_applications_waiting_for_evidence
+    @waiting_for_evidence = current_user.office.applications.waiting_for_evidence
+  end
 
   def load_graph_data
     @report_data = []

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -23,7 +23,9 @@ class HomeController < ApplicationController
   end
 
   def load_applications_waiting_for_evidence
-    @waiting_for_evidence = current_user.office.applications.waiting_for_evidence
+    unless current_user.admin?
+      @waiting_for_evidence = current_user.office.applications.waiting_for_evidence
+    end
   end
 
   def load_graph_data

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -24,8 +24,17 @@ class HomeController < ApplicationController
 
   def load_applications_waiting_for_evidence
     if evidence_check_enabled? && !current_user.admin?
-      @waiting_for_evidence = current_user.office.applications.waiting_for_evidence
+      @evidence_enabled = true
+      @waiting_for_evidence = waiting_for_evidence.map do |application|
+        Evidence::Views::Overview.new(application.evidence_check)
+      end
+    else
+      @evidence_enabled = false
     end
+  end
+
+  def waiting_for_evidence
+    current_user.office.applications.waiting_for_evidence
   end
 
   def load_graph_data

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -12,6 +12,10 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     where(benefits: false, application_type: 'income', application_outcome: %w[part full])
   }
 
+  scope :waiting_for_evidence, lambda {
+    includes(:evidence_check).references(:evidence_check).where.not(evidence_checks: { id: nil })
+  }
+
   MAX_AGE = 120
   MIN_AGE = 16
 

--- a/app/models/evidence/views/overview.rb
+++ b/app/models/evidence/views/overview.rb
@@ -1,6 +1,7 @@
 module Evidence
   module Views
     class Overview
+      attr_reader :evidence
 
       APPLICATION_ATTRS = %i[date_of_birth reference full_name ni_number
                              date_received form_name amount_to_pay]

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -1,5 +1,6 @@
 class Office < ActiveRecord::Base
   has_many :users
+  has_many :applications
   has_many :office_jurisdictions
   has_many :jurisdictions, through: :office_jurisdictions
 

--- a/app/views/home/_manager.html.slim
+++ b/app/views/home/_manager.html.slim
@@ -8,11 +8,6 @@
     .actions
       =link_to 'Start now', new_application_path, class: 'button success'
 
-    h3.pad-top-thirty-px.bold Manage your office 
-    p =link_to 'Staff overview', users_path
-    p =link_to 'Your Office', current_user.office
-     
-  
   .small-12.medium-8.large-5.columns
     .info-box
       h3.bold Get Help
@@ -22,3 +17,13 @@
         summary
           span.summary Contact us
         div Email: #{link_to Settings.mail.tech_support, "mailto:#{Settings.mail.tech_support}"}
+
+.row
+  .small-12.medium-12.large-12.columns
+    =render('home/waiting_for_evidence')
+
+.row
+  .small-12.medium-12.large-12.columns
+    h3.pad-top-thirty-px.bold Manage your office
+    p =link_to 'Staff overview', users_path
+    p =link_to 'Your Office', current_user.office

--- a/app/views/home/_manager.html.slim
+++ b/app/views/home/_manager.html.slim
@@ -20,10 +20,10 @@
 
 .row
   .small-12.medium-12.large-12.columns
-    =render('home/waiting_for_evidence')
-
-.row
-  .small-12.medium-12.large-12.columns
     h3.pad-top-thirty-px.bold Manage your office
     p =link_to 'Staff overview', users_path
     p =link_to 'Your Office', current_user.office
+
+.row
+  .small-12.medium-12.large-12.columns
+    =render('home/waiting_for_evidence')

--- a/app/views/home/_user.html.slim
+++ b/app/views/home/_user.html.slim
@@ -1,0 +1,18 @@
+.small-12.medium-8.large-5.columns
+  h2.pad-top-thirty-px.bold Process application
+  p You'll need:
+  ul
+    li the help with fees application form (EX160)
+    li the court or tribunal form related to the application
+  .actions
+    =link_to 'Start now', new_application_path, class: 'button success'
+
+.small-12.medium-8.large-5.columns
+  .info-box
+    h3.bold Get Help
+    p =link_to t('functions.staff_guide').to_s, guide_path
+    p =link_to t('functions.feedback').to_s, feedback_path
+    details
+      summary
+        span.summary Contact us
+      div Email: #{link_to Settings.mail.tech_support, "mailto:#{Settings.mail.tech_support}"}

--- a/app/views/home/_user.html.slim
+++ b/app/views/home/_user.html.slim
@@ -1,18 +1,23 @@
-.small-12.medium-8.large-5.columns
-  h2.pad-top-thirty-px.bold Process application
-  p You'll need:
-  ul
-    li the help with fees application form (EX160)
-    li the court or tribunal form related to the application
-  .actions
-    =link_to 'Start now', new_application_path, class: 'button success'
+.row
+  .small-12.medium-8.large-5.columns
+    h2.pad-top-thirty-px.bold Process application
+    p You'll need:
+    ul
+      li the help with fees application form (EX160)
+      li the court or tribunal form related to the application
+    .actions
+      =link_to 'Start now', new_application_path, class: 'button success'
 
-.small-12.medium-8.large-5.columns
-  .info-box
-    h3.bold Get Help
-    p =link_to t('functions.staff_guide').to_s, guide_path
-    p =link_to t('functions.feedback').to_s, feedback_path
-    details
-      summary
-        span.summary Contact us
-      div Email: #{link_to Settings.mail.tech_support, "mailto:#{Settings.mail.tech_support}"}
+  .small-12.medium-8.large-5.columns
+    .info-box
+      h3.bold Get Help
+      p =link_to t('functions.staff_guide').to_s, guide_path
+      p =link_to t('functions.feedback').to_s, feedback_path
+      details
+        summary
+          span.summary Contact us
+        div Email: #{link_to Settings.mail.tech_support, "mailto:#{Settings.mail.tech_support}"}
+
+.row
+  .small-12.medium-12.large-12.columns
+    =render('home/waiting_for_evidence')

--- a/app/views/home/_waiting_for_evidence.html.slim
+++ b/app/views/home/_waiting_for_evidence.html.slim
@@ -1,20 +1,21 @@
-h3 Waiting for evidence
+- if evidence_check_enabled?
+  h3 Waiting for evidence
 
-- if @waiting_for_evidence.present?
-  table.waiting-for-evidence
-    tr
-      th Reference
-      th Form
-      th Applicant
-      th Processed by
-      th Expires
-    - @waiting_for_evidence.each do |application|
+  - if @waiting_for_evidence.present?
+    table.waiting-for-evidence
       tr
-        td =link_to(application.reference, evidence_show_path(application.evidence_check))
-        td =application.form_name
-        td =application.full_name
-        td =application.user.name
-        td =application.evidence_check.expires_at.to_s(:gov_uk_long)
+        th Reference
+        th Form
+        th Applicant
+        th Processed by
+        th Expires
+      - @waiting_for_evidence.each do |application|
+        tr
+          td =link_to(application.reference, evidence_show_path(application.evidence_check))
+          td =application.form_name
+          td =application.full_name
+          td =application.user.name
+          td =application.evidence_check.expires_at.to_s(:gov_uk_long)
 
-- else
-  p There are no applications waiting for evidence
+  - else
+    p There are no applications waiting for evidence

--- a/app/views/home/_waiting_for_evidence.html.slim
+++ b/app/views/home/_waiting_for_evidence.html.slim
@@ -1,0 +1,20 @@
+h3 Waiting for evidence
+
+- if @waiting_for_evidence.present?
+  table.waiting-for-evidence
+    tr
+      th Reference
+      th Form
+      th Applicant
+      th Processed by
+      th Expires
+    - @waiting_for_evidence.each do |application|
+      tr
+        td =application.reference
+        td =application.form_name
+        td =application.full_name
+        td =application.user.name
+        td =application.evidence_check.expires_at.to_s(:gov_uk_long)
+
+- else
+  p There are no applications waiting for evidence

--- a/app/views/home/_waiting_for_evidence.html.slim
+++ b/app/views/home/_waiting_for_evidence.html.slim
@@ -10,7 +10,7 @@ h3 Waiting for evidence
       th Expires
     - @waiting_for_evidence.each do |application|
       tr
-        td =application.reference
+        td =link_to(application.reference, evidence_show_path(application.evidence_check))
         td =application.form_name
         td =application.full_name
         td =application.user.name

--- a/app/views/home/_waiting_for_evidence.html.slim
+++ b/app/views/home/_waiting_for_evidence.html.slim
@@ -1,21 +1,21 @@
-- if evidence_check_enabled?
-  h3 Waiting for evidence
+- if @evidence_enabled
+  h3 =t('evidence_check.dashboard.heading')
 
   - if @waiting_for_evidence.present?
     table.waiting-for-evidence
       tr
-        th Reference
-        th Form
-        th Applicant
-        th Processed by
-        th Expires
-      - @waiting_for_evidence.each do |application|
+        th =t('evidence_check.dashboard.table_header.reference')
+        th =t('evidence_check.dashboard.table_header.form_name')
+        th =t('evidence_check.dashboard.table_header.full_name')
+        th =t('evidence_check.dashboard.table_header.processed_by')
+        th =t('evidence_check.dashboard.table_header.expires')
+      - @waiting_for_evidence.each do |evidence|
         tr
-          td =link_to(application.reference, evidence_show_path(application.evidence_check))
-          td =application.form_name
-          td =application.full_name
-          td =application.user.name
-          td =application.evidence_check.expires_at.to_s(:gov_uk_long)
+          td =link_to(evidence.reference, evidence_show_path(evidence.evidence))
+          td =evidence.form_name
+          td =evidence.full_name
+          td =evidence.processed_by
+          td =evidence.expires
 
   - else
-    p There are no applications waiting for evidence
+    p =t('evidence_check.dashboard.no_evidence_checks')

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -7,24 +7,7 @@
   -elsif current_user.manager?
     =render 'home/manager'
   -else
-    .small-12.medium-8.large-5.columns
-      h2.pad-top-thirty-px.bold Process application
-      p You'll need:
-      ul 
-        li the help with fees application form (EX160) 
-        li the court or tribunal form related to the application
-      .actions
-        =link_to 'Start now', new_application_path, class: 'button success'
-
-    .small-12.medium-8.large-5.columns
-      .info-box
-        h3.bold Get Help
-        p =link_to t('functions.staff_guide').to_s, guide_path
-        p =link_to t('functions.feedback').to_s, feedback_path
-        details 
-          summary
-            span.summary Contact us
-          div Email: #{link_to Settings.mail.tech_support, "mailto:#{Settings.mail.tech_support}"}
+    =render 'home/user'
 -else
   .pad-top-thirty-px
     = link_to t('functions.log_in'), new_user_session_path, class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -154,6 +154,15 @@ en-GB:
         <p>Yours sincerely,</p>
 
         <p>%{user_name}</p>
+    dashboard:
+      heading: Waiting for evidence
+      no_evidence_checks: There are no applications waiting for evidence
+      table_header:
+        reference: Reference
+        form_name: Form
+        full_name: Applicant
+        processed_by: Processed by
+        expires: Expired
   activemodel:
     attributes:
       evidence/forms/evidence:
@@ -177,6 +186,9 @@ en-GB:
         income: Income
         number_of_children: Number of Children
         total_monthly_income: Total monthly income
+      evidence/views/dashboard:
+        form_name: Form
+        full_name: Applicant
       applikation/forms/benefit:
         benefits: Is the applicant receiving one of the benefits listed in question 9?
       applikation/forms/income:

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -16,6 +16,7 @@ FactoryGirl.define do
     income 500
     threshold_exceeded false
     refund false
+    user
 
     trait :probate do
       probate true

--- a/spec/features/evidence/applications_awaiting_evidence_are_displayed_on_dashboard_spec.rb
+++ b/spec/features/evidence/applications_awaiting_evidence_are_displayed_on_dashboard_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Applications awaiting evidence are displayed on dashboard', type:
   Warden.test_mode!
 
   let(:office) { create :office }
-  let(:user) { create :manager, office: office }
+  let(:user) { create :user, office: office }
 
   let(:application1) { create :application_full_remission, office: office }
   let!(:evidence1) { create :evidence_check, application: application1 }

--- a/spec/features/evidence/applications_awaiting_evidence_are_displayed_on_dashboard_spec.rb
+++ b/spec/features/evidence/applications_awaiting_evidence_are_displayed_on_dashboard_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'Applications awaiting evidence are displayed on dashboard', type: :feature do
+  enable_evidence_check
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let(:office) { create :office }
+  let(:user) { create :manager, office: office }
+
+  let(:application1) { create :application_full_remission, office: office }
+  let!(:evidence1) { create :evidence_check, application: application1 }
+  let(:application2) { create :application_full_remission, office: office }
+  let!(:evidence2) { create :evidence_check, application: application2 }
+  let(:other_application) { create :application_full_remission }
+  let!(:other_evidence) { create :evidence_check, application: other_application }
+
+  before do
+    login_as user
+  end
+
+  scenario 'User is presented the list of applications awaiting evidence only for their office' do
+    visit root_path
+
+    within '.waiting-for-evidence' do
+      expect(page).to have_content(application1.reference)
+      expect(page).to have_content(application2.reference)
+      expect(page).not_to have_content(other_application.reference)
+    end
+  end
+end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -199,6 +199,18 @@ RSpec.describe Application, type: :model do
         is_expected.to match_array([application_1, application_2])
       end
     end
+
+    describe '.waiting_for_evidence', focus: true do
+      let!(:application1) { create :application }
+      let!(:application2) { create :application }
+      let!(:evidence_check) { create :evidence_check, application: application1 }
+
+      subject { described_class.waiting_for_evidence }
+
+      it 'returns only applications which have EvidenceCheck reference' do
+        is_expected.to match_array([application1])
+      end
+    end
   end
 
   describe 'ni_number' do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Office, type: :model do
   let(:office)      { build :office }
 
   it { is_expected.to have_many(:users) }
+  it { is_expected.to have_many(:applications) }
   it { is_expected.to have_many(:office_jurisdictions) }
   it { is_expected.to have_many(:jurisdictions).through(:office_jurisdictions) }
 


### PR DESCRIPTION
It adds the list of applications waiting for evidence to the dashboard for managers and staff. 

I'm not particularly happy with some bits of the implementation, but I tried to re-use as much as possible from what we already have, so we can move on to the next bits of the evidence check flow. 

