### PR TITLE
Updated evidence check letter

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,7 +168,7 @@ en-GB:
         <p><strong>Any other monthly income</strong></p>
         <p>Documentation of any other income that you’re receiving. </p>
 
-        <p>Please send this to us by %{expiry_date} so that we can process your application.</p>
+        <p>Please send this to us by %{expiry_date} so that we can process your application. You should send this letter back with your evidence.</p>
 
         <p>Yours sincerely,</p>
 


### PR DESCRIPTION
Updated to include: “You should send this letter back with your
evidence” so staff can identify evidence for checking.