### PR TITLE
Improve evidence controller and forms

### DIFF
--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -4,11 +4,18 @@ class EvidenceController < ApplicationController
   end
 
   def accuracy
-    accuracy_form
+    @form = Evidence::Forms::Accuracy.new(evidence)
   end
 
   def accuracy_save
-    save_accuracy_form
+    @form = Evidence::Forms::Accuracy.new(evidence)
+    @form.update_attributes(accuracy_params)
+
+    if @form.save
+      redirect_after_accuracy_save
+    else
+      render :accuracy
+    end
   end
 
   def income
@@ -45,21 +52,6 @@ class EvidenceController < ApplicationController
 
   def evidence_view
     @evidence_view = Evidence::Views::Evidence.new(evidence)
-  end
-
-  def accuracy_form
-    @form = Evidence::Forms::Accuracy.new(evidence)
-  end
-
-  def save_accuracy_form
-    @form = Evidence::Forms::Accuracy.new(evidence)
-    @form.update_attributes(accuracy_params)
-
-    if @form.save
-      redirect_after_accuracy_save
-    else
-      render :accuracy
-    end
   end
 
   def accuracy_params

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -84,6 +84,4 @@ class EvidenceController < ApplicationController
   def evidence_confirmation
     @confirmation = evidence
   end
-
-  # TODO: permitted params setup
 end

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -19,11 +19,18 @@ class EvidenceController < ApplicationController
   end
 
   def income
-    income_form
+    @form = Evidence::Forms::Income.new(evidence)
   end
 
   def income_save
-    income_form_save
+    @form = Evidence::Forms::Income.new(evidence)
+    @form.update_attributes(income_params)
+
+    if @form.save
+      redirect_to evidence_result_path
+    else
+      render :income
+    end
   end
 
   def result
@@ -66,26 +73,8 @@ class EvidenceController < ApplicationController
     end
   end
 
-  def income_form
-    @form = Evidence::Forms::Income.new(income_params)
-  end
-
-  def income_form_save
-    @form = Evidence::Forms::Income.new(income_params_for_save)
-
-    if @form.save
-      redirect_to evidence_result_path
-    else
-      render :income
-    end
-  end
-
   def income_params
-    { id: evidence.id, amount: evidence.income }
-  end
-
-  def income_params_for_save
-    { id: params['id'] }.merge(params.require(:evidence).permit(:amount).symbolize_keys)
+    params.require(:evidence).permit(*Evidence::Forms::Income.permitted_attributes)
   end
 
   def evidence_result

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -48,11 +48,12 @@ class EvidenceController < ApplicationController
   end
 
   def accuracy_form
-    @form = Evidence::Forms::Accuracy.new(accuracy_params)
+    @form = Evidence::Forms::Accuracy.new(evidence)
   end
 
   def save_accuracy_form
-    @form = Evidence::Forms::Accuracy.new(accuracy_params_for_save)
+    @form = Evidence::Forms::Accuracy.new(evidence)
+    @form.update_attributes(accuracy_params)
 
     if @form.save
       redirect_after_accuracy_save
@@ -62,11 +63,7 @@ class EvidenceController < ApplicationController
   end
 
   def accuracy_params
-    { id: evidence.id, correct: evidence.correct, reason: evidence.reason.try(:explanation) }
-  end
-
-  def accuracy_params_for_save
-    { id: params['id'] }.merge(params.require(:evidence).permit(:correct, :reason).symbolize_keys)
+    params.require(:evidence).permit(*Evidence::Forms::Accuracy.permitted_attributes)
   end
 
   def redirect_after_accuracy_save

--- a/app/models/evidence/forms/accuracy.rb
+++ b/app/models/evidence/forms/accuracy.rb
@@ -10,26 +10,12 @@ module Evidence
 
       define_attributes
 
-      def initialize(evidence)
-        super(evidence)
-        @evidence = evidence
-      end
-
       validates :correct, inclusion: { in: [true, false] }
