### PR TITLE
Evidence summary page

### DIFF
--- a/app/assets/stylesheets/summary.scss
+++ b/app/assets/stylesheets/summary.scss
@@ -7,13 +7,13 @@ div.summary-section {
 
   .summary-result{
     font-weight: bold;
-    &.full {
+    &.full, &.passed {
       color: $turquoise;
     }
     &.part {
       color: $orange;
     }
-    &.none {
+    &.none, &.failed {
       color: $error-colour;
     }
   }

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -23,6 +23,12 @@ class EvidenceController < ApplicationController
     evidence_result
   end
 
+  def summary
+    evidence_view
+    evidence_overview
+    evidence_result
+  end
+
   private
 
   def prepare_evidence
@@ -32,6 +38,11 @@ class EvidenceController < ApplicationController
   def evidence_overview
     prepare_evidence
     @overview = Evidence::Views::Overview.new(@evidence)
+  end
+
+  def evidence_view
+    prepare_evidence
+    @evidence_view = Evidence::Views::Evidence.new(@evidence)
   end
 
   def accuracy_form
@@ -46,9 +57,17 @@ class EvidenceController < ApplicationController
     @form = Evidence::Forms::Evidence.new(evidence_params)
 
     if @form.save
-      redirect_to evidence_income_path
+      redirect_after_accuracy_save
     else
       render :accuracy
+    end
+  end
+
+  def redirect_after_accuracy_save
+    if @form.correct
+      redirect_to evidence_income_path
+    else
+      redirect_to evidence_summary_path
     end
   end
 

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -35,16 +35,12 @@ module SummaryHelper
   end
 
   def value_style(value)
-    base_class = 'small-12 medium-7 large-8 columns'
-    extended_class = case value.to_s
-                     when /✓/
-                       ' summary-result passed'
-                     when /✗/
-                       ' summary-result failed'
-                     else
-                       ''
-                     end
-
-    base_class + extended_class
+    ['small-12 medium-7 large-8 columns',
+     (
+      {
+        '✓' => ' summary-result passed',
+        '✗' => ' summary-result failed'
+      }[value.to_s.first] || '')
+    ].join
   end
 end

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -24,18 +24,27 @@ module SummaryHelper
     label = I18n.t("activemodel.attributes.#{object.class.name.underscore}.#{field}")
     value = object.send(field)
 
-    value_classes = 'small-12 medium-7 large-8 columns'
-    value_classes << " summary-result #{object.result}" if value_needs_styling?(value)
+    unless value.nil?
+      rows = content_tag(:div, label, class: 'small-12 medium-5 large-4 columns subheader')
+      rows << content_tag(:div, value, class: value_style(value))
 
-    rows = content_tag(:div, label, class: 'small-12 medium-5 large-4 columns subheader')
-    rows << content_tag(:div, value, class: value_classes)
-
-    content_tag(:div, class: 'row') do
-      rows
+      content_tag(:div, class: 'row') do
+        rows
+      end
     end
   end
 
-  def value_needs_styling?(value)
-    %w[✓ ✗].any? { |char| value.to_s.include? char }
+  def value_style(value)
+    base_class = 'small-12 medium-7 large-8 columns'
+    extended_class = case value.to_s
+                     when /✓/
+                       ' summary-result passed'
+                     when /✗/
+                       ' summary-result failed'
+                     else
+                       ''
+                     end
+
+    base_class + extended_class
   end
 end

--- a/app/models/evidence/forms/evidence.rb
+++ b/app/models/evidence/forms/evidence.rb
@@ -39,8 +39,14 @@ module Evidence
 
       def persist!
         @evidence = EvidenceCheck.find(id)
-        @evidence.update(correct: correct)
+        @evidence.update(fields_to_update)
         @evidence.build_reason(explanation: reason).save unless reason.blank?
+      end
+
+      def fields_to_update
+        { correct: correct }.tap do |fields|
+          fields[:outcome] = 'none' unless correct
+        end
       end
     end
   end

--- a/app/models/evidence/views/evidence.rb
+++ b/app/models/evidence/views/evidence.rb
@@ -1,0 +1,22 @@
+module Evidence
+  module Views
+    class Evidence
+
+      def initialize(evidence)
+        @evidence = evidence
+      end
+
+      def correct
+        @evidence.correct? ? 'Yes' : 'No'
+      end
+
+      def reason
+        @evidence.reason ? @evidence.reason.explanation : nil
+      end
+
+      def income
+        @evidence.income ? "£#{@evidence.income.round}" : nil
+      end
+    end
+  end
+end

--- a/app/models/evidence/views/result.rb
+++ b/app/models/evidence/views/result.rb
@@ -13,6 +13,23 @@ module Evidence
       def amount_to_pay
         "£#{@evidence.amount_to_pay.round}" if @evidence.amount_to_pay.present?
       end
+
+      def savings
+        result_translations[@evidence.application.savings_investment_valid?.to_s]
+      end
+
+      def income
+        result_translations[%w[full part].include?(result).to_s]
+      end
+
+      private
+
+      def result_translations
+        {
+          'true' => I18n.t('activerecord.attributes.application.summary.passed'),
+          'false' => I18n.t('activerecord.attributes.application.summary.failed')
+        }
+      end
     end
   end
 end

--- a/app/views/evidence/result.html.slim
+++ b/app/views/evidence/result.html.slim
@@ -4,4 +4,4 @@
 
 =render(partial: 'shared/remission_type', locals: { source: @result })
 
-= link_to 'Next', 'evidence_summary_path_when_set', class: 'button success'
+= link_to 'Next', evidence_summary_path(@evidence), class: 'button success'

--- a/app/views/evidence/summary.html.slim
+++ b/app/views/evidence/summary.html.slim
@@ -1,0 +1,8 @@
+h2 Check details
+
+=build_section 'Evidence', @evidence_view, %w[correct reason income]
+=build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status]
+=build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name]
+=build_section 'Result', @result, %w[savings income]
+
+=render(partial: 'shared/remission_type', locals: { source: @result })

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -186,6 +186,13 @@ en-GB:
         income: Income
         number_of_children: Number of Children
         total_monthly_income: Total monthly income
+      evidence/views/evidence:
+        correct: Correct
+        reason: Reason
+        income: Income
+      evidence/views/result:
+        savings: Savings
+        income: Income
       evidence/views/dashboard:
         form_name: Form
         full_name: Applicant

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   get 'evidence/:id/income', to: 'evidence#income', as: :evidence_income
   post 'evidence/:id/income_save', to: 'evidence#income_save', as: :evidence_income_save
   get 'evidence/:id/result', to: 'evidence#result', as: :evidence_result
+  get 'evidence/:id/summary', to: 'evidence#summary', as: :evidence_summary
 
   resources :evidence_checks, only: :show
 

--- a/spec/factories/evidence_checks.rb
+++ b/spec/factories/evidence_checks.rb
@@ -4,5 +4,27 @@ FactoryGirl.define do
     expires_at { rand(3..7).days.from_now }
     outcome nil
     amount_to_pay nil
+
+    factory :evidence_check_full_outcome do
+      correct true
+      income 100
+      outcome 'full'
+    end
+
+    factory :evidence_check_part_outcome do
+      correct true
+      income 100
+      outcome 'part'
+      amount_to_pay 50
+    end
+
+    factory :evidence_check_incorrect do
+      correct false
+      outcome 'none'
+
+      after(:build) do |evidence_check|
+        build :reason, evidence_check: evidence_check
+      end
+    end
   end
 end

--- a/spec/factories/reasons.rb
+++ b/spec/factories/reasons.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :reason do
+    explanation 'EXPLANATION'
+  end
+end

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -53,11 +53,17 @@ RSpec.feature 'Evidence check flow', type: :feature do
       expect(page).to have_content 'Is the evidence correct?'
     end
 
-    scenario 'fill in the form takes me to the income page' do
+    scenario 'confirming the evidence is correct redirects to the income page' do
+      choose 'evidence_correct_true'
+      click_button 'Next'
+      expect(page).to have_content 'Total monthly income from evidence'
+    end
+
+    scenario 'rejecting the evidence redirects to the summary page' do
       choose 'evidence_correct_false'
       expect(page).to have_content 'What is incorrect about the evidence?'
       click_button 'Next'
-      expect(page).to have_content 'Total monthly income from evidence'
+      expect(page).to have_content 'Check details'
     end
   end
 

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -77,7 +77,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
     end
   end
 
-  context 'when on "income result" page' do
+  context 'when on "income result" page', focus: true do
     before { visit evidence_result_path(id: evidence_check.id) }
 
     it 'displays the title of the page' do
@@ -92,6 +92,11 @@ RSpec.feature 'Evidence check flow', type: :feature do
       let(:outcome) { 'none' }
 
       it { expect(page).to have_xpath('//div[contains(@class,"callout-none")]/h3[@class="bold"]', text: '✗ The applicant must pay the full fee') }
+
+      it 'clicking the Next button redirects to the summary page' do
+        click_link_or_button 'Next'
+        expect(page).to have_content('Check details')
+      end
     end
 
     context 'when the evidence check returns [part]' do
@@ -99,12 +104,22 @@ RSpec.feature 'Evidence check flow', type: :feature do
       let(:amount) { 45 }
 
       it { expect(page).to have_xpath('//div[contains(@class,"callout-part")]/h3[@class="bold"]', text: 'The applicant must pay £45 towards the fee') }
+
+      it 'clicking the Next button redirects to the summary page' do
+        click_link_or_button 'Next'
+        expect(page).to have_content('Check details')
+      end
     end
 
     context 'when the evidence check returns full' do
       let(:outcome) { 'full' }
 
       it { expect(page).to have_xpath('//div[contains(@class,"callout-full")]/h3[@class="bold"]', text: '✓ The applicant doesn’t have to pay the fee') }
+
+      it 'clicking the Next button redirects to the summary page' do
+        click_link_or_button 'Next'
+        expect(page).to have_content('Check details')
+      end
     end
   end
 

--- a/spec/models/evidence/views/evidence_spec.rb
+++ b/spec/models/evidence/views/evidence_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Evidence::Views::Evidence do
+
+  subject(:evidence) { described_class.new(evidence_check) }
+
+  describe 'correct' do
+    let(:evidence_check) { build_stubbed(:evidence_check, correct: correct) }
+
+    subject { evidence.correct }
+
+    context 'when evidence is correct' do
+      let(:correct) { true }
+
+      it { is_expected.to eql('Yes') }
+    end
+
+    context 'when evidence is not correct' do
+      let(:correct) { false }
+
+      it { is_expected.to eql('No') }
+    end
+  end
+
+  describe 'reason' do
+    let(:evidence_check) { build_stubbed(:evidence_check, reason: reason) }
+
+    subject { evidence.reason }
+
+    context 'when reason exists' do
+      let(:explanation) { 'EXPLANATION' }
+      let(:reason) { build_stubbed(:reason, explanation: explanation) }
+
+      it { is_expected.to eql(explanation) }
+    end
+
+    context 'when reason does not exists' do
+      let(:reason) { nil }
+
+      it { is_expected.to be nil }
+    end
+  end
+
+  describe 'income' do
+    let(:evidence_check) { build_stubbed(:evidence_check, income: income) }
+
+    subject { evidence.income }
+
+    context 'when income is set' do
+      let(:income) { 200 }
+
+      it { is_expected.to eql('£200') }
+    end
+
+    context 'when income is not set' do
+      let(:income) { nil }
+
+      it { is_expected.to be nil }
+    end  end
+end

--- a/spec/routing/evidence_routing_spec.rb
+++ b/spec/routing/evidence_routing_spec.rb
@@ -21,5 +21,9 @@ RSpec.describe EvidenceController, type: :routing do
     it 'routes to #evidence_accuracy_save' do
       expect(post: '/evidence/1/income_save').to route_to('evidence#income_save', id: '1')
     end
+
+    it 'routes to #evidence_summary' do
+      expect(get: '/evidence/1/summary').to route_to('evidence#summary', id: '1')
+    end
   end
 end


### PR DESCRIPTION
It's ready to be reviewed / merged now. 

It brings the "page No. 6" part of the evidence flow. When the evidence is not correct, the page is redirected straight to this summary page. When the evidence is correct, the summary page is displayed after income result page.