### PR TITLE
Rename application outcome to outcome

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -43,8 +43,6 @@ class Application < ActiveRecord::Base
   end
   # End step 3 validation
 
-  alias_attribute :outcome, :application_outcome
-
   def children=(val)
     self[:children] = dependents? ? val : 0
   end
@@ -63,7 +61,7 @@ class Application < ActiveRecord::Base
     self.partner_over_61 = nil unless threshold_exceeded?
     if threshold_exceeded? && (!partner_over_61 || applicant_over_61?)
       self.application_type = 'none'
-      self.application_outcome = 'none'
+      self.outcome = 'none'
       self.dependents = nil
     end
   end
@@ -72,11 +70,11 @@ class Application < ActiveRecord::Base
     super
     if high_threshold_exceeded?
       self.application_type = 'none'
-      self.application_outcome = 'none'
+      self.outcome = 'none'
       self.dependents = nil
     else
       self.application_type = nil
-      self.application_outcome = nil
+      self.outcome = nil
     end
   end
 

--- a/app/models/applikation/forms/benefit.rb
+++ b/app/models/applikation/forms/benefit.rb
@@ -21,7 +21,7 @@ module Applikation
         }.tap do |fields|
           fields[:application_type] = benefits? ? 'benefit' : 'income'
           fields[:dependents] = nil if benefits?
-          fields[:application_outcome] = benefit_check.present? ? benefit_check.outcome : nil
+          fields[:outcome] = benefit_check.present? ? benefit_check.outcome : nil
         end
       end
 

