### PR TITLE
Added clearing of the reason

### DIFF
--- a/app/assets/javascripts/evidence_confirmation.coffee
+++ b/app/assets/javascripts/evidence_confirmation.coffee
@@ -6,7 +6,6 @@ EvidenceConfirmationModule =
       $('#reason-input').show()
     $('input[id*="evidence_correct_true"]').on 'click', ->
       $('#reason-input').hide()
-      $('#evidence_reason').val("")
 
   setup: ->
     if $('input[id*="evidence_correct_false"]').is(':checked')

--- a/app/assets/javascripts/evidence_confirmation.coffee
+++ b/app/assets/javascripts/evidence_confirmation.coffee
@@ -6,6 +6,7 @@ EvidenceConfirmationModule =
       $('#reason-input').show()
     $('input[id*="evidence_correct_true"]').on 'click', ->
       $('#reason-input').hide()
+      $('#evidence_reason').val("")
 
   setup: ->
     if $('input[id*="evidence_correct_false"]').is(':checked')

--- a/spec/javascripts/evidence_confirmation_spec.coffee
+++ b/spec/javascripts/evidence_confirmation_spec.coffee
@@ -70,8 +70,8 @@ describe "EvidenceConfirmationModule", ->
         @reason.append('EXPLANATION')
         @yes_button.trigger('click')
 
-      it 'removes the reason text', ->
+      it 'hides the reason section', ->
         expect(@reason_section.is(':visible')).toBe false
 
-      it 'removes the reason explanation', ->
-        expect(@reason.val()).toEqual ""
+      it 'does not remove the reason explanation', ->
+        expect(@reason.val()).toEqual 'EXPLANATION'

--- a/spec/javascripts/evidence_confirmation_spec.coffee
+++ b/spec/javascripts/evidence_confirmation_spec.coffee
@@ -1,0 +1,77 @@
+#= require radio_buttons_module
+#= require evidence_confirmation
+
+describe "EvidenceConfirmationModule", ->
+  element = null
+  beforeEach ->
+    element = $("""<div class="small-12 medium-8 large-5 columns">
+    <div class="form-group">
+      <div class="row collapse">
+        <div class="columns small-12">
+          <label for="evidence_correct">Is the evidence correct?</label>
+          <div class="options radio">
+            <div class="option">
+              <label for="evidence_correct_false">
+                <input type="radio" value="false" name="evidence[correct]" id="evidence_correct_false">
+                  No
+               </label>
+            </div>
+            <div class="option">
+              <label for="evidence_correct_true">
+                <input type="radio" value="true" name="evidence[correct]" id="evidence_correct_true">
+                Yes
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="panel-indent form-group row collapse" id="reason-input" style="display: none;">
+      <div class="columns small-12">
+        <label for="evidence_reason">What is incorrect about the evidence?</label>
+          <textarea rows="3" name="evidence[reason]" id="evidence_reason"></textarea>
+        </div>
+      </div>
+    </div>""")
+    $(document.body).append(element)
+    EvidenceConfirmationModule.setup()
+    window.RadioButtonsModule.setup()
+    @yes_button = $('#evidence_correct_true')
+    @yes_label = @yes_button.parent('label')
+    @no_button = $('#evidence_correct_false')
+    @no_label = @no_button.parent('label')
+    @reason_section = $('#reason-input')
+    @reason = $('#evidence_reason')
+
+  afterEach ->
+    element.remove()
+    element = null
+
+  describe 'initial view', ->
+    it 'neither label should be selected', ->
+      expect(@yes_label.hasClass('selected')).toBe false
+      expect(@no_label.hasClass('selected')).toBe false
+
+    it 'evidence reason section is hidden', ->
+      expect($(@reason_section).is(':visible')).toBe false
+
+  describe 'when the "No" option is chosen', ->
+    beforeEach ->
+      @no_button.trigger('click')
+
+    it 'adds a selected class to the "No" label', ->
+      expect(@no_label.hasClass('selected')).toBe true
+
+    it 'evidence reason section is shown', ->
+      expect(@reason_section.is(':visible')).toBe true
+
+    describe 'when the "Yes" option is chosen subsequently', ->
+      beforeEach ->
+        @reason.append('EXPLANATION')
+        @yes_button.trigger('click')
+
+      it 'removes the reason text', ->
+        expect(@reason_section.is(':visible')).toBe false
+
+      it 'removes the reason explanation', ->
+        expect(@reason.val()).toEqual ""


### PR DESCRIPTION
This feature was covered by the feature test, but what wasn't covered is
the textarea wasn't being cleared after the users chose the 'Yes'
option.

Added the feature that clears the textarea and the test.