-
-      def save
-        if valid?
-          persist!
-          true
-        else
-          false
-        end
-      end
 
       private
 
       def persist!
-        @evidence.update(fields_to_update)
+        @object.update(fields_to_update)
       end
 
       def fields_to_update

--- a/app/models/evidence/forms/accuracy.rb
+++ b/app/models/evidence/forms/accuracy.rb
@@ -4,7 +4,7 @@ module Evidence
       def self.permitted_attributes
         {
           correct: Boolean,
-          reason: String
+          incorrect_reason: String
         }
       end
 
@@ -13,7 +13,6 @@ module Evidence
       def initialize(evidence)
         super(evidence)
         @evidence = evidence
-        self.reason = evidence.reason.explanation if evidence.reason
       end
 
       validates :correct, inclusion: { in: [true, false] }
@@ -31,19 +30,11 @@ module Evidence
 
       def persist!
         @evidence.update(fields_to_update)
-        cleanup_reason
-        @evidence.create_reason(explanation: reason) unless reason.blank?
-      end
-
-      def cleanup_reason
-        if correct
-          self.reason = nil
-          @evidence.reason.destroy if @evidence.reason
-        end
       end
 
       def fields_to_update
-        { correct: correct }.tap do |fields|
+        self.incorrect_reason = nil if correct
+        { correct: correct, incorrect_reason: incorrect_reason }.tap do |fields|
           fields[:outcome] = 'none' unless correct
         end
       end

--- a/app/models/evidence/forms/income.rb
+++ b/app/models/evidence/forms/income.rb
@@ -10,21 +10,7 @@ module Evidence
 
       define_attributes
 
-      def initialize(evidence)
-        super(evidence)
-        @evidence = evidence
-      end
-
       validates :income, numericality: { greater_than_or_equal_to: 0 }
-
-      def save
-        if valid?
-          persist!
-          true
-        else
-          false
-        end
-      end
 
       private
 
@@ -33,7 +19,7 @@ module Evidence
       end
 
       def persist!
-        @evidence.update(fields_to_update)
+        @object.update(fields_to_update)
       end
 
       def fields_to_update
@@ -42,7 +28,7 @@ module Evidence
       end
 
       def income_calculation
-        IncomeCalculation.new(@evidence.application, formatted_income.to_i).calculate
+        IncomeCalculation.new(@object.application, formatted_income.to_i).calculate
       end
     end
   end

--- a/app/models/evidence/forms/income.rb
+++ b/app/models/evidence/forms/income.rb
@@ -4,14 +4,18 @@ module Evidence
 
       def self.permitted_attributes
         {
-          id: Integer,
-          amount: String
+          income: String
         }
       end
 
       define_attributes
 
-      validates :amount, numericality: { greater_than_or_equal_to: 0 }
+      def initialize(evidence)
+        super(evidence)
+        @evidence = evidence
+      end
+
+      validates :income, numericality: { greater_than_or_equal_to: 0 }
 
       def save
         if valid?
@@ -24,20 +28,21 @@ module Evidence
 
       private
 
-      def format_amount
-        self.amount = amount.to_f.round
+      def formatted_income
+        income.to_f.round
       end
 
       def persist!
-        @evidence = EvidenceCheck.find(id)
-        format_amount
+        @evidence.update(fields_to_update)
+      end
+
+      def fields_to_update
         result = income_calculation
-        @evidence.update(income: amount, outcome: result[:outcome], amount_to_pay: result[:amount])
+        { income: formatted_income, outcome: result[:outcome], amount_to_pay: result[:amount] }
       end
 
       def income_calculation
-        application = Application.find @evidence.application_id
-        IncomeCalculation.new(application, amount.to_i).calculate
+        IncomeCalculation.new(@evidence.application, formatted_income.to_i).calculate
       end
     end
   end

--- a/app/models/evidence/views/evidence.rb
+++ b/app/models/evidence/views/evidence.rb
@@ -10,8 +10,8 @@ module Evidence
         @evidence.correct? ? 'Yes' : 'No'
       end
 
