### PR TITLE
[DO NOT MERGE] Pundit example for processed applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'devise'
 gem 'devise_invitable'
 # roles
 gem 'cancancan', '~> 1.10'
+gem 'pundit', '~> 1.0'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 5.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,8 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    pundit (1.0.1)
+      activesupport (>= 3.0.0)
     rack (1.6.4)
     rack-livereload (0.3.16)
       rack
@@ -430,6 +432,7 @@ DEPENDENCIES
   paranoia (~> 2.0)
   pg
   pry-rails
+  pundit (~> 1.0)
   rack-livereload
   rails (= 4.2.4)
   rails-i18n (~> 4.0.0)

--- a/app/controllers/processed_applications_controller.rb
+++ b/app/controllers/processed_applications_controller.rb
@@ -1,15 +1,29 @@
 class ProcessedApplicationsController < ApplicationController
+  include Pundit
   before_action :authenticate_user!
 
   def index
-    @applications = Query::ProcessedApplications.new(current_user).find.map do |application|
+    authorize :application
+
+    @applications = applications.map do |application|
       Views::ApplicationList.new(application)
     end
   end
 
   def show
-    @application = Application.find(params[:id])
-    @overview = Views::ApplicationOverview.new(@application)
-    @result = Views::ApplicationResult.new(@application)
+    authorize application
+
+    @overview = Views::ApplicationOverview.new(application)
+    @result = Views::ApplicationResult.new(application)
+  end
+
+  private
+
+  def applications
+    @applications ||= policy_scope(Query::ProcessedApplications.new(current_user).find)
+  end
+
+  def application
+    @application ||= Application.find(params[:id])
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,29 +1,18 @@
-class ApplicationPolicy
-  attr_reader :user, :application
-
-  def initialize(user, application)
-    @user = user
-    @application = application
-  end
-
+class ApplicationPolicy < BasePolicy
   def index?
-    true
+    !admin?
   end
 
   def show?
-    true
+    !admin? && same_office?
   end
 
-  class Scope
-    attr_reader :user, :scope
+  class Scope < BasePolicy::Scope
+  end
 
-    def initialize(user, scope)
-      @user = user
-      @scope = scope
-    end
+  private
 
-    def resolve
-      scope.all
-    end
+  def same_office?
+    @record.office == @user.office
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -8,6 +8,13 @@ class ApplicationPolicy < BasePolicy
   end
 
   class Scope < BasePolicy::Scope
+    def resolve
+      if admin?
+        @scope.none
+      else
+        @scope.where(office: @user.office)
+      end
+    end
   end
 
   private

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,29 @@
+class ApplicationPolicy
+  attr_reader :user, :application
+
+  def initialize(user, application)
+    @user = user
+    @application = application
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/base_policy.rb
+++ b/app/policies/base_policy.rb
@@ -1,0 +1,27 @@
+class BasePolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+
+  private
+
+  def admin?
+    @user.admin?
+  end
+end

--- a/app/policies/base_policy.rb
+++ b/app/policies/base_policy.rb
@@ -15,7 +15,13 @@ class BasePolicy
     end
 
     def resolve
-      scope.all
+      @scope.all
+    end
+
+    private
+
+    def admin?
+      @user.admin?
     end
   end
 

--- a/spec/controllers/processed_applications_controller_spec.rb
+++ b/spec/controllers/processed_applications_controller_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
   describe 'GET #index' do
     let(:view1) { double }
     let(:view2) { double }
-    let(:query) { double(find: [application1, application2]) }
+    let(:scope) { double }
+    let(:query) { double(find: scope) }
 
     before do
       allow(Query::ProcessedApplications).to receive(:new).with(user).and_return(query)
+      allow(controller).to receive(:policy_scope).with(scope).and_return([application1, application2])
       allow(Views::ApplicationList).to receive(:new).with(application1).and_return(view1)
       allow(Views::ApplicationList).to receive(:new).with(application2).and_return(view2)
 

