### PR TITLE
Move locale to activemodel

### DIFF
--- a/app/models/applikation/forms/savings_investment.rb
+++ b/app/models/applikation/forms/savings_investment.rb
@@ -2,6 +2,8 @@ module Applikation
   module Forms
     class SavingsInvestment < ::FormObject
 
+      LOCALE = 'activemodel.errors.models.applikation/forms/savings_investment.attributes'
+
       def self.permitted_attributes
         {
           application_id: Integer,
@@ -22,13 +24,14 @@ module Applikation
 
       def check_partner_over_61
         if PartnerAgeCheck.new(self).verify == false
-          errors.add(:partner_over_61, I18n.t('activemodel.errors.models.applikation/forms/savings_investment.attributes.partner_over_61.inclusion') )
+          errors.add(:partner_over_61, I18n.t('partner_over_61.inclusion', scope: LOCALE))
         end
       end
 
       def maximum_threshold_exceeded
         if partner_over_61? && high_threshold_not_boolean?
-          errors.add(:high_threshold_exceeded, I18n.t('activemodel.errors.models.applikation/forms/savings_investment.attributes.threshold_exceeded.inclusion'))
+          error_message = I18n.t('threshold_exceeded.inclusion', scope: LOCALE)
+          errors.add(:high_threshold_exceeded, error_message)
         end
       end
 

--- a/app/models/applikation/forms/savings_investment.rb
+++ b/app/models/applikation/forms/savings_investment.rb
@@ -22,13 +22,13 @@ module Applikation
 
       def check_partner_over_61
         if PartnerAgeCheck.new(self).verify == false
-          errors.add(:partner_over_61, 'some error')
+          errors.add(:partner_over_61, I18n.t('activemodel.errors.models.applikation/forms/savings_investment.attributes.partner_over_61.inclusion') )
         end
       end
 
       def maximum_threshold_exceeded
         if partner_over_61? && high_threshold_not_boolean?
-          errors.add(:high_threshold_exceeded, 'high_threshold_exceeded error')
+          errors.add(:high_threshold_exceeded, I18n.t('activemodel.errors.models.applikation/forms/savings_investment.attributes.threshold_exceeded.inclusion'))
         end
       end
 

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -46,7 +46,7 @@ module Views
     private
 
     def format_locale(suffix)
-      prefix = 'activerecord.attributes.application.summary'
+      prefix = 'activemodel.attributes.applikation/forms/summary'
       I18n.t(suffix, scope: prefix)
     end
   end

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -41,7 +41,7 @@ module Views
     private
 
     def format_locale(suffix)
-      prefix = 'activerecord.attributes.application.summary'
+      prefix = 'activemodel.attributes.applikation/forms/summary'
       I18n.t(suffix, scope: prefix)
     end
   end

--- a/app/views/applications/build/application_details.html.slim
+++ b/app/views/applications/build/application_details.html.slim
@@ -41,7 +41,7 @@
     .small-12.medium-8.large-5.columns
       .form-group
         = f.label :form_name
-          =t('activerecord.attributes.application.form_name')
+          =t('activemodel.attributes.applikation/forms/application_detail.form_name')
           span.hint =t('general.optional').html_safe
         = f.label :form_name, @form.errors[:form_name].join(', '), class: 'error' if @form.errors[:form_name].present?
         = f.text_field :form_name, { class: 'form-control' }
@@ -50,7 +50,7 @@
     .small-12.medium-8.large-5.columns
       .form-group
         = f.label :case_number
-          =t('activerecord.attributes.application.case_number')
+          =t('activemodel.attributes.applikation/forms/application_detail.case_number')
           span.hint =t('general.optional').html_safe
         = f.label :case_number, @form.errors[:case_number].join(', '), class: 'error' if @form.errors[:case_number].present?
         = f.text_field :case_number, { class: 'form-control' }
@@ -61,7 +61,7 @@
         .option
           = f.label :probate
             = f.check_box :probate, { class: 'show-hide-checkbox', data: { section: 'probate' } }
-            = t('activerecord.attributes.application.probate')
+            = t('activemodel.attributes.applikation/forms/application_detail.probate')
 
   #probate-only.start-hidden
     .panel-indent
@@ -84,7 +84,7 @@
         .option
           = f.label :refund
             = f.check_box :refund, { class: 'show-hide-checkbox', data: { section: 'refund' } }
-            = t('activerecord.attributes.application.refund')
+            = t('activemodel.attributes.applikation/forms/application_detail.refund')
 
   #refund-only.start-hidden
     .row

--- a/app/views/applications/build/benefits.html.slim
+++ b/app/views/applications/build/benefits.html.slim
@@ -13,11 +13,11 @@ h2 Benefits
               .option
                 label for='application_benefits_false'
                   = f.radio_button :benefits, 'false'
-                  = t('activerecord.attributes.application.page_4.benefits_false')
+                  = t('activemodel.attributes.applikation/forms/benefit.benefits_false')
               .option
                 label for='application_benefits_true'
                   = f.radio_button :benefits, 'true'
-                  = t('activerecord.attributes.application.page_4.benefits_true')
+                  = t('activemodel.attributes.applikation/forms/benefit.benefits_true')
 
   = f.submit 'Next', :class => 'button primary'
 

--- a/app/views/applications/build/income.html.slim
+++ b/app/views/applications/build/income.html.slim
@@ -12,11 +12,11 @@ h2 Income
               .option
                 label for='application_dependents_false'
                   = f.radio_button :dependents, 'false', { class: 'show-hide-section', data: { section: 'children', show: 'false' } }
-                  = t('activerecord.attributes.application.income_false')
+                  = t('activemodel.attributes.applikation/forms/income.income_false')
               .option
                 label for='application_dependents_true'
                   = f.radio_button :dependents, 'true', { class: 'show-hide-section', data: { section: 'children', show: 'true' } }
-                  = t('activerecord.attributes.application.income_true')
+                  = t('activemodel.attributes.applikation/forms/income.income_true')
 
       .row.collapse.panel-indent#children-only
         .small-12.medium-6.large-6.columns.form-group

--- a/app/views/applications/build/income_result.html.slim
+++ b/app/views/applications/build/income_result.html.slim
@@ -23,7 +23,7 @@ h2 Income
                 .columns.small-8 £#{@application.fee.floor}
               .row
                 .columns.small-4.table-label Status
-                .columns.small-8 =@application.married ? t('activerecord.attributes.application.page_1.married_true') : t('activerecord.attributes.application.page_1.married_false')
+                .columns.small-8 =t("activemodel.attributes.applikation/forms/personal_information.married_#{@application.married}")
               .row
                 .columns.small-4.table-label =t('activerecord.attributes.application.children')
                 .columns.small-8 =@application.children

--- a/app/views/applications/build/income_result.html.slim
+++ b/app/views/applications/build/income_result.html.slim
@@ -25,8 +25,8 @@ h2 Income
                 .columns.small-4.table-label Status
                 .columns.small-8 =t("activemodel.attributes.applikation/forms/personal_information.married_#{@application.married}")
               .row
-                .columns.small-4.table-label =t('activerecord.attributes.application.children')
+                .columns.small-4.table-label =t('activemodel.attributes.applikation/forms/income.children')
                 .columns.small-8 =@application.children
               .row
-                .columns.small-4.table-label =t('activerecord.attributes.application.income')
+                .columns.small-4.table-label =t('activemodel.attributes.applikation/forms/income.income')
                 .columns.small-8 =number_to_currency(@application.income.floor, precision: 0)

--- a/app/views/applications/build/personal_information.html.slim
+++ b/app/views/applications/build/personal_information.html.slim
@@ -8,14 +8,14 @@
       .form-group
         = f.label :title, @form.errors[:title].join(', '), class: 'error' if @form.errors[:title].present?
         = f.label :title
-          =t('activerecord.attributes.application.title')
+          =t('activemodel.attributes.applikation/forms/personal_information.title')
           span.hint =t('general.optional').html_safe
         = f.text_field :title, { class: 'form-control' }
   .row
     .small-12.medium-8.large-5.columns
       .form-group
         = f.label :first_name
-          =t('activerecord.attributes.application.first_name')
+          =t('activemodel.attributes.applikation/forms/personal_information.first_name')
           span.hint =t('general.optional').html_safe
         = f.label :first_name, @form.errors[:first_name].join(', '), class: 'error' if @form.errors[:first_name].present?
         = f.text_field :first_name, { class: 'form-control' }
@@ -31,8 +31,8 @@
     .small-12.medium-8.large-5.columns
       .form-group
         = f.label :date_of_birth
-          = t('activerecord.attributes.application.date_of_birth')
-          span.hint.block = t('activerecord.attributes.application.page_1.date_of_birth_hint')
+          = t('activemodel.attributes.applikation/forms/personal_information.date_of_birth')
+          span.hint.block = t('activemodel.attributes.applikation/forms/personal_information.date_of_birth_hint')
         = f.label :date_of_birth, @form.errors[:date_of_birth].join(', '), class: 'error' if @form.errors[:date_of_birth].present?
         = f.text_field :date_of_birth, { class: 'form-control' }
 
@@ -40,7 +40,7 @@
     .small-12.medium-8.large-5.columns
       .form-group
         = f.label :ni_number
-          =t('activerecord.attributes.application.ni_number')
+          =t('activemodel.attributes.applikation/forms/personal_information.ni_number')
           span.hint =t('general.required_for_benefits').html_safe
         = f.label :ni_number, @form.errors[:ni_number].join(', '), class: 'error' if @form.errors[:ni_number].present?
         = f.text_field :ni_number, { class: 'form-control transform-upper' }
@@ -56,10 +56,10 @@
               .option
                 label for='application_married_false'
                   = f.radio_button :married, 'false'
-                  = t('activerecord.attributes.application.page_1.married_false')
+                  = t('activemodel.attributes.applikation/forms/personal_information.married_false')
               .option
                 label for='application_married_true'
                   = f.radio_button :married, 'true'
-                  = t('activerecord.attributes.application.page_1.married_true')
+                  = t('activemodel.attributes.applikation/forms/personal_information.married_true')
 
   = f.submit 'Next', :class => 'button primary'

--- a/app/views/applications/build/savings_investments.html.slim
+++ b/app/views/applications/build/savings_investments.html.slim
@@ -3,32 +3,32 @@
 
   .row
     .small-12.medium-12.large-12.columns
-      h2 =t('activerecord.attributes.application.page_3.header')
+      h2 =t('activemodel.attributes.applikation/forms/savings_investment.header')
   .row
     .small-12.medium-8.large-7.columns
-      label =t('activerecord.attributes.application.page_3.maximum_prompt')
+      label =t('activemodel.attributes.applikation/forms/savings_investment.maximum_prompt')
       #result.callout.received
         .row
           .small-12.columns
             h3 =number_to_currency(@application.threshold.floor, precision: 0)
-      label =t('activerecord.attributes.application.page_3.explanation')
+      label =t('activemodel.attributes.applikation/forms/savings_investment.explanation')
 
   .row
     .small-12.medium-8.large-5.columns
       .form-group
         .row.collapse
           .columns.small-12
-            = f.label :threshold_exceeded, t("activerecord.attributes.application.page_3.savings.#{@application.married ? 'married' : 'single'}")
+            = f.label :threshold_exceeded, t("activemodel.attributes.applikation/forms/savings_investment.#{@application.married ? 'married' : 'single'}")
             = f.label :threshold_exceeded, @form.errors[:threshold_exceeded].join(', '), class: 'error' if @form.errors[:threshold_exceeded].present?
             .options.radio
               .option
                 label for='application_threshold_exceeded_false'
                   = f.radio_button :threshold_exceeded, 'false', { class: 'show-hide-section', data: { section: 'over-61', show: 'false' } }
-                  = t('activerecord.attributes.application.page_3.savings.less_than')
+                  = t('activemodel.attributes.applikation/forms/savings_investment.less_than')
               .option
                 label for='application_threshold_exceeded_true'
                   = f.radio_button :threshold_exceeded, 'true', { class: 'show-hide-section', data: { section: 'over-61', show: 'true' } }
-                  = t('activerecord.attributes.application.page_3.savings.more_than')
+                  = t('activemodel.attributes.applikation/forms/savings_investment.more_than')
 
   -if @application.applicant_over_61?
     =f.hidden_field :partner_over_61, value: 'true'
@@ -42,7 +42,7 @@
           .form-group.panel-indent
             .row.collapse
               .columns.small-12
-                = f.label :partner_over_61, t('activerecord.attributes.application.partner_over_61')
+                = f.label :partner_over_61, t('activemodel.attributes.applikation/forms/savings_investment.partner_over_61')
                 = f.label :partner_over_61, @form.errors[:partner_over_61].join(', '), class: 'error' if @form.errors[:partner_over_61].present?
                 .options.radio
                   .option
@@ -63,11 +63,11 @@
                           .option
                             label for="application_high_threshold_exceeded_false"
                               = f.radio_button :high_threshold_exceeded, 'false'
-                              = t('activerecord.attributes.application.page_3.savings.less_than_high')
+                              = t('activemodel.attributes.applikation/forms/savings_investment.less_than_high')
                           .option
                             label for="application_high_threshold_exceeded_true"
                               = f.radio_button :high_threshold_exceeded, 'true'
-                              = t('activerecord.attributes.application.page_3.savings.more_than_high')
+                              = t('activemodel.attributes.applikation/forms/savings_investment.more_than_high')
 
   = f.hidden_field :status
   = f.submit 'Next', :class => 'button primary'
@@ -86,7 +86,7 @@
                 .columns.small-8 #{@application.applicant_age} years old
               .row
                 .columns.small-4.table-label Status
-                .columns.small-8 =@application.married ? t('activerecord.attributes.application.page_1.married_true') : t('activerecord.attributes.application.page_1.married_false')
+                .columns.small-8 =t("activemodel.attributes.applikation/forms/personal_information.married_#{@application.married}")
               .row
                 .columns.small-4.table-label Fee
                 .columns.small-8 £#{@application.fee.floor}

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -94,7 +94,7 @@
       .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.children')
       .small-12.medium-7.large-8.columns =@application.children
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.income')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.total_income')
       .small-12.medium-7.large-8.columns =number_to_currency(@application.income.floor, precision: 0)
     .row
       .small-12.columns

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -8,18 +8,18 @@
         h4 Personal details
       .small-12.medium-5.large-4.columns.text-right =link_to 'Change personal information', wizard_path(:personal_information)
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.full_name')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/personal_information.full_name')
       .small-12.medium-7.large-8.columns =@application.full_name
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.date_of_birth')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/personal_information.date_of_birth')
       .small-12.medium-7.large-8.columns =@application.date_of_birth.to_s(:gov_uk_long)
     -if @application.ni_number.present?
       .row