-      def reason
-        @evidence.reason ? @evidence.reason.explanation : nil
+      def incorrect_reason
+        @evidence.incorrect_reason
       end
 
       def income

--- a/app/models/evidence_check.rb
+++ b/app/models/evidence_check.rb
@@ -1,6 +1,5 @@
 class EvidenceCheck < ActiveRecord::Base
   belongs_to :application, required: true
-  has_one :reason
 
   validates :expires_at, presence: true
 end

--- a/app/models/form_object.rb
+++ b/app/models/form_object.rb
@@ -7,6 +7,12 @@ class FormObject
     super(attrs)
   end
 
+  def update_attributes(params)
+    params.each do |name, value|
+      public_send("#{name}=", value)
+    end
+  end
+
   def self.permitted_attributes
     {}
   end
@@ -24,6 +30,6 @@ class FormObject
   end
 
   def get_attribs(object)
-    object.is_a?(Application) ? object.attributes : object
+    object.is_a?(ActiveRecord::Base) ? object.attributes : object
   end
 end

--- a/app/models/form_object.rb
+++ b/app/models/form_object.rb
@@ -3,6 +3,7 @@ class FormObject
   include ActiveModel::Model
 
   def initialize(object)
+    store_if_model_passed(object)
     attrs = extract_params(object)
     super(attrs)
   end
@@ -21,7 +22,24 @@ class FormObject
     permitted_attributes.each { |attr, type| attribute attr, type }
   end
 
+  def save
+    if valid?
+      persist!
+      true
+    else
+      false
+    end
+  end
+
   private
+
+  def persist!
+    raise NotImplementedError
+  end
+
+  def store_if_model_passed(object)
+    @object = object if object.is_a?(ActiveRecord::Base)
+  end
 
   def extract_params(object)
     get_attribs(object).select do |key, _|

--- a/app/models/reason.rb
+++ b/app/models/reason.rb
@@ -1,3 +1,0 @@
-class Reason < ActiveRecord::Base
-  belongs_to :evidence_check
-end

--- a/app/views/evidence/accuracy.html.slim
+++ b/app/views/evidence/accuracy.html.slim
@@ -19,7 +19,7 @@ h2 Evidence
 
       .panel-indent.form-group.row.collapse#reason-input
         .columns.small-12
-          = f.label :reason
-          = f.text_area :reason, rows: 3
+          = f.label :incorrect_reason
+          = f.text_area :incorrect_reason, rows: 3
 
   = f.submit 'Next', :class => 'button primary'

--- a/app/views/evidence/income.html.slim
+++ b/app/views/evidence/income.html.slim
@@ -5,13 +5,13 @@ h2 Income
     .small-12.medium-8.large-5.columns
       .row
         .small-12.medium-6.large-6.columns.form-group
-          = f.label :amount
-          = f.label :amount, @form.errors[:amount].join(', '), class: 'error' if @form.errors[:amount].present?
+          = f.label :income
+          = f.label :income, @form.errors[:income].join(', '), class: 'error' if @form.errors[:income].present?
           .row.collapse.prefix-radius
             .small-2.medium-4.large-3.columns
               span.prefix
-                label.inline for='amount' £
+                label.inline for='income' £
             .small-10.medium-8.large-9.columns
-              = f.text_field :amount
+              = f.text_field :income
 
   = f.submit 'Next', :class => 'button primary'

--- a/app/views/evidence/summary.html.slim
+++ b/app/views/evidence/summary.html.slim
@@ -1,7 +1,7 @@
 h2 Check details
 
 - change_evidence_link = [ 'Change application evidence', evidence_accuracy_path(@evidence) ]
-=build_section 'Evidence', @evidence_view, %w[correct reason income], *change_evidence_link
+=build_section 'Evidence', @evidence_view, %w[correct incorrect_reason income], *change_evidence_link
 =build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status]
 =build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name]
 =build_section 'Result', @result, %w[savings income]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,7 +187,7 @@ en-GB:
         correct: Is the evidence correct?
         incorrect_reason: What is incorrect about the evidence?
       evidence/forms/income:
