### PR TITLE
When no NI number provided, prevent loop

### DIFF
--- a/app/controllers/benefit_overrides_controller.rb
+++ b/app/controllers/benefit_overrides_controller.rb
@@ -1,0 +1,29 @@
+class BenefitOverridesController < ApplicationController
+  before_action :setup_application
+
+  def paper_evidence
+    @form = BenefitOverride.new(application_id: @application.id)
+  end
+
+  def paper_evidence_save
+    evidence = allowed_params['correct']
+    @form = BenefitOverride.find_or_create_by(application_id: @application.id)
+    @form.correct = evidence
+
+    if @form.save
+      redirect_to application_build_path(application_id: @application.id, id: :summary)
+    else
+      redirect_to paper_evidence_path(@application)
+    end
+  end
+
+  private
+
+  def setup_application
+    @application = Application.find(params[:application_id])
+  end
+
+  def allowed_params
+    params.require(:benefit_override).permit(*Forms::BenefitsEvidence.permitted_attributes)
+  end
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -6,6 +6,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   has_many :benefit_checks
   has_one :evidence_check, required: false
   has_one :payment, required: false
+  has_one :benefit_override, required: false
 
   validates :reference, presence: true, uniqueness: true
 

--- a/app/models/benefit_override.rb
+++ b/app/models/benefit_override.rb
@@ -1,0 +1,4 @@
+class BenefitOverride < ActiveRecord::Base
+  belongs_to :application, required: true
+  belongs_to :completed_by, -> { with_deleted }, class_name: 'User'
+end

--- a/app/models/forms/benefits_evidence.rb
+++ b/app/models/forms/benefits_evidence.rb
@@ -1,0 +1,21 @@
+module Forms
+  class BenefitsEvidence < ::FormObject
+    def self.permitted_attributes
+      { correct: Boolean }
+    end
+
+    define_attributes
+
+    validates :correct, inclusion: { in: [true, false] }
+
+    private
+
+    def fields_to_update
+      { correct: correct }
+    end
+
+    def persist!
+      @object.update(fields_to_update)
+    end
+  end
+end

--- a/app/views/applications/build/benefits_result.html.slim
+++ b/app/views/applications/build/benefits_result.html.slim
@@ -1,28 +1,16 @@
 h2 Benefits
 
+.row.collapse
+  .columns.small-12.medium-10.large-8
+    -if @application.can_check_benefits? &&  @application.last_benefit_check.dwp_result.parameterize.underscore != 'undetermined'
+      #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
+        h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
+    -else
+      #result.callout.callout-none
+        h3.bold =t('benefit_checks.details_missing.heading')
+
+      =link_to 'The applicant has provided paper evidence', application_benefit_override_paper_evidence_path(@application)
+
 = form_for @application, url: wizard_path, method: :put, html: { autocomplete: 'off' } do |f|
-  - if @application.can_check_benefits?
-      .row.collapse
-        .columns.small-12.medium-10.large-8
-          #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
-            h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
-
-      -if @application.last_benefit_check.dwp_result.parameterize.underscore == 'undetermined'
-        =render("applications/partials/#{@application.last_benefit_check.dwp_result.parameterize.underscore}")
-        =link_to 'Check personal details', wizard_path(:personal_information)
-      -else
-        = f.hidden_field :status
-        = f.submit 'Next', :class => 'button primary'
-        =render("applications/partials/#{@application.last_benefit_check.dwp_result.parameterize.underscore}")
-
-  - else
-    .row.collapse
-      .columns.small-12.medium-10.large-8
-        #result.callout.callout-none
-          h3.bold =t('benefit_checks.details_missing.heading')
-    =link_to 'Check personal details', wizard_path(:personal_information)
-
-
-    .row
-    = f.hidden_field(:status)
-    = f.submit 'Next', class: 'button primary'
+  = f.hidden_field(:status)
+  = f.submit 'Next', class: 'button primary'

--- a/app/views/applications/build/benefits_result.html.slim
+++ b/app/views/applications/build/benefits_result.html.slim
@@ -1,24 +1,28 @@
 h2 Benefits
 
-- if @application.can_check_benefits?
+= form_for @application, url: wizard_path, method: :put, html: { autocomplete: 'off' } do |f|
+  - if @application.can_check_benefits?
+      .row.collapse
+        .columns.small-12.medium-10.large-8
+          #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
+            h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
 
