### PR TITLE
Link from evidence summary to confirmation

### DIFF
--- a/app/views/evidence/summary.html.slim
+++ b/app/views/evidence/summary.html.slim
@@ -6,3 +6,5 @@ h2 Check details
 =build_section 'Result', @result, %w[savings income]
 
 =render(partial: 'shared/remission_type', locals: { source: @result })
+
+= link_to 'Next', evidence_confirmation_path(@evidence), class: 'button success'

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -169,6 +169,11 @@ RSpec.feature 'Evidence check flow', type: :feature do
       end
     end
 
+    it 'clicking the Next button redirects to the confirmation page' do
+      click_link_or_button 'Next'
+      expect(page).to have_content('Processing complete')
+    end
+
     def page_expectation(outcome, fields = {})
       expect(page).to have_content(outcome)
       fields.each do |title, value|


### PR DESCRIPTION
Added a link that enables the user to move from the summary page to the
confirmation page.