-        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.ni_number')
+        .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/personal_information.ni_number')
         .small-12.medium-7.large-8.columns = @application.ni_number_display
     .row
       .small-12.medium-5.large-4.columns.subheader Status
-      .small-12.medium-7.large-8.columns =@application.married ? t('activerecord.attributes.application.page_1.married_true') : t('activerecord.attributes.application.page_1.married_false')
+      .small-12.medium-7.large-8.columns =t("activemodel.attributes.applikation/forms/personal_information.married_#{@application.married}")
 
   .summary-section
     .row
@@ -27,32 +27,32 @@
         h4 Application details
       .small-12.medium-5.large-4.columns.text-right =link_to 'Change application details', wizard_path(:application_details)
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.fee')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.fee')
       .small-12.medium-7.large-8.columns =number_to_currency(@application.fee.floor, precision: 0)
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.jurisdiction_id')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.jurisdiction_id')
       .small-12.medium-7.large-8.columns =@application.jurisdiction.display_full
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.date_received')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.date_received')
       .small-12.medium-7.large-8.columns =@application.date_received.to_s(:gov_uk_long)
     -if @application.form_name.present?
       .row
-        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.form_name_summary')
+        .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.form_name_summary')
         .small-12.medium-7.large-8.columns =@application.form_name
     -if @application.case_number.present?
       .row
