### PR TITLE
Allow the users to override benefits check

### DIFF
--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Views
   class ApplicationOverview
     attr_reader :application
@@ -54,9 +55,8 @@ module Views
 
     def benefits
       if type.eql?('benefit')
-        if @application.last_benefit_check
-          format_locale(@application.last_benefit_check.dwp_result.eql?('Yes').to_s)
-        end
+        return format_locale('passed_with_evidence') if benefit_override?
+        format_locale(benefit_result) if @application.last_benefit_check
       end
     end
 
@@ -97,6 +97,14 @@ module Views
       if date
         date.to_s(:gov_uk_long)
       end
+    end
+
+    def benefit_result
+      @application.last_benefit_check.dwp_result.eql?('Yes').to_s
+    end
+
+    def benefit_override?
+      BenefitOverride.exists?(application_id: @application.id)
     end
   end
 end

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -104,7 +104,7 @@ module Views
     end
 
     def benefit_override?
-      BenefitOverride.exists?(application_id: @application.id)
+      BenefitOverride.exists?(application_id: @application.id, correct: true)
     end
   end
 end

--- a/app/views/applications/build/benefits_result.html.slim
+++ b/app/views/applications/build/benefits_result.html.slim
@@ -8,6 +8,8 @@ header
     -if @application.can_check_benefits? &&  @application.last_benefit_check.dwp_result.parameterize.underscore != 'undetermined'
       #result.callout class=(@application.last_benefit_check.dwp_result.parameterize.underscore)
         h3.bold =t("benefit_checks.#{@application.last_benefit_check.dwp_result.parameterize.underscore}.heading").html_safe
+      - unless @application.last_benefit_check.benefits_valid?
+        =link_to 'The applicant has provided paper evidence', application_benefit_override_paper_evidence_path(@application)
     -else
       #result.callout.callout-none
         h3.bold =t('benefit_checks.details_missing.heading')
@@ -17,7 +19,7 @@ header
     = form_for @application, url: wizard_path, method: :put, html: { autocomplete: 'off' } do |f|
       = f.hidden_field(:status)
       = f.submit 'Next', class: 'button primary'
-  
+
   .large-5.columns
     .guidance
       h4 How is this worked out?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,7 @@ en-GB:
         none: '✗ Failed'
         'true': '✓ Passed'
         'false': '✗ Failed'
+        passed_with_evidence: '✓ Passed (paper evidence checked)'
         savings_investments: Savings and investments
         benefits: Benefits
         income: Income

--- a/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
+++ b/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
@@ -49,16 +49,37 @@ RSpec.feature 'Allow override when DWP checker says "NO"', type: :feature do
     expect(page).to have_content 'The applicant has provided paper evidence'
   end
 
-  context 'when displaying the summary' do
-    before do
-      click_link 'The applicant has provided paper evidence'
-      choose 'benefit_override_correct_true'
-      click_button 'Next'
+  context 'when the user provides paper evidence' do
+    before { click_link 'The applicant has provided paper evidence' }
+
+    context 'and the evidence is correct' do
+      describe 'when displaying the summary' do
+        before do
+          choose 'benefit_override_correct_true'
+          click_button 'Next'
+        end
+
+        scenario 'shows the benefits result as passed' do
+          expect(page).to have_content 'Check details'
+          expect(page).to have_content '✓ Passed (paper evidence checked)'
+          expect(page).to have_content '✓   The applicant doesn’t have to pay the fee'
+        end
+      end
     end
 
-    scenario 'shows the benefits result as passed' do
-      expect(page).to have_content 'Check details'
-      expect(page).to have_content '✓ Passed (paper evidence checked)'
+    context 'when the user does not provide supporting evidence' do
+      describe 'when displaying the summary' do
+        before do
+          choose 'benefit_override_correct_false'
+          click_button 'Next'
+        end
+
+        scenario 'shows the benefits result as passed' do
+          expect(page).to have_content 'Check details'
+          expect(page).to have_content '✗ Failed'
+          expect(page).to have_content '✗   The applicant must pay the full fee'
+        end
+      end
     end
   end
 end

--- a/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
+++ b/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
@@ -2,9 +2,6 @@
 require 'rails_helper'
 
 def personal_details_page
-  login_as user
-  visit applications_new_path
-
   fill_in 'application_last_name', with: 'Smith'
   fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
   fill_in 'application_ni_number', with: 'AB123456A'
@@ -40,6 +37,8 @@ RSpec.feature 'Allow override when DWP checker says "NO"', type: :feature do
 
   before do
     dwp_api_response 'No'
+    login_as user
+    visit applications_new_path
     personal_details_page
     application_details
     savings_and_investments
@@ -48,5 +47,18 @@ RSpec.feature 'Allow override when DWP checker says "NO"', type: :feature do
 
   scenario 'there should be link for accept the proof for benefit claiming' do
     expect(page).to have_content 'The applicant has provided paper evidence'
+  end
+
+  context 'when displaying the summary' do
+    before do
+      click_link 'The applicant has provided paper evidence'
+      choose 'benefit_override_correct_true'
+      click_button 'Next'
+    end
+
+    scenario 'shows the benefits result as passed' do
+      expect(page).to have_content 'Check details'
+      expect(page).to have_content '✓ Passed (paper evidence checked)'
+    end
   end
 end

--- a/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
+++ b/spec/features/applications/allow_override_when_dwp_checker_says_no_spec.rb
@@ -1,0 +1,52 @@
+# coding: utf-8
+require 'rails_helper'
+
+def personal_details_page
+  login_as user
+  visit applications_new_path
+
+  fill_in 'application_last_name', with: 'Smith'
+  fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
+  fill_in 'application_ni_number', with: 'AB123456A'
+  choose 'application_married_false'
+  click_button 'Next'
+end
+
+def application_details
+  fill_in 'application_fee', with: 410
+  find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+  fill_in 'application_date_received', with: Time.zone.today
+  click_button 'Next'
+end
+
+def savings_and_investments
+  choose 'application_threshold_exceeded_false'
+  click_button 'Next'
+end
+
+def benefits_page
+  choose 'application_benefits_true'
+  click_button 'Next'
+end
+
+RSpec.feature 'Allow override when DWP checker says "NO"', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions) { create_list :jurisdiction, 3 }
+  let!(:office)        { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)          { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+
+  before do
+    dwp_api_response 'No'
+    personal_details_page
+    application_details
+    savings_and_investments
+    benefits_page
+  end
+
+  scenario 'there should be link for accept the proof for benefit claiming' do
+    expect(page).to have_content 'The applicant has provided paper evidence'
+  end
+end


### PR DESCRIPTION
Allow the staff to override benefit check when the result is 'No', if
the member of public presents paper based evidence.