### PR TITLE
Refactor the application model

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -245,28 +245,4 @@ class Application < ActiveRecord::Base # rubocop:disable ClassLength
   def active_or_status_is?(status_name)
     active? || status.to_s.include?(status_name)
   end
-
-  def dob_age_valid?
-    errors.add(:date_of_birth, "can't contain non numbers") if date_of_birth =~ /a-zA-Z/
-    validate_dob_maximum unless date_of_birth.blank?
-    validate_dob_minimum unless date_of_birth.blank?
-  end
-
-  def validate_dob_maximum
-    if date_of_birth < Time.zone.today - MAX_AGE.years
-      errors.add(
-        :date_of_birth,
-        I18n.t('activerecord.attributes.dwp_check.dob_too_old', max_age: MAX_AGE)
-      )
-    end
-  end
-
-  def validate_dob_minimum
-    if date_of_birth > Time.zone.today - MIN_AGE.years
-      errors.add(
-        :date_of_birth,
-        I18n.t('activerecord.attributes.dwp_check.dob_too_young', min_age: MIN_AGE)
-      )
-    end
-  end
 end


### PR DESCRIPTION
When the personal_information model was split out, the age
validation code was [moved over](https://github.com/ministryofjustice/fr-staffapp/blob/master/app/models/applikation/forms/personal_information.rb#L56), along with the tests.

The original code was left behind and is no longer used.

This removal should improve the code-climate score for the
(decreasingly) monolithic application model.