-        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.case_number')
+        .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.case_number')
         .small-12.medium-7.large-8.columns =@application.case_number
     -if @application.probate
       .row
-        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.deceased_name')
+        .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.deceased_name')
         .small-12.medium-7.large-8.columns =@application.deceased_name
       .row
-        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.date_of_death')
+        .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.date_of_death')
         .small-12.medium-7.large-8.columns =@application.date_of_death.to_s(:gov_uk_long)
     -if @application.refund
       .row
-        .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.date_fee_paid')
+        .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/application_detail.date_fee_paid')
         .small-12.medium-7.large-8.columns =@application.date_fee_paid.to_s(:gov_uk_long)
     -unless @application.emergency_reason.blank?
       .row
@@ -61,22 +61,22 @@
 
   .row
     .small-12.medium-7.large-8.columns
-      h4 =t('activerecord.attributes.application.page_3.header')
+      h4 =t('activemodel.attributes.applikation/forms/savings_investment.header')
     .small-12.medium-5.large-4.columns.text-right =link_to 'Change savings and investments', wizard_path(:savings_investments)
   .row
-    .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.savings_investments')
+    .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.savings_investments')
     -if @application.savings_investment_valid?
-      .small-12.medium-7.large-8.columns.summary-result.success =t('activerecord.attributes.application.summary.passed').html_safe
+      .small-12.medium-7.large-8.columns.summary-result.success =t('activemodel.attributes.applikation/forms/summary.passed').html_safe
     -else
