### PR TITLE
updated wording inline with design

### DIFF
--- a/app/views/evidence/summary.html.slim
+++ b/app/views/evidence/summary.html.slim
@@ -7,4 +7,4 @@ h2 Check details
 
 =render(partial: 'shared/remission_type', locals: { source: @result })
 
-= link_to 'Next', evidence_confirmation_path(@evidence), class: 'button success'
+= link_to 'Complete processing', evidence_confirmation_path(@evidence), class: 'button success'

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -170,7 +170,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
     end
 
     it 'clicking the Next button redirects to the confirmation page' do
-      click_link_or_button 'Next'
+      click_link_or_button 'Complete processing'
       expect(page).to have_content('Processing complete')
     end
 


### PR DESCRIPTION
The design calls for the button to have a specific
wording, not just Next.

More work is needed to submit this page as a form to
set completed_at and _by values.  A separate branch
will be created for this.