-        amount: Total monthly income from evidence
+        income: Total monthly income from evidence
       evidence/views/overview:
         reference: Reference
         processed_by: Processed by

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,7 +185,7 @@ en-GB:
     attributes:
       evidence/forms/accuracy:
         correct: Is the evidence correct?
-        reason: What is incorrect about the evidence?
+        incorrect_reason: What is incorrect about the evidence?
       evidence/forms/income:
         amount: Total monthly income from evidence
       evidence/views/overview:
@@ -206,7 +206,7 @@ en-GB:
         total_monthly_income: Total monthly income
       evidence/views/evidence:
         correct: Correct
-        reason: Reason
+        incorrect_reason: Reason
         income: Income
       evidence/views/result:
         savings: Savings

--- a/db/migrate/20151013143545_move_reason_to_evidence_check.rb
+++ b/db/migrate/20151013143545_move_reason_to_evidence_check.rb
@@ -1,0 +1,32 @@
+class MoveReasonToEvidenceCheck < ActiveRecord::Migration
+  def up
+    add_column :evidence_checks, :incorrect_reason, :string, null: true
+
+    update_query = <<SQL
+UPDATE evidence_checks
+SET incorrect_reason = reasons.explanation
+FROM reasons
+WHERE reasons.evidence_check_id = evidence_checks.id
+SQL
+    execute(update_query)
+
+    drop_table :reasons
+  end
+
+  def down
+    create_table :reasons do |t|
+      t.string :explanation
+      t.references :evidence_check, index: true, foreign_key: true
+    end
+
+    insert_query = <<SQL
+INSERT INTO reasons (explanation, evidence_check_id)
+SELECT evidence_checks.incorrect_reason, evidence_checks.id
+FROM evidence_checks
+WHERE evidence_checks.incorrect_reason IS NOT NULL
+SQL
+    execute(insert_query)
+
+    remove_column :evidence_checks, :incorrect_reason
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151008102856) do
+ActiveRecord::Schema.define(version: 20151013143545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,14 +98,15 @@ ActiveRecord::Schema.define(version: 20151008102856) do
   add_index "dwp_checks", ["office_id"], name: "index_dwp_checks_on_office_id", using: :btree
 
   create_table "evidence_checks", force: :cascade do |t|
-    t.integer  "application_id", null: false
+    t.integer  "application_id",   null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "expires_at",     null: false
+    t.datetime "expires_at",       null: false
     t.boolean  "correct"
     t.integer  "income"
     t.string   "outcome"
     t.integer  "amount_to_pay"
+    t.string   "incorrect_reason"
   end
 
   add_index "evidence_checks", ["application_id"], name: "index_evidence_checks_on_application_id", using: :btree
@@ -161,13 +162,6 @@ ActiveRecord::Schema.define(version: 20151008102856) do
 
   add_index "r2_calculators", ["created_by_id"], name: "index_r2_calculators_on_created_by_id", using: :btree
 
-  create_table "reasons", force: :cascade do |t|
-    t.string  "explanation"
-    t.integer "evidence_check_id"
-  end
-
-  add_index "reasons", ["evidence_check_id"], name: "index_reasons_on_evidence_check_id", using: :btree
-
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
     t.string   "encrypted_password",     default: ""
@@ -202,7 +196,6 @@ ActiveRecord::Schema.define(version: 20151008102856) do
   add_index "users", ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
-  add_foreign_key "applications", "jurisdictions"
   add_foreign_key "applications", "offices"
   add_foreign_key "applications", "users"
   add_foreign_key "benefit_checks", "applications"
@@ -212,7 +205,6 @@ ActiveRecord::Schema.define(version: 20151008102856) do
   add_foreign_key "office_jurisdictions", "jurisdictions"
   add_foreign_key "office_jurisdictions", "offices"
   add_foreign_key "r2_calculators", "users", column: "created_by_id"
-  add_foreign_key "reasons", "evidence_checks"
   add_foreign_key "users", "jurisdictions"
   add_foreign_key "users", "offices"
 end

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -30,14 +30,13 @@ RSpec.describe EvidenceController, type: :controller do
     let(:form) { double }
     let(:expected_form_params) do
       {
-        id: evidence.id,
         correct: evidence.correct,
         reason: evidence.reason.try(:explanation)
       }
     end
 
     before(:each) do
-      allow(Evidence::Forms::Accuracy).to receive(:new).with(expected_form_params).and_return(form)
+      allow(Evidence::Forms::Accuracy).to receive(:new).with(evidence).and_return(form)
 
       get :accuracy, id: evidence.id
     end
@@ -55,16 +54,16 @@ RSpec.describe EvidenceController, type: :controller do
     end
   end
 
-  describe 'POST #accuracy_save' do
+  describe 'POST #accuracy_save', focus: true do
     let(:form) { double }
-    let(:params) { { correct: true, reason: 'reason' } }
-    let(:expected_form_params) { { id: evidence.id.to_s }.merge(params) }
+    let(:expected_form_params) { { correct: true, reason: 'reason' } }
 
     before do
-      allow(Evidence::Forms::Accuracy).to receive(:new).with(expected_form_params).and_return(form)
+      allow(Evidence::Forms::Accuracy).to receive(:new).with(evidence).and_return(form)
+      allow(form).to receive(:update_attributes).with(expected_form_params)
       allow(form).to receive(:save).and_return(form_save)
 
-      post :accuracy_save, id: evidence.id, evidence: params
+      post :accuracy_save, id: evidence.id, evidence: expected_form_params
     end
 
     context 'when the form can be saved' do

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe EvidenceController, type: :controller do
     let(:expected_form_params) do
       {
         correct: evidence.correct,
-        reason: evidence.reason.try(:explanation)
+        incorrect_reason: evidence.incorrect_reason
       }
     end
 
@@ -56,7 +56,7 @@ RSpec.describe EvidenceController, type: :controller do
 
   describe 'POST #accuracy_save', focus: true do
     let(:form) { double }
-    let(:expected_form_params) { { correct: true, reason: 'reason' } }
+    let(:expected_form_params) { { correct: true, incorrect_reason: 'reason' } }
 
     before do
       allow(Evidence::Forms::Accuracy).to receive(:new).with(evidence).and_return(form)

--- a/spec/factories/evidence_checks.rb
+++ b/spec/factories/evidence_checks.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :evidence_check do
     application
     expires_at { rand(3..7).days.from_now }
+    incorrect_reason nil
     outcome nil
     amount_to_pay nil
 
@@ -20,11 +21,8 @@ FactoryGirl.define do
 
     factory :evidence_check_incorrect do
       correct false
+      incorrect_reason 'SOME REASON'
       outcome 'none'
-
-      after(:build) do |evidence_check|
-        build :reason, evidence_check: evidence_check
-      end
     end
   end
 end

--- a/spec/factories/reasons.rb
+++ b/spec/factories/reasons.rb
@@ -1,5 +1,0 @@
-FactoryGirl.define do
-  factory :reason do
-    explanation 'EXPLANATION'
-  end
-end

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
 
     it 'fill in the income form takes me to the next page' do
       expect(page).to have_content 'Total monthly income from evidence'
-      fill_in 'evidence_amount', with: 500
+      fill_in 'evidence_income', with: 500
       click_button 'Next'
     end
   end

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -132,7 +132,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
       let(:expected_fields) do
         {
           'Correct' => 'No',
-          'Reason' => evidence.reason.explanation
+          'Reason' => evidence.incorrect_reason
         }
       end
 

--- a/spec/models/evidence/forms/accuracy_spec.rb
+++ b/spec/models/evidence/forms/accuracy_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Evidence::Forms::Accuracy do
-  params_list = %i[correct reason]
+  params_list = %i[correct incorrect_reason]
 
   let(:evidence) { build_stubbed :evidence_check }
   subject(:form) { described_class.new(evidence) }
@@ -26,7 +26,7 @@ RSpec.describe Evidence::Forms::Accuracy do
         it { is_expected.to be true }
 
         context 'if the reason had been set' do
-          let(:params) { { correct: true, reason: 'some reason' } }
+          let(:params) { { correct: true, incorrect_reason: 'some reason' } }
 
           it { is_expected.to be true }
         end
@@ -78,20 +78,16 @@ RSpec.describe Evidence::Forms::Accuracy do
         expect(evidence.outcome).to be nil
       end
 
-      context 'if the reason already existed' do
-        let(:evidence) { create :evidence_check_incorrect }
+      it 'keeps the incorrect reason empty' do
+        subject && evidence.reload
 
-        it 'deletes the reason' do
-          subject && evidence.reload
-
-          expect(evidence.reason).to be nil
-        end
+        expect(evidence.incorrect_reason).to be nil
       end
     end
 
     context 'for a valid form when the evidence is incorrect' do
-      let(:reason) { 'REASON' }
-      let(:params) { { correct: false, reason: reason } }
+      let(:incorrect_reason) { 'REASON' }
+      let(:params) { { correct: false, incorrect_reason: incorrect_reason } }
 
       it { is_expected.to be true }
 
@@ -99,7 +95,7 @@ RSpec.describe Evidence::Forms::Accuracy do
         subject && evidence.reload
 
         expect(evidence.correct).to be false
-        expect(evidence.reason.explanation).to eql(reason)
+        expect(evidence.incorrect_reason).to eql(incorrect_reason)
       end
 
       it 'sets the outcome to none' do

--- a/spec/models/evidence/forms/accuracy_spec.rb
+++ b/spec/models/evidence/forms/accuracy_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Evidence::Forms::Accuracy do
-  params_list = %i[correct reason id]
+  params_list = %i[correct reason]
 
-  let(:evidence) { { correct: true } }
-  subject(:evidence_form) { described_class.new(evidence) }
+  let(:evidence) { build_stubbed :evidence_check }
+  subject(:form) { described_class.new(evidence) }
 
   describe '.permitted_attributes' do
     it 'returns a list of attributes' do
@@ -13,110 +13,99 @@ RSpec.describe Evidence::Forms::Accuracy do
   end
 
   describe 'validations' do
-    context 'for attribute "id"' do
-      context 'when an integer' do
-        let(:evidence) { { correct: true, id: 1 } }
-
-        it { expect(subject.valid?).to be true }
-      end
-
-      context 'when not an integer' do
-        let(:evidence) { { correct: true, id: 'foo' } }
-
-        it { expect(subject.valid?).to be false }
-      end
-
-      context 'when not present' do
-        let(:evidence) { { correct: true } }
-
-        it { expect(subject.valid?).to be false }
-      end
+    before do
+      form.update_attributes(params)
     end
+
+    subject { form.valid? }
 
     context 'for attribute "correct"' do
       context 'when true' do
-        let(:evidence) { { correct: true, id: 1 } }
+        let(:params) { { correct: true } }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be true }
 
         context 'if the reason had been set' do