-      .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe
+      .small-12.medium-7.large-8.columns.summary-result.failure =t('activemodel.attributes.applikation/forms/summary.failed').html_safe
   -case @application.application_type
   -when 'benefit'
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.benefits')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.benefits')
       -if @application.last_benefit_check && @application.last_benefit_check.benefits_valid
-        .small-12.medium-7.large-8.columns.summary-result.success =t('activerecord.attributes.application.summary.passed').html_safe
+        .small-12.medium-7.large-8.columns.summary-result.success =t('activemodel.attributes.applikation/forms/summary.passed').html_safe
       -else
-        .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe
+        .small-12.medium-7.large-8.columns.summary-result.failure =t('activemodel.attributes.applikation/forms/summary.failed').html_safe
     .row
       .small-12.columns
         .row.collapse.medium-10.large-8
@@ -84,17 +84,17 @@
             h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}").html_safe
   -when 'income'
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.summary.income')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.income')
       -if @application.application_outcome == 'none'
-        .small-12.medium-7.large-8.columns.summary-result.failure =t('activerecord.attributes.application.summary.failed').html_safe
+        .small-12.medium-7.large-8.columns.summary-result.failure =t('activemodel.attributes.applikation/forms/summary.failed').html_safe
       -else
         .small-12.medium-7.large-8.columns.summary-result class=(@application.application_outcome == 'full' ? 'success' : 'partial')