-  = form_for @application, url: wizard_path, method: :put, html: { autocomplete: 'off' } do |f|
+      -if @application.last_benefit_check.dwp_result.parameterize.underscore == 'undetermined'
+        =render("applications/partials/#{@application.last_benefit_check.dwp_result.parameterize.underscore}")
+        =link_to 'Check personal details', wizard_path(:personal_information)
+      -else
+        = f.hidden_field :status
+        = f.submit 'Next', :class => 'button primary'
+        =render("applications/partials/#{@application.last_benefit_check.dwp_result.parameterize.underscore}")
+
+  - else
     .row.collapse
       .columns.small-12.medium-10.large-8
-        #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
-          h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
+        #result.callout.callout-none
+          h3.bold =t('benefit_checks.details_missing.heading')
+    =link_to 'Check personal details', wizard_path(:personal_information)
 
-    -if @application.last_benefit_check.dwp_result.parameterize.underscore == 'undetermined'
-      =render("applications/partials/#{@application.last_benefit_check.dwp_result.parameterize.underscore}")
-      =link_to 'Check personal details', wizard_path(:personal_information)
-    -else
-      = f.hidden_field :status
-      = f.submit 'Next', :class => 'button primary'
-      =render("applications/partials/#{@application.last_benefit_check.dwp_result.parameterize.underscore}")
 
-- else
-  .row.collapse
-    .columns.small-12.medium-10.large-8
-      #result.callout.details_missing
-        h3.bold =t('benefit_checks.details_missing.heading')
-  =link_to 'Check personal details', wizard_path(:personal_information)
+    .row
+    = f.hidden_field(:status)
+    = f.submit 'Next', class: 'button primary'

--- a/app/views/applications/build/confirmation.html.slim
+++ b/app/views/applications/build/confirmation.html.slim
@@ -3,15 +3,19 @@ h2 Application processed
 .row
   .small-12.columns
     .row.collapse.medium-10.large-8
-    - if @application.application_outcome.nil?
-      = render 'applications/partials/full_fee'
+    - if !@application.benefit_override.nil? && @application.benefit_override.correct.equal?(true)
+      #result.callout class='callout-full'
+        h3.bold =t('remissions.full').html_safe
     - else
-      -case @application.application_type
-      -when 'none'
+      - if @application.application_outcome.nil?
         = render 'applications/partials/full_fee'
-      -else
-        #calculator.callout class="callout-#{@application.application_outcome ? @application.application_outcome : 'error'}"
-          h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay? ? @application.amount_to_pay.floor : 0, precision: 0)).html_safe
+      - else
+        -case @application.application_type
+        -when 'none'
+          = render 'applications/partials/full_fee'
+        -else
+          #calculator.callout class="callout-#{@application.application_outcome ? @application.application_outcome : 'error'}"
+            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay? ? @application.amount_to_pay.floor : 0, precision: 0)).html_safe
 .row
   .small-12.medium-12.large-12.columns
     h4 Next steps

--- a/app/views/applications/build/confirmation.html.slim
+++ b/app/views/applications/build/confirmation.html.slim
@@ -3,10 +3,12 @@ h2 Application processed
 .row
   .small-12.columns
     .row.collapse.medium-10.large-8
+    - if @application.application_outcome.nil?
+      = render 'applications/partials/full_fee'
+    - else
       -case @application.application_type
       -when 'none'
-        #calculator.callout.callout-none
-          h3.bold =t('remissions.none').html_safe
+        = render 'applications/partials/full_fee'
       -else
         #calculator.callout class="callout-#{@application.application_outcome ? @application.application_outcome : 'error'}"
           h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay? ? @application.amount_to_pay.floor : 0, precision: 0)).html_safe

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -80,8 +80,11 @@
     .row
       .small-12.columns
         .row.collapse.medium-10.large-8
-          #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
-            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}").html_safe
+          - if @application.application_outcome.nil?
+            = render 'applications/partials/full_fee'
+          - else
+            #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
+              h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}").html_safe
   -when 'income'
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.income')
@@ -122,4 +125,4 @@
         h5 =@application.inspect
 
   = f.hidden_field :status