-          let(:evidence) { { id: 1, correct: true, reason: 'some reason' } }
+          let(:params) { { correct: true, reason: 'some reason' } }
 
-          it { expect(subject.valid?).to be true }
+          it { is_expected.to be true }
         end
       end
 
       context 'when false' do
-        let(:evidence) { { correct: false, id: 1 } }
+        let(:params) { { correct: false } }
 
-        it { expect(subject.valid?).to be true }
+        it { is_expected.to be true }
       end
 
       context 'when not a boolean value' do
-        let(:evidence) { { correct: 'some string' } }
+        let(:params) { { correct: 'some string' } }
 
-        it { expect(subject.valid?).to be false }
+        it { is_expected.to be false }
       end
     end
   end
 
-  describe '#save', focus: true do
-    let(:evidence_check) { create(:evidence_check) }
-    subject { evidence_form.save }
+  describe '#save' do
+    let(:evidence) { create :evidence_check }
+
+    before do
+      form.update_attributes(params)
+    end
+
+    subject { form.save }
 
     context 'for an invalid form' do
-      let(:evidence) { {} }
+      let(:params) { { correct: nil } }
 
       it { is_expected.to be false }
     end
 
     context 'for a valid form when the evidence is correct' do
-      let(:evidence) { { id: evidence_check.id, correct: true } }
+      let(:params) { { correct: true } }
 
       it { is_expected.to be true }
 
       it 'updates the correct field on evidence check' do
