### PR TITLE
Add values to letters

### DIFF
--- a/app/views/evidence/_confirmation_none_remission.html.slim
+++ b/app/views/evidence/_confirmation_none_remission.html.slim
@@ -1,4 +1,6 @@
 .row
   .small-12.medium-12.large-12.columns
     .evidence-confirmation-letter
-      =t('evidence.no-remission.letter_html')
+      =t('evidence.no-remission.letter_html',
+         full_name: confirmation.application.full_name,
+         current_user: current_user.name)

--- a/app/views/evidence/_confirmation_part_remission.html.slim
+++ b/app/views/evidence/_confirmation_part_remission.html.slim
@@ -1,4 +1,8 @@
 .row
   .small-12.medium-12.large-12.columns
     .evidence-confirmation-letter
-      =t('evidence.part-remission.letter_html')
+      =t('evidence.part-remission.letter_html',
+         full_name: confirmation.application.full_name,
+         current_user: current_user.name,
+         fee: confirmation.amount_to_pay,
+         date: confirmation.expires_at.strftime(Date::DATE_FORMATS[:gov_uk_long]))

--- a/app/views/evidence/confirmation.html.slim
+++ b/app/views/evidence/confirmation.html.slim
@@ -3,6 +3,6 @@
     h2 Processing complete
 
     - unless @confirmation.outcome == 'full'
-      = render(partial: "confirmation_#{@confirmation.outcome}_remission")
+      = render(partial: "confirmation_#{@confirmation.outcome}_remission", locals: { confirmation: @confirmation })
 
 = link_to 'Back to start', root_path, class: 'button success'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,7 +37,7 @@ en-GB:
         <p>%{current_user}</p>
     no-remission:
       letter_html: |
-        <p>Dear Mr %{full_name}</p>
+        <p>Dear %{full_name}</p>
         <p>We have received your documents however they are not correct, therefore we’re unable to process your application. This may have an impact on the original case or claim related to this application.</p>
         <p>You will need to make a new application if you still require help.</p>
         <p>Yours sincerely,</p>

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -199,12 +199,24 @@ RSpec.feature 'Evidence check flow', type: :feature do
         let(:outcome) { 'part' }
 
         it { expect(page).to have_content 'part-fee' }
+
+        it { expect(page).to have_content(evidence.application.full_name) }
+
+        it { expect(page).to have_content(user.name) }
+
+        it { expect(page).to have_content(evidence.amount_to_pay) }
+
+        it { expect(page).to have_content(evidence.expires_at.strftime('%-d %B %Y')) }
       end
 
       context 'rejected' do
         let(:outcome) { 'none' }
 
         it { expect(page).to have_content 'not correct' }
+
+        it { expect(page).to have_content(evidence.application.full_name) }
+
+        it { expect(page).to have_content(user.name) }
       end
     end
   end


### PR DESCRIPTION
[finishes #105467270]
[finishes #105467530]

The evidence check letters for part and no remission had 
placeholders for values.  Replaced the placeholders with 
the required data.