-  = f.submit 'Continue', :class => 'button primary'
+  = f.submit 'Complete processing', class: 'button primary'

--- a/app/views/applications/build/summary.html.slim
+++ b/app/views/applications/build/summary.html.slim
@@ -73,18 +73,22 @@
   -when 'benefit'
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.benefits')
-      -if @application.last_benefit_check && @application.last_benefit_check.benefits_valid
+      -if (@application.last_benefit_check && @application.last_benefit_check.benefits_valid) || (!@application.benefit_override.nil? && @application.benefit_override.correct.equal?(true))
         .small-12.medium-7.large-8.columns.summary-result.success =t('activemodel.attributes.applikation/forms/summary.passed').html_safe
       -else
         .small-12.medium-7.large-8.columns.summary-result.failure =t('activemodel.attributes.applikation/forms/summary.failed').html_safe
     .row
       .small-12.columns
         .row.collapse.medium-10.large-8
-          - if @application.application_outcome.nil?
-            = render 'applications/partials/full_fee'
+          - if !@application.benefit_override.nil? && @application.benefit_override.correct.equal?(true)
+            #result.callout class='callout-full'
+              h3.bold =t('remissions.full').html_safe
           - else
-            #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
-              h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}").html_safe
+            - if @application.application_outcome.nil?
+              = render 'applications/partials/full_fee'
+            - else
+              #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
+                h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}").html_safe
   -when 'income'
     .row
       .small-12.medium-5.large-4.columns.subheader =t('activemodel.attributes.applikation/forms/summary.income')

--- a/app/views/applications/partials/_full_fee.html.slim
+++ b/app/views/applications/partials/_full_fee.html.slim
@@ -1,0 +1,2 @@
+#calculator.callout.callout-none
+  h3.bold =t('remissions.none').html_safe

--- a/app/views/benefit_overrides/paper_evidence.html.slim
+++ b/app/views/benefit_overrides/paper_evidence.html.slim
@@ -1,0 +1,20 @@
+h2 Evidence
+
+= form_for @form, url: application_benefit_override_paper_evidence_save_path(@application), method: :post, html: { autocomplete: 'off' } do |f|
+  .row
+    .small-12.medium-8.large-5.columns
+      .form-group
+        .row.collapse
+          .columns.small-12
+            = f.label :correct, t('benefit_override.title')
+            .options.radio
+              .option
+                label for='benefit_override_correct_false'
+                  = f.radio_button :correct, 'false'
+                  = t('benefit_override.incorrect')
+              .option
+                label for='benefit_override_correct_true'
+                  = f.radio_button :correct, 'true'
+                  = t('benefit_override.correct')
+
+  = f.submit 'Next', class: 'button primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,7 @@ en-GB:
     :no:
       heading: '✗ &nbsp; The applicant is not receiving benefits'
     details_missing:
-      heading: DWP check couldn't be performed, please make sure you've provided all personal details including National Insurance number
+      heading: "The applicant's details could not be checked with the Depatment for Work and Pensions"
     deleted:
       heading: The applicant is not receiving benefits
     deceased:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,25 +1,8 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en-GB:
+  benefit_override:
+    title: 'Do you have a letter confirming the applicant is receiving one of the benefits listed in question 9?'
+    incorrect: 'No'
+    correct: Yes, the letter is for the correct applicant and dated in the last 3 months
   evidence:
     correct: 'Yes'
     incorrect: 'No'
@@ -109,7 +92,7 @@ en-GB:
     :no:
       heading: '✗ &nbsp; The applicant is not receiving benefits'
     details_missing:
-      heading: "The applicant's details could not be checked with the Depatment for Work and Pensions"
+      heading: "The applicant's details could not be checked with the Department for Work and Pensions"
     deleted:
       heading: The applicant is not receiving benefits
     deceased:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   get '/applications/new' => 'applications/build#create'
   resources :applications do
     resources :build, controller: 'applications/build'
+    get 'benefit_override/paper_evidence', to: 'benefit_overrides#paper_evidence'
+    post 'benefit_override/paper_evidence_save', to: 'benefit_overrides#paper_evidence_save'
   end
 
   get 'evidence/:id', to: 'evidence#show', as: :evidence_show

