### PR TITLE
Implemented application emergency

### DIFF
--- a/app/controllers/applications/build_controller.rb
+++ b/app/controllers/applications/build_controller.rb
@@ -79,6 +79,7 @@ class Applications::BuildController < ApplicationController
     if @form.valid?
       status = { status: get_status(step) }
       form_params.delete('application_id')
+      form_params.delete('emergency') if form_params.key?(:emergency)
       @application.update(form_params.merge(status))
       render_wizard @application
     else

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -10,7 +10,10 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   validates :reference, presence: true, uniqueness: true
 
   scope :evidencecheckable, lambda {
-    where(benefits: false, application_type: 'income', application_outcome: %w[part full])
+    where(benefits: false,
+          application_type: 'income',
+          emergency_reason: nil,
+          application_outcome: %w[part full])
   }
 
   scope :waiting_for_evidence, lambda {

--- a/app/models/applikation/forms/application_detail.rb
+++ b/app/models/applikation/forms/application_detail.rb
@@ -4,6 +4,7 @@ module Applikation
 
       TIME_LIMIT_FOR_PROBATE = 20
 
+      # rubocop:disable MethodLength
       def self.permitted_attributes
         { fee: Integer,
           jurisdiction_id: Integer,
@@ -12,6 +13,8 @@ module Applikation
           date_of_death: Date,
           deceased_name: String,
           refund: Boolean,
+          emergency: Boolean,
+          emergency_reason: String,
           date_fee_paid: Date,
           form_name: String,
           case_number: String }
@@ -22,6 +25,7 @@ module Applikation
       validates :fee, numericality: { allow_blank: true }
       validates :fee, presence: true
       validates :jurisdiction_id, presence: true
+      validate :reason
 
       validates :date_received, date: {
         after: proc { Time.zone.today - 3.months },
@@ -41,6 +45,19 @@ module Applikation
           after: proc { Time.zone.today - 3.months },
           before: proc { Time.zone.today + 1.day }
         }
+      end
+
+      private
+
+      def reason
+        errors.add(
+          :emergency_reason,
+          :cant_have_emergency_reason_without_emergency
+        ) if emergency_without_reason?
+      end
+
+      def emergency_without_reason?
+        emergency? && emergency_reason.blank?
       end
     end
   end

--- a/app/views/applications/build/application_details.html.slim
+++ b/app/views/applications/build/application_details.html.slim
@@ -94,4 +94,20 @@
           = f.label :date_fee_paid, @form.errors[:date_fee_paid].join(', '), class: 'error' if @form.errors[:date_fee_paid].present?
           = f.text_field :date_fee_paid, { class: 'form-control' }
 
+  .row
+    .small-12.medium-8.large-5.columns
+      .options.radio
+        .option
+          = f.label :emergency
+            = f.check_box :emergency, { class: 'show-hide-checkbox', data: { section: 'emergency' } }
+            = t('activemodel.attributes.applikation/forms/application_detail.emergency')
+
+  #emergency-only.start-hidden
+    .row
+      .small-12.medium-8.large-5.columns
+        .form-group.panel-indent
+          = f.label :emergency_reason
+          = f.label :emergency_reason, @form.errors[:emergency_reason].join(', '), class: 'error' if @form.errors[:emergency_reason].present?
+          = f.text_area :emergency_reason, { class: 'form-control' }
+
   = f.submit 'Next', class: 'button primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,6 +219,9 @@ en-GB:
         benefits: Is the applicant receiving one of the benefits listed in question 9?
       applikation/forms/income:
         dependents: Are there any financially dependent children?
+      applikation/forms/application_detail:
+        emergency: This is an emergency case
+        emergency_reason: Reason for emergency
     errors:
       models:
         applikation/forms/application_detail:
@@ -248,6 +251,8 @@ en-GB:
               not_a_date: Enter the date in this format 01/01/2015
               invalid: Enter the date in this format day month, year DD/MM/YYYY
               before: The date of death cannot be a future date
+            emergency_reason:
+              cant_have_emergency_reason_without_emergency: "Can't have emergency reason without emergency"
         applikation/forms/personal_information:
           attributes:
             date_of_birth:

--- a/db/migrate/20151015143356_add_emergency_reason_to_application.rb
+++ b/db/migrate/20151015143356_add_emergency_reason_to_application.rb
@@ -1,0 +1,5 @@
+class AddEmergencyReasonToApplication < ActiveRecord::Migration
+  def change
+    add_column :applications, :emergency_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151014114305) do
+ActiveRecord::Schema.define(version: 20151015143356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20151014114305) do
     t.integer  "amount_to_pay"
     t.boolean  "high_threshold_exceeded"
     t.string   "reference"
+    t.string   "emergency_reason"
   end
 
   add_index "applications", ["office_id"], name: "index_applications_on_office_id", using: :btree
@@ -106,9 +107,9 @@ ActiveRecord::Schema.define(version: 20151014114305) do
     t.integer  "income"
     t.string   "outcome"
     t.integer  "amount_to_pay"
-    t.string   "incorrect_reason"
     t.datetime "completed_at"
     t.integer  "completed_by_id"
+    t.string   "incorrect_reason"
   end
 
   add_index "evidence_checks", ["application_id"], name: "index_evidence_checks_on_application_id", using: :btree

--- a/spec/features/applications/emergency_applications_spec.rb
+++ b/spec/features/applications/emergency_applications_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Emergency application', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions) { create_list :jurisdiction, 3 }
+  let!(:office)        { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)          { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+
+  before do
+    login_as user
+    visit applications_new_path
+
+    fill_in 'application_last_name', with: 'Smith'
+    fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
+    fill_in 'application_ni_number', with: 'AB123456A'
+    choose 'application_married_false'
+    click_button 'Next'
+  end
+
+  context 'when on application details page' do
+    scenario 'there will be emergency application option' do
+      expect(page).to have_content 'This is an emergency case'
+    end
+
+    context 'when the emergency case option is chosen' do
+      before { check 'application_emergency' }
+      reason = 'A really good reason'
+      label_text = 'Reason for emergency'
+
+      scenario 'there will be a way to add the explanation for emergency reason' do
+        expect(page).to have_content label_text
+        fill_in 'application_emergency_reason', with: reason
+        expect(page).to have_field('Reason for emergency', with: reason)
+      end
+    end
+  end
+end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -197,9 +197,14 @@ RSpec.describe Application, type: :model do
       let!(:application_1) { create :application_part_remission }
       let!(:application_2) { create :application_full_remission }
       let!(:application_3) { create :application_no_remission }
+      let!(:emergency_application) { create :application_full_remission, emergency_reason: 'REASON' }
 
       it 'includes only part and full remission applications' do
         is_expected.to match_array([application_1, application_2])
+      end
+
+      it 'does not include emergency applications' do
+        is_expected.not_to include emergency_application
       end
     end
 


### PR DESCRIPTION
Some application's will need to be expedited through the system, so
they'll need to be declared as emergency applications.

This change allows for that.

Also, no emergency application will be selected for evidence check.

**WRONG THINGS:** currently in the ApplicationDetail model I'm assigning an
attribute called `emergency' which I manually remove in the Application
controller and in the ApplicationDetail model specs. The reason for that
is that currently Application model is one huge monolith and once we
split it up, these ugly hacks will be removed.