### PR TITLE
Evidence check creation fix

### DIFF
--- a/app/controllers/applications/build_controller.rb
+++ b/app/controllers/applications/build_controller.rb
@@ -87,7 +87,7 @@ class Applications::BuildController < ApplicationController
   end
 
   def evidence_check_selection
-    if next_step?(:summary)
+    if next_step?(:summary) && evidence_check_enabled?
       EvidenceCheckSelector.new(@application, Settings.evidence_check.expires_in_days).decide!
     end
   end

--- a/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
+++ b/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
@@ -22,6 +22,9 @@ RSpec.feature 'Evidence check page displayed instead of confirmation', type: :fe
       visit application_build_path(application_id: application.id, id: 'income_result')
 
       click_button 'Next'
+
+      expect(page).to have_content 'Evidence of income needs to be checked for this application'
+
       click_button 'Continue'
 
       expect(evidence_check_rendered?).to be true
@@ -45,6 +48,9 @@ RSpec.feature 'Evidence check page displayed instead of confirmation', type: :fe
       visit application_build_path(application_id: application.id, id: 'income_result')
 
       click_button 'Next'
+
+      expect(page).to have_content '✓ The applicant doesn’t have to pay the fee'
+
       click_button 'Continue'
 
       expect(confirmation_rendered?).to be true


### PR DESCRIPTION
Added evidence_check feature flag tests, then implemented 
a fix where the 10th income application would get flagged
even if the feature flag was turned off.