--- a/db/migrate/20151021112859_create_benefit_overrides.rb
+++ b/db/migrate/20151021112859_create_benefit_overrides.rb
@@ -1,0 +1,13 @@
+class CreateBenefitOverrides < ActiveRecord::Migration
+  def change
+    create_table :benefit_overrides do |t|
+      t.references :application, index: true, null: false
+      t.boolean :correct
+      t.integer :completed_by_id
+
+      t.timestamps null: false
+    end
+
+    add_foreign_key :benefit_overrides, :applications
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151018115056) do
+ActiveRecord::Schema.define(version: 20151021112859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,16 @@ ActiveRecord::Schema.define(version: 20151018115056) do
 
   add_index "benefit_checks", ["application_id"], name: "index_benefit_checks_on_application_id", using: :btree
   add_index "benefit_checks", ["user_id"], name: "index_benefit_checks_on_user_id", using: :btree
+
+  create_table "benefit_overrides", force: :cascade do |t|
+    t.integer  "application_id",  null: false
+    t.boolean  "correct"
+    t.integer  "completed_by_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "benefit_overrides", ["application_id"], name: "index_benefit_overrides_on_application_id", using: :btree
 
   create_table "dwp_checks", force: :cascade do |t|
     t.string   "last_name"
@@ -216,6 +226,7 @@ ActiveRecord::Schema.define(version: 20151018115056) do
   add_foreign_key "applications", "users"
   add_foreign_key "benefit_checks", "applications"
   add_foreign_key "benefit_checks", "users"
+  add_foreign_key "benefit_overrides", "applications"
   add_foreign_key "feedbacks", "offices"
   add_foreign_key "feedbacks", "users"
   add_foreign_key "office_jurisdictions", "jurisdictions"

--- a/spec/controllers/benefit_overrides_controller_spec.rb
+++ b/spec/controllers/benefit_overrides_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe BenefitOverridesController, type: :controller do
+  include Devise::TestHelpers
+
+  let(:application) { create :application }
+  let(:benefit_override) { build_stubbed(:benefit_override) }
+
+  describe 'GET #paper_evidence' do
+    before { get :paper_evidence, application_id: application.id }
+
+    it { expect(response).to have_http_status(200) }
+
+    it { expect(response).to render_template(:paper_evidence) }
+  end
+
+  describe 'POST #paper_evidence_save' do
+    context 'when the data provided is correct' do
+      let(:post_body) { { application_id: application.id, benefit_override: { correct: true } } }
+      before { post :paper_evidence_save, post_body }
+
+      it { expect(response).to have_http_status(302) }
+    end
+
+    context 'when the data provided is not correct' do
+      it 'raises an exception when no parameters are passed in' do
+        expect{
+          post :paper_evidence_save, application_id: application.id
+        }.to raise_error ActionController::ParameterMissing
+      end
+    end
+  end
+end

--- a/spec/factories/benefit_overrides.rb
+++ b/spec/factories/benefit_overrides.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :benefit_override do
+    correct false
+    completed_by_id 1
+  end
+end

--- a/spec/features/applications/application_form_stories_spec.rb
+++ b/spec/features/applications/application_form_stories_spec.rb
@@ -304,7 +304,7 @@ RSpec.feature 'Completing the application details', type: :feature do
                   end
 
                   context 'when the user clicks continue' do
-                    before { click_button 'Continue' }
+                    before { click_button 'Complete processing' }
 
                     scenario 'the confirmation is shown' do
                       expect(page).to have_xpath('//h2', text: 'Application processed')

--- a/spec/features/applications/benefit_results_are_rendered_spec.rb
+++ b/spec/features/applications/benefit_results_are_rendered_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Benefit Results', type: :feature do
     context 'after user selects yes to benefits' do
       context 'when NI has not been provided', focus: true do
         let(:ni_number) { nil }
+        let(:error_message) { "The applicant's details could not be checked with the Depatment for Work and Pensions" }
 
         scenario 'the page is rendered with message prompting to fill all details' do
           visit application_build_path(application_id: application.id, id: 'benefits')
@@ -26,7 +27,7 @@ RSpec.feature 'Benefit Results', type: :feature do
           choose 'application_benefits_true'
           click_button 'Next'
 
-          expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "details_missing")]/h3[@class="bold"]')
+          expect(page).to have_content error_message
         end
       end
 