-          =t('activerecord.attributes.application.summary.passed').html_safe
+          =t('activemodel.attributes.applikation/forms/summary.passed').html_safe
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.children')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.children')
       .small-12.medium-7.large-8.columns =@application.children
     .row
-      .small-12.medium-5.large-4.columns.subheader =t('activerecord.attributes.application.income')
+      .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.income')
       .small-12.medium-7.large-8.columns =number_to_currency(@application.income.floor, precision: 0)
     .row
       .small-12.columns

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -243,17 +243,90 @@ en-GB:
       evidence/views/dashboard:
         form_name: Form
         full_name: Applicant
-      applikation/forms/benefit:
-        benefits: Is the applicant receiving one of the benefits listed in question 9?
-      applikation/forms/income:
-        dependents: Are there any financially dependent children?
+      applikation/forms/personal_information:
+        undetermined: 'The details you’ve entered are incorrect, check and try again'
+        title: Title
+        first_name: First and middle names
+        last_name: 'Last name'
+        last_name_hint: 'First 3 letters only'
+        full_name: Full name
+        ni_number: 'National Insurance number'
+        date_of_birth: 'Date of birth'
+        married: Status
+        date_of_birth_hint: For example 01/11/1980
+        married_false: Single
+        married_true: Married or living with someone and sharing an income
+        form_name_summary: Form name or number
       applikation/forms/application_detail:
