### PR TITLE
Extracted scopes from Application into Query objects

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -42,7 +42,7 @@ class HomeController < ApplicationController
   end
 
   def waiting_for_evidence
-    current_user.office.applications.waiting_for_evidence
+    Query::WaitingForEvidence.new(current_user).find
   end
 
   def waiting_for_payment

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -46,7 +46,7 @@ class HomeController < ApplicationController
   end
 
   def waiting_for_payment
-    current_user.office.applications.waiting_for_payment
+    Query::WaitingForPayment.new(current_user).find
   end
 
   def load_graph_data

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -11,14 +11,6 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
 
   validates :reference, presence: true, uniqueness: true
 
-  scope :waiting_for_payment, lambda {
-    includes(:payment).
-      references(:payment).
-      where('payments.completed_at IS NULL').
-      where.not(payments: { id: nil }).
-      order('payments.expires_at ASC')
-  }
-
   # Fixme remove this delegation methods when all tests are clean
   APPLICANT_GETTERS = %i[title first_name last_name date_of_birth ni_number married married?]
   APPLICANT_SETTERS = %i[title= first_name= last_name= date_of_birth= ni_number= married=]

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -11,13 +11,6 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
 
   validates :reference, presence: true, uniqueness: true
 
-  scope :evidencecheckable, lambda {
-    where(benefits: false,
-          application_type: 'income',
-          emergency_reason: nil,
-          application_outcome: %w[part full])
-  }
-
   scope :waiting_for_evidence, lambda {
     includes(:evidence_check).
       references(:evidence_check).

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -11,14 +11,6 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
 
   validates :reference, presence: true, uniqueness: true
 
-  scope :waiting_for_evidence, lambda {
-    includes(:evidence_check).
-      references(:evidence_check).
-      where('evidence_checks.completed_at IS NULL').
-      where.not(evidence_checks: { id: nil }).
-      order('evidence_checks.expires_at ASC')
-  }
-
   scope :waiting_for_payment, lambda {
     includes(:payment).
       references(:payment).

--- a/app/models/query/evidence_checkable.rb
+++ b/app/models/query/evidence_checkable.rb
@@ -1,0 +1,16 @@
+module Query
+  class EvidenceCheckable
+    def initialize(relation = Application)
+      @relation = relation
+    end
+
+    def find_all
+      @relation.where(
+        benefits: false,
+        application_type: 'income',
+        emergency_reason: nil,
+        application_outcome: %w[part full]
+      )
+    end
+  end
+end

--- a/app/models/query/waiting_for_evidence.rb
+++ b/app/models/query/waiting_for_evidence.rb
@@ -1,0 +1,15 @@
+module Query
+  class WaitingForEvidence
+    def initialize(user)
+      @user = user
+    end
+
+    def find
+      @user.office.applications.includes(:evidence_check).
+        references(:evidence_check).
+        where('evidence_checks.completed_at IS NULL').
+        where.not(evidence_checks: { id: nil }).
+        order('evidence_checks.expires_at ASC')
+    end
+  end
+end

--- a/app/models/query/waiting_for_payment.rb
+++ b/app/models/query/waiting_for_payment.rb
@@ -1,0 +1,15 @@
+module Query
+  class WaitingForPayment
+    def initialize(user)
+      @user = user
+    end
+
+    def find
+      @user.office.applications.includes(:payment).
+        references(:payment).
+        where('payments.completed_at IS NULL').
+        where.not(payments: { id: nil }).
+        order('payments.expires_at ASC')
+    end
+  end
+end

--- a/app/services/evidence_check_selector.rb
+++ b/app/services/evidence_check_selector.rb
@@ -11,7 +11,7 @@ class EvidenceCheckSelector
   private
 
   def evidence_check?
-    if Application.evidencecheckable.exists?(@application.id)
+    if Query::EvidenceCheckable.new.find_all.exists?(@application.id)
       @application.refund? ? check_every_other_refund : check_every_tenth_non_refund
     end
   end
@@ -30,7 +30,10 @@ class EvidenceCheckSelector
   end
 
   def application_position(refund)
-    Application.evidencecheckable.where('id <= ? AND refund = ?', @application.id, refund).count
+    Query::EvidenceCheckable.new.find_all.where(
+      'id <= ? AND refund = ?',
+      @application.id,
+      refund).count
   end
 
   def expires_at

--- a/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
+++ b/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Evidence check page displayed instead of confirmation', type: :fe
     login_as user
   end
 
-  let(:application) { create :application_full_remission }
+  let(:application) { create :application_full_remission, reference: Random.srand }
 
   context 'when the Evidence check feature is enabled' do
     enable_evidence_check

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -199,21 +199,6 @@ RSpec.describe Application, type: :model do
       end
     end
 
-    describe '.waiting_for_evidence', focus: true do
-      let!(:application1) { create :application }
-      let!(:application2) { create :application }
-      let!(:application3) { create :application }
-      let!(:evidence_check1) { create :evidence_check, application: application1, expires_at: 2.days.from_now }
-      let!(:evidence_check2) { create :evidence_check, application: application2, expires_at: 1.days.from_now }
-      let!(:evidence_check3) { create :evidence_check, application: application3, expires_at: 1.days.from_now, completed_at: 2.days.ago }
-
-      subject { described_class.waiting_for_evidence }
-
-      it 'returns only applications which have uncompleted EvidenceCheck reference in order of expiry' do
-        is_expected.to eq([application2, application1])
-      end
-    end
-
     describe '.waiting_for_payment', focus: true do
       let!(:application1) { create :application }
       let!(:application2) { create :application }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -199,23 +199,6 @@ RSpec.describe Application, type: :model do
       end
     end
 
-    describe '.evidencecheckable' do
-      subject { described_class.evidencecheckable }
-
-      let!(:application_1) { create :application_part_remission }
-      let!(:application_2) { create :application_full_remission }
-      let!(:application_3) { create :application_no_remission }
-      let!(:emergency_application) { create :application_full_remission, emergency_reason: 'REASON' }
-
-      it 'includes only part and full remission applications' do
-        is_expected.to match_array([application_1, application_2])
-      end
-
-      it 'does not include emergency applications' do
-        is_expected.not_to include emergency_application
-      end
-    end
-
     describe '.waiting_for_evidence', focus: true do
       let!(:application1) { create :application }
       let!(:application2) { create :application }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -198,21 +198,6 @@ RSpec.describe Application, type: :model do
         end
       end
     end
-
-    describe '.waiting_for_payment', focus: true do
-      let!(:application1) { create :application }
-      let!(:application2) { create :application }
-      let!(:application3) { create :application }
-      let!(:payment1) { create :payment, application: application1, expires_at: 2.days.from_now }
-      let!(:payment2) { create :payment, application: application2, expires_at: 1.days.from_now }
-      let!(:payment3) { create :payment, application: application3, expires_at: 1.days.from_now, completed_at: 2.days.ago }
-
-      subject { described_class.waiting_for_payment }
-
-      it 'returns only applications which have uncompleted Payment reference in order of expiry' do
-        is_expected.to eq([application2, application1])
-      end
-    end
   end
 
   describe '#threshold' do

--- a/spec/models/query/evidence_checkable_spec.rb
+++ b/spec/models/query/evidence_checkable_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Query::EvidenceCheckable, type: :model do
+  describe '.find_all' do
+    subject { described_class.new.find_all }
+
+    let!(:application_1) { create :application_part_remission }
+    let!(:application_2) { create :application_full_remission }
+    let!(:application_3) { create :application_no_remission }
+    let!(:emergency_application) { create :application_full_remission, emergency_reason: 'REASON' }
+
+    it 'includes only part and full remission applications' do
+      is_expected.to match_array([application_1, application_2])
+    end
+
+    it 'does not include emergency applications' do
+      is_expected.not_to include emergency_application
+    end
+  end
+end

--- a/spec/models/query/waiting_for_evidence_spec.rb
+++ b/spec/models/query/waiting_for_evidence_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Query::WaitingForEvidence, type: :model do
+  describe '#find' do
+    let!(:user1) { create :user }
+    let!(:user2) { create :user }
+    let!(:application1) { create :application, user_id: user1.id, office_id: user1.office_id }
+    let!(:application2) { create :application, user_id: user1.id, office_id: user1.office_id }
+    let!(:application3) { create :application, user_id: user2.id, office_id: user2.office_id }
+    let!(:evidence_check1) { create :evidence_check, application: application1, expires_at: 2.days.from_now }
+    let!(:evidence_check2) { create :evidence_check, application: application2, expires_at: 1.days.from_now }
+    let!(:evidence_check3) { create :evidence_check, application: application3, expires_at: 1.days.from_now }
+
+    subject { described_class.new(user1).find }
+
+    it 'returns only applications which have EvidenceCheck reference in order of expiry' do
+      is_expected.to eq([application2, application1])
+    end
+  end
+end

--- a/spec/models/query/waiting_for_payment_spec.rb
+++ b/spec/models/query/waiting_for_payment_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Query::WaitingForPayment, type: :model do
+  describe '#find' do
+
+    let(:user) { create :user }
+    let!(:application1) { create :application, user_id: user.id, office_id: user.office_id }
+    let!(:application2) { create :application, user_id: user.id, office_id: user.office_id }
+    let!(:application3) { create :application, user_id: user.id, office_id: user.office_id }
+    let!(:payment1) { create :payment, application: application1, expires_at: 2.days.from_now }
+    let!(:payment2) { create :payment, application: application2, expires_at: 1.days.from_now }
+    let!(:payment3) { create :payment, application: application3, expires_at: 1.days.from_now, completed_at: 2.days.ago }
+
+    subject { described_class.new(user).find }
+
+    it 'returns only applications which have uncompleted Payment reference in order of expiry' do
+      is_expected.to eq([application2, application1])
+    end
+  end
+end


### PR DESCRIPTION
This is just a discussion starter, to see what you @colinbruce & @novotnyjakub think.

This is just an example of how we can do things: instead of having it
all stuffed into the Application model, tease it out.

The new nested structure directory 'query', that is open for debate,
maybe it should be called 'queries'?

Also something like this can be extracted out into this new query object and tested tighter:
https://github.com/ministryofjustice/fr-staffapp/blob/extract-queries/app/services/evidence_check_selector.rb#L33