-        subject && evidence_check.reload
+        subject && evidence.reload
 
-        expect(evidence_check.correct).to be true
+        expect(evidence.correct).to be true
       end
 
       it 'keeps the outcome empty' do
-        subject && evidence_check.reload
+        subject && evidence.reload
 
-        expect(evidence_check.outcome).to be nil
+        expect(evidence.outcome).to be nil
       end
 
       context 'if the reason already existed' do
-        before do
-          create :reason, evidence_check: evidence_check
-        end
+        let(:evidence) { create :evidence_check_incorrect }
 
         it 'deletes the reason' do
-          subject && evidence_check.reload
+          subject && evidence.reload
 
-          expect(evidence_check.reason).to be nil
+          expect(evidence.reason).to be nil
         end
       end
     end
 
     context 'for a valid form when the evidence is incorrect' do
       let(:reason) { 'REASON' }
-      let(:evidence) { { id: evidence_check.id, correct: false, reason: reason } }
+      let(:params) { { correct: false, reason: reason } }
 
       it { is_expected.to be true }
 
       it 'updates the correct field on evidence check and creates reason record with explanation' do
-        subject && evidence_check.reload
+        subject && evidence.reload
 
-        expect(evidence_check.correct).to be false
-        expect(evidence_check.reason.explanation).to eql(reason)
+        expect(evidence.correct).to be false
+        expect(evidence.reason.explanation).to eql(reason)
       end
 
       it 'sets the outcome to none' do