+        fee: Fee
+        jurisdiction_id: Jurisdiction
+        date_received: Date application received
+        form_name: Form number or name
+        case_number: Case number
+        probate: This is a probate case
+        deceased_name: Name of the deceased
+        date_of_death: Date of their death
+        refund: This is a refund case
+        date_fee_paid: Date fee paid
         emergency: This is an emergency case
         emergency_reason: Reason for emergency
+      applikation/forms/savings_investment:
+        header: Savings and investments
+        maximum_prompt: 'Maximum amount of savings and investments allowed:'
+        explanation: This amount may be different to what’s on the form. It’s calculated on the applicant’s age and fee amount.
+        single: In question 7, the applicant has
+        married: In question 7, the applicant and their partner have
+        partner_over_61: "In question 8, is the applicant's partner 61 or over?"
+        less_than: Less than this amount
+        more_than: More than this amount
+        less_than_high: Less than £16,000
+        more_than_high: More than £16,000
+        high_threshold_exceeded: In question 8, the applicant and their partner have
+      applikation/forms/benefit:
+        benefits: Is the applicant receiving one of the benefits listed in question 9?
+        benefits_false: 'No'
+        benefits_true: 'Yes'
+      applikation/forms/income:
+        dependents: Are there any financially dependent children?
+        income_false: 'No'
+        income_true: 'Yes'
+        children: Number of children
+        income: Total monthly income
+      applikation/forms/summary:
+        passed: '✓ Passed'
+        failed: '✗ Failed'
+        full: '✓ Passed'
+        part: '✓ Passed'
+        none: '✗ Failed'
+        'true': '✓ Passed'
+        'false': '✗ Failed'
+        savings_investments: Savings and investments
+        benefits: Benefits
+        income: Income
     errors:
       models:
+        applikation/forms/personal_information:
+          attributes:
+            last_name:
+              blank: Enter the applicant's last name
+              too_short: Last name is too short (minimum is 2 characters)
+            date_of_birth:
+              too_young: "The applicant can't be under %{minimum_age} years old"
+              too_old: "The applicant can't be over %{maximum_age} years old"
+              non_date: "You must provide a valid date of birth"
+              not_a_date: Enter the date in this format 01/11/1980
+            ni_number:
+              blank: 'Enter the applicant’s National Insurance number'
+              invalid: 'Enter 2 letters, 6 numbers and 1 letter for the National Insurance number'
+            married:
+              inclusion: Please select a marital status
         applikation/forms/application_detail:
           attributes:
+            fee:
+              blank: Enter the fee
+              not_a_number: The fee should be numeric
+            jurisdiction_id:
+              blank: You must select a jurisdiction
             date_received:
               blank: Enter the date the application was received
               not_a_date: Enter the date in this format 01/01/2015