--- a/app/models/query/evidence_checkable.rb
+++ b/app/models/query/evidence_checkable.rb
@@ -18,7 +18,7 @@ module Query
         applications: {
           benefits: false,
           application_type: 'income',
-          application_outcome: %w[part full]
+          outcome: %w[part full]
         },
         details: {
           emergency_reason: nil

--- a/app/models/query/processed_applications.rb
+++ b/app/models/query/processed_applications.rb
@@ -14,7 +14,7 @@ module Query
 
     def where_condition
       <<-WHERE.gsub(/^\s+\|/, '')
-        |(applications.application_outcome IS NOT NULL)
+        |(applications.outcome IS NOT NULL)
         |AND
         |(evidence_checks.id IS NULL OR evidence_checks.completed_at IS NOT NULL)
         |AND

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -73,7 +73,7 @@ module Views
     end
 
     def result
-      @application.application_outcome
+      @application.outcome
     end
 
     def savings_investment_params

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Views
   class ApplicationResult
 
@@ -30,7 +31,7 @@ module Views
       when EvidenceCheck
         evidence_or_application.outcome
       when Application
-        evidence_or_application.application_outcome
+        evidence_or_application.outcome
       end
     end
 

--- a/app/models/views/applikation/result.rb
+++ b/app/models/views/applikation/result.rb
@@ -7,7 +7,7 @@ module Views
           'callout'
         elsif !benefit_overridden? && benefit_overide_correct?
           'full'
-        elsif @application.application_outcome.nil?
+        elsif @application.outcome.nil?
           'none'
         else
           super

--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -14,7 +14,7 @@ class BenefitCheckRunner
     if can_run? && should_run?
       BenefitCheckService.new(benefit_check)
 
-      @application.update(application_type: 'benefit', application_outcome: benefit_check.outcome)
+      @application.update(application_type: 'benefit', outcome: benefit_check.outcome)
     end
   end
 

--- a/app/services/income_calculation_runner.rb
+++ b/app/services/income_calculation_runner.rb
@@ -8,7 +8,7 @@ class IncomeCalculationRunner
     if income_calculation_result
       @application.update(
         application_type: 'income',
-        application_outcome: income_calculation_result[:outcome],
+        outcome: income_calculation_result[:outcome],
         amount_to_pay: income_calculation_result[:amount]
       )
     end

--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -10,28 +10,28 @@ header
       #result.callout class='callout-full'
         h3.bold =t('remissions.full').html_safe
     - else
-      - if @application.application_outcome.nil?
+      - if @application.outcome.nil?
         = render 'applications/partials/full_fee'
       - else
         -case @application.application_type
         -when 'none'
           = render 'applications/partials/full_fee'
         -else
-          #calculator.callout class="callout-#{@application.application_outcome ? @application.application_outcome : 'error'}"
-            h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay? ? @application.amount_to_pay.floor : 0, precision: 0)).html_safe  
+          #calculator.callout class="callout-#{@application.outcome ? @application.outcome : 'error'}"
+            h3.bold =t("remissions.#{@application.outcome ? @application.outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay? ? @application.amount_to_pay.floor : 0, precision: 0)).html_safe
 
     = link_to 'Back to start', root_path, class: 'button primary'
-  
+
   .large-5.columns
     .guidance
       h4 Next steps
       ul
-        -if @application.application_outcome == 'full'
+        -if @application.outcome.eql?('full')
           li Complete the remission register with the application details
           li Write the reference number on the top right corner of the paper form
           li Copy the reference number into the case management system
           li The applicant’s process can now be issued
-        -elsif @application.application_outcome == 'part'
+        -elsif @application.outcome.eql?('part')
           li Write to the applicant with details of how much they have to pay
           li Store the application form in a secure location until you receive the part-payment
           li You don't need to complete the remission register until part-payment has been received
@@ -41,5 +41,5 @@ header
           li Write the reference number on the top right corner of the paper form
           li Copy the reference number into the case management system
           li Write to the applicant and send back all the documents
-                
+
       p: strong = link_to 'See the guides', guide_path, target: 'blank'

--- a/app/views/applications/process/income_result.html.slim
+++ b/app/views/applications/process/income_result.html.slim
@@ -5,8 +5,8 @@ header
 
 .row
   .small-12.medium-8.large-5.columns
-    #calculator.callout class="callout-#{@application.application_outcome ? @application.application_outcome : 'error'}"
-      h3.bold =t("remissions.#{@application.application_outcome ? @application.application_outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay.floor, precision: 0)).html_safe
+    #calculator.callout class="callout-#{@application.outcome ? @application.outcome : 'error'}"
+      h3.bold =t("remissions.#{@application.outcome ? @application.outcome : 'error'}", amount_to_pay: number_to_currency(@application.amount_to_pay.floor, precision: 0)).html_safe
 
     div
       = link_to 'Next', application_summary_path(@application), class: 'button primary'
@@ -34,4 +34,3 @@ header
       h4 Total monthly income
       p = link_to 'Read about the maximum amount of income allowed', guide_process_application_path(anchor: 'income'), target: 'blank'
       p: strong= link_to 'See the guides', guide_path, target: 'blank'
-          

--- a/db/migrate/20151112110146_rename_application_outcome_to_outcome.rb
+++ b/db/migrate/20151112110146_rename_application_outcome_to_outcome.rb
@@ -1,0 +1,5 @@
+class RenameApplicationOutcomeToOutcome < ActiveRecord::Migration
+  def change
+    rename_column :applications, :application_outcome, :outcome
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151110090803) do
+ActiveRecord::Schema.define(version: 20151112110146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20151110090803) do
     t.integer  "income"
     t.boolean  "dependents"
     t.string   "application_type"
-    t.string   "application_outcome"
+    t.string   "outcome"
     t.integer  "amount_to_pay"
     t.boolean  "high_threshold_exceeded"
     t.string   "reference"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -208,6 +208,7 @@ ActiveRecord::Schema.define(version: 20151112110146) do
   add_foreign_key "applications", "users"
   add_foreign_key "benefit_checks", "applications"
   add_foreign_key "benefit_checks", "users"
+  add_foreign_key "benefit_overrides", "applications"
   add_foreign_key "feedbacks", "offices"
   add_foreign_key "feedbacks", "users"
   add_foreign_key "office_jurisdictions", "jurisdictions"

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -49,7 +49,7 @@ FactoryGirl.define do
 
     trait :confirm do
       benefits false
-      application_outcome 'full'
+      outcome 'full'
       application_type 'income'
     end
 
@@ -61,7 +61,7 @@ FactoryGirl.define do
       income 2000
       dependents true
       children 3
-      application_outcome 'part'
+      outcome 'part'
       application_type 'income'
       amount_to_pay 100
     end
@@ -74,7 +74,7 @@ FactoryGirl.define do
       income 10
       dependents true
       children 1
-      application_outcome 'full'
+      outcome 'full'
       application_type 'income'
     end
 
@@ -84,7 +84,7 @@ FactoryGirl.define do
       dependents false
       children 1
       income 3000
-      application_outcome 'none'
+      outcome 'none'
       application_type 'income'
     end
 

--- a/spec/features/applications/remission_confirmation_spec.rb
+++ b/spec/features/applications/remission_confirmation_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
         before { visit_confirmation_page }
 
         scenario 'they have part remission' do
-          expect(application.application_outcome).to eq 'part'
+          expect(application.outcome).to eq 'part'
         end
 
         scenario 'the part remission copy is show' do
@@ -56,7 +56,7 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
         before { visit_confirmation_page }
 
         scenario 'they have full remission' do
-          expect(application.application_outcome).to eq 'full'
+          expect(application.outcome).to eq 'full'
         end
 
         scenario 'the full remission copy is shown' do
@@ -78,7 +78,7 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
         before { visit_confirmation_page }
 
         scenario 'they have no remission' do
-          expect(application.application_outcome).to eq 'none'
+          expect(application.outcome).to eq 'none'
         end
 
         scenario 'the no remission copy is shown' do

--- a/spec/models/applikation/forms/benefit_spec.rb
+++ b/spec/models/applikation/forms/benefit_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Applikation::Forms::Benefit do
 
   describe '#save' do
     let(:attributes) { { benefits: benefits } }
-    let(:application) { create :application, application_type: nil, dependents: false, benefits: nil, application_outcome: nil }
+    let(:application) { create :application, application_type: nil, dependents: false, benefits: nil, outcome: nil }
     subject(:form) { described_class.new(application) }
 
     subject do
@@ -80,13 +80,13 @@ RSpec.describe Applikation::Forms::Benefit do
             let(:benefit_check) { create :benefit_check, :yes_result, application: application }
 
             it 'updates outcome based on the result' do
-              expect(application.application_outcome).to eql 'full'
+              expect(application.outcome).to eql 'full'
             end
           end
 
           context 'when benefit check has not been done' do
-            it 'keeps application_outcome unchanged' do
-              expect(application.application_outcome).to be nil
+            it 'keeps outcome unchanged' do
+              expect(application.outcome).to be nil
             end
           end
         end

--- a/spec/models/query/processed_applications_spec.rb
+++ b/spec/models/query/processed_applications_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Query::ProcessedApplications, type: :model do
     let!(:application4) { create :application_full_remission, office: office }
     let!(:application6) { create :application_full_remission, office: office }
     let!(:application5) { create :application_full_remission, office: office }
-    let!(:application7) { create :application, office: office, application_outcome: nil }
+    let!(:application7) { create :application, office: office, outcome: nil }
 
     before do
       create :evidence_check, application: application1

--- a/spec/models/views/application_overview_spec.rb
+++ b/spec/models/views/application_overview_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Views::ApplicationOverview do
   end
 
   describe '#income' do
-    let(:application) { build_stubbed(:application, application_outcome: outcome) }
+    let(:application) { build_stubbed(:application, outcome: outcome) }
 
     subject { view.income }
 
@@ -122,7 +122,7 @@ RSpec.describe Views::ApplicationOverview do
   end
 
   describe '#result' do
-    let(:application) { build_stubbed(:application, application_outcome: outcome) }
+    let(:application) { build_stubbed(:application, outcome: outcome) }
 
     subject { view.result }
 

--- a/spec/models/views/application_result_spec.rb
+++ b/spec/models/views/application_result_spec.rb
@@ -73,13 +73,13 @@ RSpec.describe Views::ApplicationResult do
 
     context 'when the application has evidence check' do
       let(:evidence) { build_stubbed :evidence_check, outcome: outcome }
-      let(:application) { build_stubbed :application, evidence_check: evidence, application_outcome: nil }
+      let(:application) { build_stubbed :application, evidence_check: evidence, outcome: nil }
 
       include_examples 'result examples', 'evidence'
     end
 
     context 'when the application does not have evidence check' do
-      let(:application) { build_stubbed :application, application_outcome: outcome }
+      let(:application) { build_stubbed :application, outcome: outcome }
 
       include_examples 'result examples', 'application'
     end
@@ -126,13 +126,13 @@ RSpec.describe Views::ApplicationResult do
 
     context 'when the application has evidence check' do
       let(:evidence) { build_stubbed :evidence_check, outcome: outcome }
-      let(:application) { build_stubbed :application, evidence_check: evidence, application_outcome: nil }
+      let(:application) { build_stubbed :application, evidence_check: evidence, outcome: nil }
 
       include_examples 'result examples', 'evidence'
     end
 
     context 'when the application does not have evidence check' do
-      let(:application) { build_stubbed :application, application_outcome: outcome }
+      let(:application) { build_stubbed :application, outcome: outcome }
 
       include_examples 'result examples', 'application'
     end

--- a/spec/models/views/applikation/result_spec.rb
+++ b/spec/models/views/applikation/result_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'rails_helper'
 
 RSpec.describe Views::Applikation::Result do
@@ -30,8 +31,8 @@ RSpec.describe Views::Applikation::Result do
       end
     end
 
-    context 'when application_outcome is nil' do
-      before { application.application_outcome = nil }
+    context 'when outcome is nil' do
+      before { application.outcome = nil }
 
       it { is_expected.to eql 'none' }
     end

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -69,7 +69,7 @@ RSpec.shared_examples 'runs benefit check record' do
     end
 
     it 'sets the applicaiton outcome based on the result' do
-      expect(application.application_outcome).to eql('full')
+      expect(application.outcome).to eql('full')
     end
   end
 end

--- a/spec/services/income_calculation_runner_spec.rb
+++ b/spec/services/income_calculation_runner_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe IncomeCalculationRunner do
-  let(:application) { create :application, application_type: nil, application_outcome: nil }
+  let(:application) { create :application, application_type: nil, outcome: nil }
 
   subject(:runner) { described_class.new(application) }
 
@@ -24,7 +24,7 @@ RSpec.describe IncomeCalculationRunner do
       end
 
       it 'sets application outcome as per result' do
-        expect(application.application_outcome).to eql('part')
+        expect(application.outcome).to eql('part')
       end
 
       it 'sets amount_to_pay as per result' do
@@ -40,7 +40,7 @@ RSpec.describe IncomeCalculationRunner do
       end
 
       it 'does not set application outcome' do
-        expect(application.application_outcome).to be nil
+        expect(application.outcome).to be nil
       end
     end
 


### PR DESCRIPTION
No need for the **`application_'** part of the name, especially since this is a column in **`applications'** table.

Also added a **'missed'** migration for a foreign key for applications on benefit_override table.