-        subject && evidence_check.reload
+        subject && evidence.reload
 
-        expect(evidence_check.outcome).to eql('none')
+        expect(evidence.outcome).to eql('none')
       end
     end
   end

--- a/spec/models/evidence/forms/accuracy_spec.rb
+++ b/spec/models/evidence/forms/accuracy_spec.rb
@@ -66,21 +66,17 @@ RSpec.describe Evidence::Forms::Accuracy do
 
       it { is_expected.to be true }
 
-      it 'updates the correct field on evidence check' do
-        subject && evidence.reload
+      before { subject && evidence.reload }
 
+      it 'updates the correct field on evidence check' do
         expect(evidence.correct).to be true
       end
 
       it 'keeps the outcome empty' do
-        subject && evidence.reload
-
         expect(evidence.outcome).to be nil
       end
 
       it 'keeps the incorrect reason empty' do
-        subject && evidence.reload
-
         expect(evidence.incorrect_reason).to be nil
       end
     end
@@ -91,16 +87,14 @@ RSpec.describe Evidence::Forms::Accuracy do
 
       it { is_expected.to be true }
 
-      it 'updates the correct field on evidence check and creates reason record with explanation' do
-        subject && evidence.reload
+      before { subject && evidence.reload }
 
+      it 'updates the correct field on evidence check and creates reason record with explanation' do
         expect(evidence.correct).to be false
         expect(evidence.incorrect_reason).to eql(incorrect_reason)
       end
 
       it 'sets the outcome to none' do
-        subject && evidence.reload
-
         expect(evidence.outcome).to eql('none')
       end
     end

--- a/spec/models/evidence/views/evidence_spec.rb
+++ b/spec/models/evidence/views/evidence_spec.rb
@@ -22,22 +22,13 @@ RSpec.describe Evidence::Views::Evidence do
     end
   end
 