@@ -282,22 +355,26 @@ en-GB:
             emergency_reason:
               cant_have_emergency_reason_without_emergency: "Can't have emergency reason without emergency"
               too_long: "is too long, it needs to be less than 500 characters"
-        applikation/forms/personal_information:
+        applikation/forms/savings_investment:
           attributes:
-            date_of_birth:
-              too_young: "The applicant can't be under %{minimum_age} years old"
-              too_old: "The applicant can't be over %{maximum_age} years old"
-              non_date: "You must provide a valid date of birth"
-              not_a_date: Enter the date in this format 01/11/1980
+            threshold_exceeded:
+              inclusion: You must answer the savings question
+            partner_over_61:
+              inclusion: Please confirm the ages
         applikation/forms/benefit:
           attributes:
             benefits:
               inclusion: You must answer the benefits question
         applikation/forms/income:
           attributes:
+            dependents:
+              inclusion: 'You must answer the dependent children question'
             children:
               not_a_number: Choose number of children
               cant_have_children_assigned: "You can't have number of children assigned when there are no dependants"
+            income:
+              blank: Enter the total monthly income
+              not_a_number: Enter the total monthly income
   activerecord:
     errors:
       models:
@@ -338,57 +415,6 @@ en-GB:
               invalid: Enter the date in this format day month, year DD/MM/YYYY
               after: The application must have been made in the last 3 months
               before: The application cannot be a future date
-        application:
-          attributes:
-            last_name:
-              blank: Enter the applicant's last name
-              too_short: Last name is too short (minimum is 2 characters)
-            date_of_birth:
-              blank: Enter the applicant's date of birth
-              invalid: 'Enter the date as day, month, year DD/MM/YYYY'
-              not_a_date: 'Enter the date in this format 01/11/1980'
-            ni_number:
-              blank: 'Enter the applicant’s National Insurance number'
-              invalid: 'Enter 2 letters, 6 numbers and 1 letter for the National Insurance number'
-            married:
-              inclusion: Please select a marital status
-            fee:
-              blank: Enter the fee
-              not_a_number: The fee should be numeric
-            jurisdiction_id:
-              blank: You must select a jurisdiction
-            date_received:
-              blank: Enter the date the application was received
-              not_a_date: Enter the date in this format 01/01/2015
-              invalid: Enter the date in this format day month, year DD/MM/YYYY
-              after: The application must have been made in the last 3 months
-              before: The application cannot be a future date
-            date_of_death:
-              blank: The date of death should be entered
-              not_a_date: Enter the date in this format 01/01/2015
-              invalid: Enter the date in this format day month, year DD/MM/YYYY
-              before: The date of death cannot be a future date
-            deceased_name:
-              blank: The deceased's name should be entered
-            date_fee_paid:
-              not_a_date: Enter the date in this format 01/01/2015
-              invalid: Enter the date in this format day month, year DD/MM/YYYY
-              after: The application must have been made in the last 3 months
-              before: The application cannot be a future date
-              blank: The date fee paid should be entered
-            threshold_exceeded:
-              inclusion: You must answer the savings question
-            partner_over_61:
-              inclusion: Please confirm the ages
-            benefits:
-              inclusion: You must answer the benefits question
-            dependents:
-              inclusion: 'You must answer the dependent children question'
-            children:
-              not_a_number: Choose number of children
-            income:
-              blank: Enter the total monthly income
-              not_a_number: Enter the total monthly income
     attributes:
       user:
         current_password: Current password
@@ -415,69 +441,6 @@ en-GB:
         date_to_check_hint: 'For refunds enter the date the case or claim was issued by the court.'
       office:
         name: Name of office