--- a/spec/features/applications/benefit_results_are_rendered_spec.rb
+++ b/spec/features/applications/benefit_results_are_rendered_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Benefit Results', type: :feature do
     context 'after user selects yes to benefits' do
       context 'when NI has not been provided', focus: true do
         let(:ni_number) { nil }
-        let(:error_message) { "The applicant's details could not be checked with the Depatment for Work and Pensions" }
+        let(:error_message) { "The applicant's details could not be checked with the Department for Work and Pensions" }
 
         scenario 'the page is rendered with message prompting to fill all details' do
           visit application_build_path(application_id: application.id, id: 'benefits')
@@ -120,19 +120,15 @@ RSpec.feature 'Benefit Results', type: :feature do
           end
 
           scenario 'the next button is not rendered' do
-            expect(page).not_to have_xpath('//input[@type="submit"]')
+            expect(page).to have_xpath('//input[@type="submit"]')
           end
 
           scenario 'a link to personal details is rendered' do
-            expect(page).to have_xpath('//a', text: 'Check personal details')
+            expect(page).to have_content "The applicant's details could not be checked with the Department for Work and Pensions"
           end
 
           scenario 'the view is rendered with the correct style' do
-            expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "undetermined")]/h3[@class="bold"]')
-          end
-
-          scenario 'the view is rendered with the correct information' do
-            expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "undetermined")]/h3[@class="bold"]', text: I18n.t('benefit_checks.undetermined.heading'))
+            expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-none")]/h3[@class="bold"]')
           end
         end
 

