### PR TITLE
Bug fix: prevent empty paper evidence submission

### DIFF
--- a/app/controllers/benefit_overrides_controller.rb
+++ b/app/controllers/benefit_overrides_controller.rb
@@ -1,19 +1,16 @@
 class BenefitOverridesController < ApplicationController
-  before_action :setup_application
+  before_action :setup_application, :form_object
 
   def paper_evidence
-    @form = BenefitOverride.new(application_id: @application.id)
   end
 
   def paper_evidence_save
-    evidence = allowed_params['correct']
-    @form = BenefitOverride.find_or_create_by(application_id: @application.id)
-    @form.correct = evidence
+    @form.update_attributes(allowed_params)
 
     if @form.save
       redirect_to application_build_path(application_id: @application.id, id: :summary)
     else
-      redirect_to paper_evidence_path(@application)
+      redirect_to application_benefit_override_paper_evidence_path(@application)
     end
   end
 
@@ -21,6 +18,14 @@ class BenefitOverridesController < ApplicationController
 
   def setup_application
     @application = Application.find(params[:application_id])
+  end
+
+  def benefit_override
+    BenefitOverride.find_or_create_by(application_id: @application.id)
+  end
+
+  def form_object
+    @form = Forms::BenefitsEvidence.new(benefit_override)
   end
 
   def allowed_params

--- a/app/models/forms/benefits_evidence.rb
+++ b/app/models/forms/benefits_evidence.rb
@@ -7,8 +7,13 @@ module Forms
     define_attributes
 
     validates :correct, inclusion: { in: [true, false] }
+    validate :isnt_blank
 
     private
+
+    def isnt_blank
+      !correct.blank?
+    end
 
     def fields_to_update
       { correct: correct }

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Views
   class ApplicationOverview
     attr_reader :application
@@ -54,9 +55,8 @@ module Views
 
     def benefits
       if type.eql?('benefit')
-        if @application.last_benefit_check
-          format_locale(@application.last_benefit_check.dwp_result.eql?('Yes').to_s)
-        end
+        return format_locale('passed_with_evidence') if benefit_override?
+        format_locale(benefit_result) if @application.last_benefit_check
       end
     end
 
@@ -97,6 +97,14 @@ module Views
       if date
         date.to_s(:gov_uk_long)
       end
+    end
+
+    def benefit_result
+      @application.last_benefit_check.dwp_result.eql?('Yes').to_s
+    end
+
+    def benefit_override?
+      BenefitOverride.exists?(application_id: @application.id, correct: true)
     end
   end
 end

--- a/app/views/applications/build/benefits_result.html.slim
+++ b/app/views/applications/build/benefits_result.html.slim
@@ -8,6 +8,8 @@ header
     -if @application.can_check_benefits? &&  @application.last_benefit_check.dwp_result.parameterize.underscore != 'undetermined'
       #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
         h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
+      - unless @application.last_benefit_check.benefits_valid?
+        =link_to 'The applicant has provided paper evidence', application_benefit_override_paper_evidence_path(@application)
     -else
       #result.callout.callout-none
         h3.bold =t('benefit_checks.details_missing.heading')
@@ -17,7 +19,7 @@ header
     = form_for @application, url: wizard_path, method: :put, html: { autocomplete: 'off' } do |f|
       = f.hidden_field(:status)
       = f.submit 'Next', class: 'button primary'
-  
+
   .large-5.columns
     .guidance
       h4 How is this worked out?

--- a/app/views/benefit_overrides/paper_evidence.html.slim
+++ b/app/views/benefit_overrides/paper_evidence.html.slim
@@ -1,12 +1,13 @@
 h2 Evidence
 
-= form_for @form, url: application_benefit_override_paper_evidence_save_path(@application), method: :post, html: { autocomplete: 'off' } do |f|
+= form_for @form, as: :benefit_override, url: application_benefit_override_paper_evidence_save_path(@application), method: :post, html: { autocomplete: 'off' } do |f|
   .row
     .small-12.medium-8.large-5.columns
       .form-group
         .row.collapse
           .columns.small-12
             = f.label :correct, t('benefit_override.title')