-      application:
-        undetermined: 'The details you’ve entered are incorrect, check and try again'
-        title: Title
-        first_name: First and middle names
-        last_name: 'Last name'
-        last_name_hint: 'First 3 letters only'
-        full_name: Full name
-        ni_number: 'National Insurance number'
-        date_of_birth: 'Date of birth'
-        married: Status
-        fee: Fee
-        jurisdiction_id: Jurisdiction
-        date_received: Date application received
-        form_name: Form number or name
-        case_number: Case number
-        probate: This is a probate case
-        deceased_name: Name of the deceased
-        date_of_death: Date of their death
-        refund: This is a refund case
-        date_fee_paid: Date fee paid
-        partner_over_61: "In question 8, is the applicant's partner 61 or over?"
-        benefits: Is the applicant receiving one of the benefits listed in question 9?
-        dependents: Are there any financially dependent children?
-        children: Number of children
-        income: Total monthly income
-        high_threshold_exceeded: In question 8, the applicant and their partner have
-        page_1:
-          date_of_birth_hint: For example 01/11/1980
-          married_false: Single
-          married_true: Married or living with someone and sharing an income
-          form_name_summary: Form name or number
-        page_3:
-          header: Savings and investments
-          maximum_prompt: 'Maximum amount of savings and investments allowed:'
-          explanation: This amount may be different to what’s on the form. It’s calculated on the applicant’s age and fee amount.
-          savings:
-            single: In question 7, the applicant has
-            married: In question 7, the applicant and their partner have
-            less_than: Less than this amount
-            more_than: More than this amount
-            less_than_high: Less than £16,000
-            more_than_high: More than £16,000
-        page_4:
-          benefits_false: 'No'
-          benefits_true: 'Yes'
-        income_page:
-          header: Application result
-        summary:
-          passed: '✓ Passed'
-          failed: '✗ Failed'
-          full: '✓ Passed'
-          part: '✓ Passed'
-          none: '✗ Failed'
-          'true': '✓ Passed'
-          'false': '✗ Failed'
-          savings_investments: Savings and investments
-          benefits: Benefits
-          income: Income
-        benefits_false: 'No'
-        benefits_true: 'Yes'
-        income_false: 'No'
-        income_true: 'Yes'
-        emergency_reason: Emergency reason
       r2_calc:
         labels:
           fee: Fee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,7 +302,8 @@ en-GB:
         'false': '✗ Failed'
         savings_investments: Savings and investments
         benefits: Benefits
-        income: Total monthly income
+        total_income: Total monthly income
+        income: Income
         children: Number of children
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -302,7 +302,8 @@ en-GB:
         'false': '✗ Failed'
         savings_investments: Savings and investments
         benefits: Benefits
-        income: Income
+        income: Total monthly income
+        children: Number of children
     errors:
       models:
         applikation/forms/personal_information:

--- a/spec/features/applications/application_jurisdiction_validation_spec.rb
+++ b/spec/features/applications/application_jurisdiction_validation_spec.rb
@@ -36,14 +36,14 @@ RSpec.feature 'While filling in the application details', type: :feature do
       end
 
       context 'when only the jurisdiction is selected' do
-        scenario "and the form resubmitted, jurisdiction selection is not shown" do
+        scenario 'and the form resubmitted, jurisdiction selection is not shown' do
           find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
           click_button 'Next'
           expect(page).to have_xpath('//h2', text: 'Application details')
           fill_in 'application_fee', with: '300'
           fill_in 'application_date_received', with: Time.zone.today - 3.days
           click_button 'Next'
-          expect(page).to have_content "can't be blank"
+          expect(page).to have_content 'You must select a jurisdiction'
           # TODO: the bug manifests here if we resubmit the form, the
           # selection for the Jurisdiction is gone!
         end


### PR DESCRIPTION
The application form referenced the local file in the ActiveRecord
namespace.  Once the form objects were created, the labels 
needed moving into the ActiveModel namespace.  This left 
duplication and some form labels/errors that had not transitioned 
properly.

This PR moves all entries into their proper namespaces and 
updates the savings_investment model to add the correct error
messages.