### PR TITLE
Bug fix: prevent empty paper evidence submission

### DIFF
--- a/app/controllers/benefit_overrides_controller.rb
+++ b/app/controllers/benefit_overrides_controller.rb
@@ -1,19 +1,16 @@
 class BenefitOverridesController < ApplicationController
-  before_action :setup_application
+  before_action :setup_application, :form_object
 
   def paper_evidence
-    @form = BenefitOverride.new(application_id: @application.id)
   end
 
   def paper_evidence_save
-    evidence = allowed_params['correct']
-    @form = BenefitOverride.find_or_create_by(application_id: @application.id)
-    @form.correct = evidence
+    @form.update_attributes(allowed_params)
 
     if @form.save
       redirect_to application_build_path(application_id: @application.id, id: :summary)
     else
-      redirect_to paper_evidence_path(@application)
+      redirect_to application_benefit_override_paper_evidence_path(@application)
     end
   end
 
@@ -21,6 +18,14 @@ class BenefitOverridesController < ApplicationController
 
   def setup_application
     @application = Application.find(params[:application_id])
+  end
+
+  def benefit_override
+    BenefitOverride.find_or_create_by(application_id: @application.id)
+  end
+
+  def form_object
+    @form = Forms::BenefitsEvidence.new(benefit_override)
   end
 
   def allowed_params

--- a/app/models/forms/benefits_evidence.rb
+++ b/app/models/forms/benefits_evidence.rb
@@ -7,8 +7,13 @@ module Forms
     define_attributes
 
     validates :correct, inclusion: { in: [true, false] }
+    validate :isnt_blank
 
     private
+
+    def isnt_blank
+      !correct.blank?
+    end
 
     def fields_to_update
       { correct: correct }

--- a/app/views/benefit_overrides/paper_evidence.html.slim
+++ b/app/views/benefit_overrides/paper_evidence.html.slim
@@ -1,12 +1,13 @@
 h2 Evidence
 
-= form_for @form, url: application_benefit_override_paper_evidence_save_path(@application), method: :post, html: { autocomplete: 'off' } do |f|
+= form_for @form, as: :benefit_override, url: application_benefit_override_paper_evidence_save_path(@application), method: :post, html: { autocomplete: 'off' } do |f|
   .row
     .small-12.medium-8.large-5.columns
       .form-group
         .row.collapse
           .columns.small-12
             = f.label :correct, t('benefit_override.title')
+            = f.hidden_field :correct, value: nil
             .options.radio
               .option
                 label for='benefit_override_correct_false'

--- a/spec/controllers/benefit_overrides_controller_spec.rb
+++ b/spec/controllers/benefit_overrides_controller_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe BenefitOverridesController, type: :controller do
           post :paper_evidence_save, application_id: application.id
         }.to raise_error ActionController::ParameterMissing
       end
+
+      it 'redirects to paper_evidence' do
+        expect(
+          post :paper_evidence_save, application_id: application.id, benefit_override: { correct: nil }
+        ).to redirect_to(action: :paper_evidence)
+      end
     end
   end
 end

--- a/spec/models/forms/benefits_evidence_spec.rb
+++ b/spec/models/forms/benefits_evidence_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe Forms::BenefitsEvidence do
 
       it { is_expected.to be false }
     end
+
+    context 'when no value is passed in' do
+      let(:params) { { correct: '' } }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
When the Benefits Override flow's evidence page would be submitted
without the either options chosen, the form could be submitted and an
error would be thrown.

This commit prevent's the form to be submitted for saving without one of
the options being picked.