### PR TITLE
Dashboard fix

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,7 +47,7 @@ en-GB:
       incorrect_reason: What is incorrect about the evidence?
     dashboard:
       heading: Waiting for evidence
-      no_evidence_checks: There are no applications waiting for evidence
+      no_records: There are no applications waiting for evidence
       table_header:
         reference: Reference
         applicant: Applicant
@@ -61,7 +61,7 @@ en-GB:
       incorrect_reason: What is incorrect about the payment?
     dashboard:
       heading: Waiting for payment
-      no_evidence_checks: There are no applications waiting for payment
+      no_records: There are no applications waiting for payment
       table_header:
         reference: Reference
         applicant: Applicant


### PR DESCRIPTION
The dashboards were looking for locale keys named no_record
I renamed the two keys from no_evidence_checks which were
wrong for evidence_checks and **very** wrong for payments!