--- a/spec/controllers/processed_applications_controller_spec.rb
+++ b/spec/controllers/processed_applications_controller_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
 
   let(:user) { create(:user) }
 
-  let(:application1) { build_stubbed(:application) }
-  let(:application2) { build_stubbed(:application) }
+  let(:application1) { build_stubbed(:application, office: user.office) }
+  let(:application2) { build_stubbed(:application, office: user.office) }
 
   before do
     sign_in user

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationPolicy, type: :policy do
+  let(:office) { build_stubbed(:office) }
+  let(:application) { build_stubbed(:application, office: office) }
+
+  subject(:policy) { described_class.new(user, application) }
+
+  context 'for staff' do
+    let(:user) { build_stubbed(:user) }
+
+    it { is_expected.to permit_action(:index) }
+
+    context 'when the application belongs to their office' do
+      let(:user) { build_stubbed(:user, office: office) }
+
+      it { is_expected.to permit_action(:show) }
+    end
+
+    context 'when the application does not belong to their office' do
+      it { is_expected.not_to permit_action(:show) }
+    end
+  end
+
+  context 'for a manager' do
+    let(:user) { build_stubbed(:manager) }
+
+    it { is_expected.to permit_action(:index) }
+
+    context 'when the application belongs to their office' do
+      let(:user) { build_stubbed(:manager, office: office) }
+
+      it { is_expected.to permit_action(:show) }
+    end
+
+    context 'when the application does not belong to their office' do
+      it { is_expected.not_to permit_action(:show) }
+    end
+  end
+
+  context 'for an admin' do
+    let(:user) { build_stubbed(:admin_user) }
+
+    it { is_expected.not_to permit_action(:index) }
+    it { is_expected.not_to permit_action(:show) }
+  end
+end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -44,4 +44,36 @@ RSpec.describe ApplicationPolicy, type: :policy do
     it { is_expected.not_to permit_action(:index) }
     it { is_expected.not_to permit_action(:show) }
   end
+
+  describe ApplicationPolicy::Scope do
+    describe '#resolve' do
+      let(:office) { create :office }
+      let!(:application1) { create :application }
+      let!(:application2) { create :application, office: office }
+
+      subject { described_class.new(user, Application).resolve }
+
+      context 'for a regular user' do
+        let(:user) { create(:user, office: office) }
+
+        it 'returns only applications which belong to the same office' do
+          is_expected.to eq([application2])
+        end
+      end
+
+      context 'for a manager' do
+        let(:user) { create(:manager, office: office) }
+
+        it 'returns only applications which belong to the same office' do
+          is_expected.to eq([application2])
+        end
+      end
+
+      context 'for an admin' do
+        let(:user) { create(:admin_user) }
+
+        it { is_expected.to be_empty }
+      end
+    end
+  end
 end

--- a/spec/support/policies.rb
+++ b/spec/support/policies.rb
@@ -1,0 +1,13 @@
+RSpec::Matchers.define :permit_action do |action|
+  match do |policy|
+    policy.public_send("#{action}?")
+  end
+
+  failure_message do |policy|
+    "#{policy.class} does not permit #{action} on #{policy.record} for #{policy.user.inspect}."
+  end
+
+  failure_message_when_negated do |policy|
+    "#{policy.class} does not forbid #{action} on #{policy.record} for #{policy.user.inspect}."
+  end
+end


### PR DESCRIPTION
This PR is not to be merged, but it's a conversation starter about authorisation. 

I wanted to demonstrate how we could use `pundit` to test-drive policies, which I'm not sure if it's easily possible in `cancancan`. Also the concept of policy_scope which filters records not complying with the policy is very usefull as well.

It's particularly cool to generate a full documentation of who can do what:

```ruby
rspec -f d spec/policies/application_policy_spec.rb
```

@dotemacs @colinbruce what do you think?