### PR TITLE
Fix for part payments from evidence-checks

### DIFF
--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -88,7 +88,7 @@ class EvidenceController < ApplicationController
       completed_by: current_user
     )
     if payment_enabled?
-      PaymentBuilder.new(@evidence.application, Settings.payment.expires_in_days).decide!
+      PaymentBuilder.new(@evidence, Settings.payment.expires_in_days).decide!
     end
     redirect_to evidence_confirmation_path
   end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -94,6 +94,8 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   end
   # End step 5 validation
 
+  alias_attribute :outcome, :application_outcome
+
   def children=(val)
     self[:children] = dependents? ? val : 0
   end

--- a/app/services/payment_builder.rb
+++ b/app/services/payment_builder.rb
@@ -1,6 +1,7 @@
 class PaymentBuilder
-  def initialize(application, expires_in_days)
-    @application = application
+  def initialize(initiator, expires_in_days)
+    @initiator = initiator
+    @application = load_application
     @expires_in_days = expires_in_days
   end
 
@@ -10,17 +11,13 @@ class PaymentBuilder
 
   private
 
-  def outcome
-    case evidence_or_application
+  def load_application
+    case @initiator
     when EvidenceCheck
-      evidence_or_application.outcome
+      @initiator.application
     when Application
-      evidence_or_application.application_outcome
+      @initiator
     end
-  end
-
-  def evidence_or_application
-    @application.evidence_check || @application
   end
 
   def part_payment_needed?
@@ -32,7 +29,7 @@ class PaymentBuilder
   end
 
   def part_remission_or_not_evidence_checked
-    outcome.eql?('part') && evidence_check_payment_validation?
+    @initiator.outcome.eql?('part') && evidence_check_payment_validation?
   end
 
   def evidence_check_payment_validation?

--- a/app/services/payment_builder.rb
+++ b/app/services/payment_builder.rb
@@ -10,6 +10,19 @@ class PaymentBuilder
 
   private
 
+  def outcome
+    case evidence_or_application
+    when EvidenceCheck
+      evidence_or_application.outcome
+    when Application
+      evidence_or_application.application_outcome
+    end
+  end
+
+  def evidence_or_application
+    @application.evidence_check || @application
+  end
+
   def part_payment_needed?
     part_remission_or_not_evidence_checked unless application_has_payment?
   end
@@ -19,7 +32,7 @@ class PaymentBuilder
   end
 
   def part_remission_or_not_evidence_checked
-    @application.application_outcome.eql?('part') && evidence_check_payment_validation?
+    outcome.eql?('part') && evidence_check_payment_validation?
   end
 
   def evidence_check_payment_validation?

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.feature 'Evidence check flow', type: :feature do
-
+  enable_payment
   include Warden::Test::Helpers
   Warden.test_mode!
 
@@ -152,6 +152,13 @@ RSpec.feature 'Evidence check flow', type: :feature do
 
       it 'renders correct outcome' do
         page_expectation("The applicant must pay £#{evidence.amount_to_pay} towards the fee", expected_fields)
+      end
+
+      context 'clicking the Next button' do
+        before { click_link_or_button 'Complete processing' }
+        it 'creates a payment record' do
+          expect(evidence.application.payment?).to be true
+        end
       end
     end
 


### PR DESCRIPTION
Implement test for creation of object at end of evidence-check flow
Update the payment builder to check for application and
evidence check being passed in.

The Payment builder was only looking at the application model to check
for part payment results, I re-used the code from the application_result
view model to test for the presence of both.