### PR TITLE
Extend resolver service

### DIFF
--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -45,7 +45,9 @@ class EvidenceController < ApplicationController
   end
 
   def summary_save
-    record_confirmation
+    ResolverService.new(evidence, current_user).process
+    PartPaymentBuilder.new(@evidence, Settings.part_payment.expires_in_days).decide!
+    redirect_to evidence_confirmation_path
   end
 
   def confirmation
@@ -80,17 +82,6 @@ class EvidenceController < ApplicationController
     else
       redirect_to evidence_summary_path
     end
-  end
-
-  def record_confirmation
-    evidence.update(
-      completed_at: Time.zone.now,
-      completed_by: current_user
-    )
-
-    PartPaymentBuilder.new(@evidence, Settings.part_payment.expires_in_days).decide!
-
-    redirect_to evidence_confirmation_path
   end
 
   def income_params

--- a/app/controllers/part_payments_controller.rb
+++ b/app/controllers/part_payments_controller.rb
@@ -27,11 +27,7 @@ class PartPaymentsController < ApplicationController
   end
 
   def summary_save
-    part_payment.update(
-      completed_at: Time.zone.now,
-      completed_by: current_user
-    )
-
+    ResolverService.new(part_payment, current_user).process
     redirect_to(confirmation_part_payment_path(part_payment))
   end
 

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -24,6 +24,22 @@ describe ResolverService do
           it { is_expected.not_to be_nil }
         end
       end
+
+      context 'when created with a part-payment' do
+        let(:object) { create(:part_payment) }
+
+        describe 'updates the objects.completed_by value' do
+          subject { object.completed_by.name }
+
+          it { is_expected.to eql user.name }
+        end
+
+        describe 'sets the completed_at value' do
+          subject { object.completed_at }
+
+          it { is_expected.not_to be_nil }
+        end
+      end
     end
   end
 end

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -40,6 +40,23 @@ describe ResolverService do
           it { is_expected.not_to be_nil }
         end
       end
+
+      context 'when created with an evidence_check' do
+        let(:object) { create(:evidence_check_full_outcome) }
+
+        describe 'updates the objects.completed_by value' do
+          subject { object.completed_by.name }
+
+          it { is_expected.to eql user.name }
+        end
+
+        describe 'sets the completed_at value' do
+          subject { object.completed_at }
+
+          it { is_expected.not_to be_nil }
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
This ensures that all three models: Application, EvidenceCheck and PartPayment use the same method of setting their completed data fields.

Next step: 
Move the creation of EvidenceChecks and PartPayments into the ResolverService
This will reduce the work done in the controllers