### PR TITLE
Reverted the validation changes

### DIFF
--- a/app/models/applikation/forms/application_detail.rb
+++ b/app/models/applikation/forms/application_detail.rb
@@ -3,10 +3,6 @@ module Applikation
     class ApplicationDetail < ::FormObject
 
       TIME_LIMIT_FOR_PROBATE = 20
-      TODAY = Time.zone.today
-      MIN_DATE = TODAY - 3.months
-      MAX_DATE = TODAY + 1.day
-      MIN_DATE_PROBATE = TODAY - TIME_LIMIT_FOR_PROBATE.years
 
       # rubocop:disable MethodLength
       def self.permitted_attributes
@@ -33,22 +29,22 @@ module Applikation
       validate :emergency_reason_size
 
       validates :date_received, date: {
-        after: proc { MIN_DATE },
-        before: proc { MAX_DATE }
+        after: proc { Time.zone.today - 3.months },
+        before: proc { Time.zone.today + 1.day }
       }
 
       with_options if: :probate? do
         validates :deceased_name, presence: true
         validates :date_of_death, date: {
-          after: proc { MIN_DATE_PROBATE },
-          before: proc { MAX_DATE }
+          after: proc { Time.zone.today - TIME_LIMIT_FOR_PROBATE.years },
+          before: proc { Time.zone.today + 1.day }
         }
       end
 
       with_options if: :refund? do
         validates :date_fee_paid, date: {
-          after: proc { MIN_DATE },
-          before: proc { MAX_DATE }
+          after: proc { Time.zone.today - 3.months },
+          before: proc { Time.zone.today + 1.day }
         }
       end
 

--- a/spec/models/applikation/forms/application_detail_spec.rb
+++ b/spec/models/applikation/forms/application_detail_spec.rb
@@ -326,4 +326,19 @@ RSpec.describe Applikation::Forms::ApplicationDetail do
       it { is_expected.to be false }
     end
   end
+
+  context 'instantiates at now' do
+    Timecop.freeze(Time.zone.now - 1.day) do
+      describe 'after 24 hours' do
+        before do
+          Timecop.travel(Time.zone.now + 2.day)
+          detail.valid?
+        end
+        describe 'the detail should be valid' do
+          let(:detail) { build_stubbed(:complete_detail) }
+          it { is_expected.to be_valid  }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
The new time constants were being set on first creation and locking the date
to the server launch date.

Added a Timecop test to ensure that any future attempts to refactor this
don't break it again!