### PR TITLE
Enabled caching of gems for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: false
 rvm:
 - 2.2.3
+cache: bundler
 before_script:
 - psql -c 'create role fr login createdb;' -U postgres
 addons:


### PR DESCRIPTION
This parameter enables caching of gem for Travis CI, so it speeds up the
testing.

Travis CI docs here:
http://docs.travis-ci.com/user/caching/