### PR TITLE
Evidence result specs

### DIFF
--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -103,4 +103,19 @@ RSpec.describe EvidenceController, type: :controller do
       end
     end
   end
+
+  describe 'GET #result' do
+    before do
+      allow(EvidenceCheck).to receive(:find)
+      get :result, id: evidence
+    end
+
+    it 'returns the correct status code' do
+      expect(response.status).to eq 200
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template :result
+    end
+  end
 end

--- a/spec/routing/evidence_routing_spec.rb
+++ b/spec/routing/evidence_routing_spec.rb
@@ -21,5 +21,9 @@ RSpec.describe EvidenceController, type: :routing do
     it 'routes to #evidence_accuracy_save' do
       expect(post: '/evidence/1/income_save').to route_to('evidence#income_save', id: '1')
     end
+
+    it 'routes to #evidence_result' do
+      expect(get: '/evidence/1/result').to route_to('evidence#result', id: '1')
+    end
   end
 end


### PR DESCRIPTION
Added the missing specs to the result action on the evidence controller.

All the other actions have these specs, so trying to stay uniform.