### PR TITLE
Two digit year fix

### DIFF
--- a/app/models/applikation/forms/personal_information.rb
+++ b/app/models/applikation/forms/personal_information.rb
@@ -38,11 +38,18 @@ module Applikation
       private
 
       def dob_age_valid?
+        validate_dob
+        unless errors.include?(:date_of_birth)
+          validate_dob_minimum
+          validate_dob_maximum
+        end
+      end
+
+      def validate_dob
         if date_of_birth =~ /[a-zA-Z]/
           errors.add(:date_of_birth, "can't contain non numbers")
-        else
-          validate_dob_minimum unless date_of_birth.blank?
-          validate_dob_maximum unless date_of_birth.blank?
+        elsif !date_of_birth.is_a?(Date)
+          errors.add(:date_of_birth, :not_a_date)
         end
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,6 +254,7 @@ en-GB:
               too_young: "The applicant can't be under %{minimum_age} years old"
               too_old: "The applicant can't be over %{maximum_age} years old"
               non_date: "You must provide a valid date of birth"
+              not_a_date: Enter the date in this format 01/11/1980
         applikation/forms/benefit:
           attributes:
             benefits:

--- a/spec/models/applikation/forms/personal_information_spec.rb
+++ b/spec/models/applikation/forms/personal_information_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe Applikation::Forms::PersonalInformation do
 
         it { expect(subject.valid?).not_to be true }
       end
+
+      context 'when the the date_of_birth is passed a two digit year' do
+        before { personal_information[:date_of_birth] = '1/11/80' }
+
+        it { expect(subject.valid?).not_to be true }
+
+        it 'returns an error message, if omitted' do
+          subject.valid?
+          expect(subject.errors[:date_of_birth]).to eq ['Enter the date in this format 01/11/1980']
+        end
+      end
     end
 
     describe 'married' do


### PR DESCRIPTION
[finishes #104996152]
Addresses these [sentry alerts](https://sentry.service.dsd.io/mojds/prod-staff-app/group/247/)

When a user entered a two digit year into date of birth, a 500 error was
being generated.  This fix returns an error to the user and returns to
the page with a validation message.