+            = f.hidden_field :correct, value: nil
             .options.radio
               .option
                 label for='benefit_override_correct_false'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,7 @@ en-GB:
         none: '✗ Failed'
         'true': '✓ Passed'
         'false': '✗ Failed'
+        passed_with_evidence: '✓ Passed (paper evidence checked)'
         savings_investments: Savings and investments
         benefits: Benefits
         income: Income

--- a/spec/controllers/benefit_overrides_controller_spec.rb
+++ b/spec/controllers/benefit_overrides_controller_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe BenefitOverridesController, type: :controller do
           post :paper_evidence_save, application_id: application.id
         }.to raise_error ActionController::ParameterMissing
       end
+
+      it 'redirects to paper_evidence' do
+        expect(
+          post :paper_evidence_save, application_id: application.id, benefit_override: { correct: nil }
+        ).to redirect_to(action: :paper_evidence)
+      end
     end
   end
 end

--- a/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
+++ b/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
@@ -1,0 +1,85 @@
+# coding: utf-8
+require 'rails_helper'
+
+def personal_details_page
+  fill_in 'application_last_name', with: 'Smith'
+  fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
+  fill_in 'application_ni_number', with: 'AB123456A'
+  choose 'application_married_false'
+  click_button 'Next'
+end
+
+def application_details
+  fill_in 'application_fee', with: 410
+  find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+  fill_in 'application_date_received', with: Time.zone.today
+  click_button 'Next'
+end
+
+def savings_and_investments
+  choose 'application_threshold_exceeded_false'
+  click_button 'Next'
+end
+
+def benefits_page
+  choose 'application_benefits_true'
+  click_button 'Next'
+end
+
+RSpec.feature 'Allow override when DWP checker says "NO"', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions) { create_list :jurisdiction, 3 }
+  let!(:office)        { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)          { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+
+  before do
+    dwp_api_response 'No'
+    login_as user
+    visit applications_new_path
+    personal_details_page
+    application_details
+    savings_and_investments
+    benefits_page
+  end
+
+  scenario 'there should be link for accept the proof for benefit claiming' do
+    expect(page).to have_content 'The applicant has provided paper evidence'
+  end
+
+  context 'when the user provides paper evidence' do
+    before { click_link 'The applicant has provided paper evidence' }
+
+    context 'and the evidence is correct' do
+      describe 'when displaying the summary' do
+        before do
+          choose 'benefit_override_correct_true'
+          click_button 'Next'
+        end
+
+        scenario 'shows the benefits result as passed' do
+          expect(page).to have_content 'Check details'
+          expect(page).to have_content '✓ Passed (paper evidence checked)'
+          expect(page).to have_content '✓   The applicant doesn’t have to pay the fee'
+        end
+      end
+    end
+
+    context 'when the user does not provide supporting evidence' do
+      describe 'when displaying the summary' do
+        before do
+          choose 'benefit_override_correct_false'
+          click_button 'Next'
+        end
+
+        scenario 'shows the benefits result as passed' do
+          expect(page).to have_content 'Check details'
+          expect(page).to have_content '✗ Failed'
+          expect(page).to have_content '✗   The applicant must pay the full fee'
+        end
+      end
+    end
+  end
+end

--- a/spec/models/forms/benefits_evidence_spec.rb
+++ b/spec/models/forms/benefits_evidence_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe Forms::BenefitsEvidence do
 
       it { is_expected.to be false }
     end
+
+    context 'when no value is passed in' do
+      let(:params) { { correct: '' } }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
When the Benefits Override flow's evidence page would be submitted
without the either options chosen, the form could be submitted and an
error would be thrown.

This commit prevent's the form to be submitted for saving without one of
the options being picked.