### PR TITLE
Create part-payments

### DIFF
--- a/app/controllers/applications/build_controller.rb
+++ b/app/controllers/applications/build_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable ClassLength
 class Applications::BuildController < ApplicationController
   include Wicked::Wizard
   before_action :authenticate_user!
@@ -44,6 +45,7 @@ class Applications::BuildController < ApplicationController
 
   def update
     evidence_check_selection
+    create_payment_if_needed
 
     if FORM_OBJECTS.include?(step)
       handle_form_object(params, step)
@@ -90,6 +92,12 @@ class Applications::BuildController < ApplicationController
   def evidence_check_selection
     if next_step?(:summary) && evidence_check_enabled?
       EvidenceCheckSelector.new(@application, Settings.evidence_check.expires_in_days).decide!
+    end
+  end
+
+  def create_payment_if_needed
+    if next_step?(:summary) && payment_enabled?
+      PaymentBuilder.new(@application, Settings.payment.expires_in_days).decide!
     end
   end
 

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -87,6 +87,9 @@ class EvidenceController < ApplicationController
       completed_at: Time.zone.now,
       completed_by: current_user
     )
+    if payment_enabled?
+      PaymentBuilder.new(@evidence.application, Settings.payment.expires_in_days).decide!
+    end
     redirect_to evidence_confirmation_path
   end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -198,6 +198,10 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
     !evidence_check.nil?
   end
 
+  def payment?
+    !payment.nil?
+  end
+
   private
 
   def income_required?

--- a/app/services/payment_builder.rb
+++ b/app/services/payment_builder.rb
@@ -12,8 +12,12 @@ class PaymentBuilder
 
   def part_payment?
     unless @application.payment?
-      @application.application_outcome == 'part' && !@application.evidence_check?
+      @application.application_outcome == 'part' && evidence_check_payment_validation?
     end
+  end
+
+  def evidence_check_payment_validation?
+    !@application.evidence_check? || @application.evidence_check.completed_at.present?
   end
 
   def expires_at

--- a/app/services/payment_builder.rb
+++ b/app/services/payment_builder.rb
@@ -1,0 +1,20 @@
+class PaymentBuilder
+  def initialize(application, expires_in_days)
+    @application = application
+    @expires_in_days = expires_in_days
+  end
+
+  def decide!
+    @application.create_payment(expires_at: expires_at) if part_payment?
+  end
+
+  private
+
+  def part_payment?
+    @application.application_outcome == 'part' && !@application.evidence_check?
+  end
+
+  def expires_at
+    @expires_in_days.days.from_now
+  end
+end

--- a/app/services/payment_builder.rb
+++ b/app/services/payment_builder.rb
@@ -11,7 +11,9 @@ class PaymentBuilder
   private
 
   def part_payment?
-    @application.application_outcome == 'part' && !@application.evidence_check?
+    unless @application.payment?
+      @application.application_outcome == 'part' && !@application.evidence_check?
+    end
   end
 
   def expires_at

--- a/app/services/payment_builder.rb
+++ b/app/services/payment_builder.rb
@@ -5,15 +5,21 @@ class PaymentBuilder
   end
 
   def decide!
-    @application.create_payment(expires_at: expires_at) if part_payment?
+    @application.create_payment(expires_at: expires_at) if part_payment_needed?
   end
 
   private
 
-  def part_payment?
-    unless @application.payment?
-      @application.application_outcome == 'part' && evidence_check_payment_validation?
-    end
+  def part_payment_needed?
+    part_remission_or_not_evidence_checked unless application_has_payment?
+  end
+
+  def application_has_payment?
+    @application.payment?
+  end
+
+  def part_remission_or_not_evidence_checked
+    @application.application_outcome.eql?('part') && evidence_check_payment_validation?
   end
 
   def evidence_check_payment_validation?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,3 +12,4 @@ evidence_check:
   expires_in_days: 14
 payment:
   enabled: <%= ENV['PAYMENT_ENABLED'] || false %>
+  expires_in_days: 14

--- a/spec/services/payment_builder_spec.rb
+++ b/spec/services/payment_builder_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe PaymentBuilder do
+  let(:current_time) { Time.zone.now }
+  let(:expires_in_days) { 2 }
+  subject(:payment_builder) { described_class.new(application, expires_in_days) }
+
+  describe '#decide!' do
+    subject do
+      Timecop.freeze(current_time) do
+        payment_builder.decide!
+      end
+
+      application.payment
+    end
+
+    context 'when application is a part payment' do
+      let(:application) { create :application_part_remission }
+
+      it { is_expected.to be_a(Payment) }
+
+      it 'sets expiration on the payment' do
+        expect(subject.expires_at).to eql(current_time + expires_in_days.days)
+      end
+    end
+
+    context 'for non-applicable application types' do
+      describe 'full remission' do
+        let(:application) { create :application_full_remission }
+
+        it 'does not create a payment record' do
+          is_expected.to be nil
+        end
+      end
+
+      describe 'no remission' do
+        let(:application) { create :application_no_remission }
+
+        it 'does not create a payment record' do
+          is_expected.to be nil
+        end
+      end
+
+      describe 'part payment' do
+        let(:application) { create :application_part_remission }
+        before { allow_message_expectations_on_nil }
+
+        context 'and an evidence check has been created' do
+          before { allow(application).to receive(:evidence_check?).and_return(true) }
+
+          context 'but not completed' do
+            before { allow(application.evidence_check).to receive(:completed_at).and_return(nil) }
+
+            it 'does not create a payment record' do
+              is_expected.to be nil
+            end
+          end
+
+          context 'and completed' do
+            before { allow(application.evidence_check).to receive(:completed_at).and_return(Time.zone.now - 1.days) }
+
+            it { is_expected.to be_a(Payment) }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a user reaches the end of the application form and
evidence check processes, a payment record is created
when the result is a partial-remission.  

If an application form results in partial and is selected for
evidence check, the payment record is not created.