### PR TITLE
Fix for NI summary display

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -101,9 +101,7 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   end
 
   def ni_number_display
-    unless self[:ni_number].nil?
-      self[:ni_number].gsub(/(.{2})/, '\1 ')
-    end
+    ni_number.gsub(/(.{2})/, '\1 ') unless ni_number.nil?
   end
 
   # FIXME: Remove the threshold field from db as it's read only now


### PR DESCRIPTION
After fixing the part payments creation by evidence checks
the ni number is no longer displayed correctly on the application
form summary page.

Despite this being re-done in an upcoming refactoring pull request
this fixes the display issue so that other features can be
released.