--- a/spec/features/applications/no_ni_number_and_undetermined_result_spec.rb
+++ b/spec/features/applications/no_ni_number_and_undetermined_result_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+def personal_details_without_ni_number
+  login_as user
+  visit applications_new_path
+
+  fill_in 'application_last_name', with: 'Smith'
+  fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
+  choose 'application_married_false'
+  click_button 'Next'
+end
+
+def application_details
+  fill_in 'application_fee', with: 410
+  find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+  fill_in 'application_date_received', with: Time.zone.today
+  click_button 'Next'
+end
+
+def savings_and_investments
+  choose 'application_threshold_exceeded_false'
+  click_button 'Next'
+end
+
+def benefits_page
+  choose 'application_benefits_true'
+  click_button 'Next'
+end
+
+RSpec.feature 'No NI number provided', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions) { create_list :jurisdiction, 3 }
+  let!(:office)        { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)          { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+
+  before do
+    personal_details_without_ni_number
+    application_details
+    savings_and_investments
+    benefits_page
+  end
+
+  scenario 'correct warning message' do
+    warning_string = "The applicant's details could not be checked with the Depatment for Work and Pensions"
+    expect(page).to have_content warning_string
+  end
+
+  scenario '"Next" button' do
+    expect(page).to have_button 'Next'
+  end
+
+  context 'when the user progresses to the summary page' do
+    before { click_button 'Next' }
+    let(:error_message) { 'The applicant must pay the full fee' }
+
+    it { expect(page).to have_content error_message }
+
+    it { expect(page).to have_button 'Complete processing' }
+
+    context 'when the user completes the application' do
+      before { click_button 'Complete processing' }
+
+      it { expect(page).to have_content 'Application processed' }
+
+      it { expect(page).to have_content 'The applicant must pay the full fee' }
+    end
+  end
+end

--- a/spec/features/applications/stray_error_on_confirmation_page_spec.rb
+++ b/spec/features/applications/stray_error_on_confirmation_page_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Stray error on the confirmation page', type: :feature do
       click_button 'Next'
 
       expect(page).to have_xpath('//h2', text: 'Check details')
-      click_button 'Continue'
+      click_button 'Complete processing'
     end
 
     context 'when on application processed page' do

--- a/spec/features/applications/when_benefits_checker_returns_undetermined_result_spec.rb
+++ b/spec/features/applications/when_benefits_checker_returns_undetermined_result_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+def personal_details_page
+  fill_in 'application_last_name', with: 'Hirani'
+  fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
+  fill_in 'application_ni_number', with: 'JK089012B'
+  choose 'application_married_false'
+  click_button 'Next'
+end
+
+def application_details
+  fill_in 'application_fee', with: 410
+  find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+  fill_in 'application_date_received', with: Time.zone.today
+  click_button 'Next'
+end
+
+def savings_and_investments
+  choose 'application_threshold_exceeded_false'
+  click_button 'Next'
+end
+
+def benefits_page
+  choose 'application_benefits_true'
+  click_button 'Next'
+end
+
+def drive_to_the_benefits_page
+  personal_details_page
+  application_details
+  savings_and_investments
+  benefits_page
+end
+
+RSpec.feature 'When benefits checker result is "Undetermined"', type: :feature do
+  let!(:jurisdictions)   { create_list :jurisdiction, 3 }
+  let!(:office)          { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)            { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+  let(:message)          { "The applicant's details could not be checked with the Department for Work and Pensions" }
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  before do
+    dwp_api_response 'Undetermined'
+
+    login_as user
+    visit applications_new_path
+
+    drive_to_the_benefits_page
+  end
+
+  scenario 'shows the benefits override flow' do
+    expect(page).to have_content message
+  end
+end

--- a/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
+++ b/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Evidence check page displayed instead of confirmation', type: :fe
 
       expect(page).to have_content 'Evidence of income needs to be checked for this application'
 
-      click_button 'Continue'
+      click_button 'Complete processing'
 
       expect(evidence_check_rendered?).to be true
     end
@@ -51,7 +51,7 @@ RSpec.feature 'Evidence check page displayed instead of confirmation', type: :fe
 
       expect(page).to have_content '✓ The applicant doesn’t have to pay the fee'
 
-      click_button 'Continue'
+      click_button 'Complete processing'
 
       expect(confirmation_rendered?).to be true
     end

--- a/spec/models/benefit_override_spec.rb
+++ b/spec/models/benefit_override_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe BenefitOverride, type: :model do
+  it { is_expected.to belong_to(:application) }
+  it { is_expected.to validate_presence_of(:application) }
+end

--- a/spec/models/forms/benefits_evidence_spec.rb
+++ b/spec/models/forms/benefits_evidence_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe Forms::BenefitsEvidence do
+  params_list = %i[correct]
+
+  describe '.permitted_attributes' do
+    it 'returns a list of attributes' do
+      expect(described_class.permitted_attributes.keys).to match_array(params_list)
+    end
+  end
+
+  let(:benefit_override) { build_stubbed :benefit_override }
+
+  subject(:form) { described_class.new(benefit_override) }
+
+  describe 'validations' do
+    before { form.update_attributes(params) }
+    subject { form.valid? }
+
+    context 'for attribute "correct"' do
+      context 'when true' do
+        let(:params) { { correct: true } }
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context 'when false' do
+      let(:params) { { correct: false } }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when not a boolean value' do
+      let(:params) { { correct: 'some string' } }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe '#save' do
+    let(:application) { create :application }
+    let(:benefit_override) { create :benefit_override, application: application }
+
+    before { form.update_attributes(params) }
+
+    subject { form.save }
+
+    context 'for an invalid form' do
+      let(:params) { { correct: nil } }
+
+      it { is_expected.to be false }
+    end
+
+    context 'for a valid form when the evidence is correct' do
+      context 'when true' do
+        let(:params) { { correct: true } }
+
+        it { is_expected.to be true }
+
+        before { subject && benefit_override.reload }
+
+        it 'updates the correct field on benefits_override' do
+          expect(benefit_override.correct).to be true
+        end
+      end
+
+      context 'when false' do
+        let(:params) { { correct: false } }
+
+        it { is_expected.to be true }
+
+        before { subject && benefit_override.reload }
+
+        it 'updates the correct field on benefit_override' do
+          expect(benefit_override.correct).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/services/evidence_check_selector_spec.rb
+++ b/spec/services/evidence_check_selector_spec.rb
@@ -40,7 +40,7 @@ describe EvidenceCheckSelector do
 
     context 'for a non-benefit remission application' do
       context 'for a non-refund application' do
-        let(:application) { create :application_full_remission }
+        let(:application) { create :application_full_remission, reference: 'XY55-22-3' }
 
         context 'when the application is the 10th (10% gets checked)' do
           before do


### PR DESCRIPTION
There was an issue when a user didn't provide their NI number and the
application was started, the benefit check was attempted but it could
not be done because benefit check requires the NI number for the lookup.
This would throw the user into a loop. This change tries to prevent
that.