-  describe 'reason' do
-    let(:evidence_check) { build_stubbed(:evidence_check, reason: reason) }
+  describe 'incorrect_reason' do
+    let(:evidence_check) { build_stubbed(:evidence_check_incorrect) }
 
-    subject { evidence.reason }
+    subject { evidence.incorrect_reason }
 
-    context 'when reason exists' do
-      let(:explanation) { 'EXPLANATION' }
-      let(:reason) { build_stubbed(:reason, explanation: explanation) }
-
-      it { is_expected.to eql(explanation) }
-    end
-
-    context 'when reason does not exists' do
-      let(:reason) { nil }
-
-      it { is_expected.to be nil }
+    it 'returns the incorrect reason from the evidence check' do
+      is_expected.to eql(evidence_check.incorrect_reason)
     end
   end
 

--- a/spec/models/form_object_spec.rb
+++ b/spec/models/form_object_spec.rb
@@ -47,4 +47,37 @@ RSpec.describe FormObject do
       expect(form.fee).to eql(params[:fee])
     end
   end
+
+  describe 'save' do
+    before do
+      allow(form).to receive(:valid?).and_return(valid)
+      allow(form).to receive(:persist!)
+    end
+
+    subject { form.save }
+
+    context 'when the form is valid' do
+      let(:valid) { true }
+
+      it 'method #persist! is called' do
+        subject
+
+        expect(form).to have_received(:persist!)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the form is not valid' do
+      let(:valid) { false }
+
+      it 'does not call #persist!' do
+        subject
+
+        expect(form).not_to have_received(:persist!)
+      end
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/form_object_spec.rb
+++ b/spec/models/form_object_spec.rb
@@ -12,25 +12,39 @@ RSpec.describe FormObject do
 
   params_list = FormTestClass.permitted_attributes.keys
 
-  describe 'when Application object is passed in' do
-    let(:application) { create :application }
-    let(:form) { FormTestClass.new(application) }
+  let(:application) { create :application }
+  let(:object_or_hash) { application }
+  subject(:form) { FormTestClass.new(object_or_hash) }
 
-    params_list.each do |attr_name|
-      it "assigns #{attr_name}" do
-        expect(form.send(attr_name)).to eq application.send(attr_name)
+  describe '#initialize' do
+    describe 'when an ActiveRecord object is passed in' do
+      params_list.each do |attr_name|
+        it "assigns #{attr_name}" do
+          expect(form.send(attr_name)).to eq application.send(attr_name)
+        end
+      end
+    end
+
+    describe 'when a Hash is passed in' do
+      let(:hash) { { id: 1, fee: 2 } }
+      let(:object_or_hash) { hash }
+
+      params_list.each do |attr_name|
+        it "assigns #{attr_name}" do
+          expect(form.send(attr_name)).to eq hash[attr_name]
+        end
       end
     end
   end
 
-  describe 'when a Hash is passed in' do
-    let(:hash) { { id: 1, fee: 2 } }
-    let(:form) { FormTestClass.new(hash) }
+  describe '#update_attributes' do
+    let(:params) { { fee: 10 } }
+    before do
+      form.update_attributes(params)
+    end
 
-    params_list.each do |attr_name|
-      it "assigns #{attr_name}" do
-        expect(form.send(attr_name)).to eq hash[attr_name]
-      end
+    it 'updates the attributes on the form' do
+      expect(form.fee).to eql(params[:fee])
     end
   end
 end


### PR DESCRIPTION
This is not just a refactoring PR, but also a preparation for the new Payment flow.

As discussed and agreed with @dotemacs, we'll for now put the `reason` back to the `EvidenceCheck` table. That way we should be able to re-use exactly the same form object for the new flow. We've briefly discussed and I'm sure there'll be more how to slice our models going forward.

It's also one further step to make our form objects as similar to each other as possible.

Last but not least the `EvidenceController` should now be cleaner and not have any responsibility for parameters processing.