### PR TITLE
Return application

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -198,7 +198,7 @@ header {
   background-color: $govuk-blue;
 }
 a.button.alternative{
-  background-color: $link-colour;
+  background-color: $light-blue;
 }
 
 .accordion-navigation > a:after {

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -61,8 +61,8 @@ class EvidenceController < ApplicationController
   end
 
   def return_application
-    evidence.application.assign_attributes(application_type: 'returned', outcome: 'none')
-    redirect_to root_path if evidence.application.save
+    assign_evidence_check_and_application_values
+    redirect_to root_path if evidence.save && evidence.application.save
   end
 
   private
@@ -105,5 +105,12 @@ class EvidenceController < ApplicationController
 
   def evidence_confirmation
     @confirmation = evidence
+  end
+
+  def assign_evidence_check_and_application_values
+    evidence.assign_attributes(outcome: 'returned',
+                               completed_at: Time.zone.now,
+                               completed_by_id: current_user.id)
+    evidence.application.assign_attributes(application_type: 'returned', outcome: 'none')
   end
 end

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -60,6 +60,11 @@ class EvidenceController < ApplicationController
     application_overview
   end
 
+  def return_application
+    evidence.application.assign_attributes(application_type: 'returned', outcome: 'none')
+    redirect_to root_path if evidence.application.save
+  end
+
   private
 
   def evidence

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -56,6 +56,10 @@ class EvidenceController < ApplicationController
     evidence_confirmation
   end
 
+  def return_letter
+    application_overview
+  end
+
   private
 
   def evidence

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -61,8 +61,7 @@ class EvidenceController < ApplicationController
   end
 
   def return_application
-    assign_evidence_check_and_application_values
-    redirect_to root_path if evidence.save && evidence.application.save
+    redirect_to root_path if ResolverService.new(evidence, current_user).resolve('return')
   end
 
   private
@@ -105,12 +104,5 @@ class EvidenceController < ApplicationController
 
   def evidence_confirmation
     @confirmation = evidence
-  end
-
-  def assign_evidence_check_and_application_values
-    evidence.assign_attributes(outcome: 'returned',
-                               completed_at: Time.zone.now,
-                               completed_by_id: current_user.id)
-    evidence.application.assign_attributes(application_type: 'returned', outcome: 'none')
   end
 end

--- a/app/views/evidence/return_letter.html.slim
+++ b/app/views/evidence/return_letter.html.slim
@@ -10,4 +10,4 @@ header
          full_name: @overview.full_name,
          current_user: current_user.name).html_safe
 
-= link_to 'Back to start', root_path, class: 'button'
+= link_to 'Finish', evidence_return_application_path, class: 'button'

--- a/app/views/evidence/return_letter.html.slim
+++ b/app/views/evidence/return_letter.html.slim
@@ -10,4 +10,5 @@ header
          full_name: @overview.full_name,
          current_user: current_user.name).html_safe
 
-= link_to 'Finish', evidence_return_application_path, class: 'button'
+= form_for @evidence, url: :evidence_return_application, method: :post, html: { autocomplete: 'off' } do |f|
+  = f.submit 'Finish', class: 'button'

--- a/app/views/evidence/return_letter.html.slim
+++ b/app/views/evidence/return_letter.html.slim
@@ -1,0 +1,13 @@
+header
+  .row
+    .small-12.medium-12.large-12.columns
+      h2 Processing complete
+
+.row
+  .small-12.medium-12.large-12.columns
+    .evidence-confirmation-letter
+      =t('evidence.return_letter',
+         full_name: @overview.full_name,
+         current_user: current_user.name).html_safe
+
+= link_to 'Back to start', root_path, class: 'button'

--- a/app/views/evidence/show.html.slim
+++ b/app/views/evidence/show.html.slim
@@ -8,13 +8,13 @@ header
     .panel
       h4 Process evidence
       #note You'll need the applicant's evidence of income
-      = link_to 'Next', evidence_accuracy_path(@evidence), class: 'button success'
+      = link_to 'Next', evidence_accuracy_path(@evidence), class: 'button'
       details
         summary
           span.summary.primary What if the applicant hasn't provided evidence?
         div
-          div If no evidence has been received by #{@processing_details.expires.to_s(:gov_uk_long)}, return all documents to the applicant with a letter.
-          = link_to 'Return application', evidence_return_letter_path(@evidence), class: 'button'
+          div If no evidence has been received by <strong>#{@processing_details.expires.to_s(:gov_uk_long)}</strong>, return all documents to the applicant with a letter.
+          = link_to 'Return application', evidence_return_letter_path(@evidence), class: 'button alternative'
           div This will remove application from the list of applications waiting for evidence on the dashboard
 
 =build_section 'Processing details', @processing_details, %w[reference processed_by expires]

--- a/app/views/evidence/show.html.slim
+++ b/app/views/evidence/show.html.slim
@@ -9,6 +9,8 @@ header
       h4 Process evidence
       #note You'll need the applicant's evidence of income
       = link_to 'Next', evidence_accuracy_path(@evidence), class: 'button success'
+      = link_to 'Return application', evidence_return_letter_path(@evidence), class: 'button'
+      #note This will remove application from the list of applications waiting for evidence on the dashboard
 
 =build_section 'Processing details', @processing_details, %w[reference processed_by expires]
 =build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status]

--- a/app/views/evidence/show.html.slim
+++ b/app/views/evidence/show.html.slim
@@ -9,8 +9,13 @@ header
       h4 Process evidence
       #note You'll need the applicant's evidence of income
       = link_to 'Next', evidence_accuracy_path(@evidence), class: 'button success'
-      = link_to 'Return application', evidence_return_letter_path(@evidence), class: 'button'
-      #note This will remove application from the list of applications waiting for evidence on the dashboard
+      details
+        summary
+          span.summary.primary What if the applicant hasn't provided evidence?
+        div
+          div If no evidence has been received by #{@processing_details.expires.to_s(:gov_uk_long)}, return all documents to the applicant with a letter.
+          = link_to 'Return application', evidence_return_letter_path(@evidence), class: 'button'
+          div This will remove application from the list of applications waiting for evidence on the dashboard
 
 =build_section 'Processing details', @processing_details, %w[reference processed_by expires]
 =build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,15 @@ en-GB:
         applicant: Applicant
         processed_by: Processed by
         expires: Expires
+    return_letter: |
+      <p>Dear %{full_name}</p>
+      <p>We have received your documents however they are not correct,
+      therefore we’re unable to process your application. This may
+      have an impact on the original case or claim related to this
+      application.</p>
+      <p>You will need to make a new application if you still require help.</p>
+      <p>Yours sincerely,</p>
+      <p>%{current_user}</p>
   part_payment:
     correct: 'Yes'
     incorrect: 'No'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
   post 'evidence/:id/summary', to: 'evidence#summary_save', as: :evidence_summary_save
   get 'evidence/:id/confirmation', to: 'evidence#confirmation', as: :evidence_confirmation
   get 'evidence/:id/return_letter', to: 'evidence#return_letter', as: :evidence_return_letter
+  # rubocop:disable Metrics/LineLength
   post 'evidence/:id/return_application', to: 'evidence#return_application', as: :evidence_return_application
 
   resources :evidence_checks, only: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
   get 'evidence/:id/summary', to: 'evidence#summary', as: :evidence_summary
   post 'evidence/:id/summary', to: 'evidence#summary_save', as: :evidence_summary_save
   get 'evidence/:id/confirmation', to: 'evidence#confirmation', as: :evidence_confirmation
+  get 'evidence/:id/return_letter', to: 'evidence#return_letter', as: :evidence_return_letter
 
   resources :evidence_checks, only: :show
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
   post 'evidence/:id/summary', to: 'evidence#summary_save', as: :evidence_summary_save
   get 'evidence/:id/confirmation', to: 'evidence#confirmation', as: :evidence_confirmation
   get 'evidence/:id/return_letter', to: 'evidence#return_letter', as: :evidence_return_letter
+  post 'evidence/:id/return_application', to: 'evidence#return_application', as: :evidence_return_application
 
   resources :evidence_checks, only: :show
 

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -319,14 +319,23 @@ RSpec.describe EvidenceController, type: :controller do
   end
 
   describe 'GET #return_letter' do
-    before(:each) { get :return_letter, id: evidence }
+    context 'as a signed out user' do
+      before(:each) { get :return_letter, id: evidence }
 
-    it 'returns the correct status code' do
-      expect(response).to have_http_status(200)
+      it { expect(response).to have_http_status(:redirect) }
+
+      it { expect(response).to redirect_to(user_session_path) }
     end
 
-    it 'renders the correct template' do
-      expect(response).to render_template('return_letter')
+    context 'as a signed in user' do
+      before(:each) do
+        sign_in user
+        get :return_letter, id: evidence
+      end
+
+      it { expect(response).to have_http_status(200) }
+
+      it { expect(response).to render_template('return_letter') }
     end
   end
 end

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -317,4 +317,16 @@ RSpec.describe EvidenceController, type: :controller do
       end
     end
   end
+
+  describe 'GET #return_letter' do
+    before(:each) { get :return_letter, id: evidence }
+
+    it 'returns the correct status code' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template('return_letter')
+    end
+  end
 end

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -360,16 +360,4 @@ RSpec.describe EvidenceController, type: :controller do
       end
     end
   end
-
-  describe 'GET #return_letter' do
-    before(:each) { get :return_letter, id: evidence }
-
-    it 'returns the correct status code' do
-      expect(response).to have_http_status(200)
-    end
-
-    it 'renders the correct template' do
-      expect(response).to render_template('return_letter')
-    end
-  end
 end

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -358,26 +358,6 @@ RSpec.describe EvidenceController, type: :controller do
       it 'returns the correct status code' do
         expect(response).to have_http_status(:redirect)
       end
-
-      it 'updates the application outcome' do
-        expect(evidence.application.outcome).to eq 'none'
-      end
-
-      it 'updates the evidence outcome' do
-        expect(evidence.outcome).to eq 'returned'
-      end
-
-      it 'updates the evidence completed_at' do
-        expect(evidence.completed_at).not_to be_nil
-      end
-
-      it 'updates the evidence completed_by' do
-        expect(evidence.completed_by_id).not_to be_nil
-      end
-
-      it 'updates the application type' do
-        expect(evidence.application.application_type).to eq 'returned'
-      end
     end
   end
 end

--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -363,6 +363,18 @@ RSpec.describe EvidenceController, type: :controller do
         expect(evidence.application.outcome).to eq 'none'
       end
 
+      it 'updates the evidence outcome' do
+        expect(evidence.outcome).to eq 'returned'
+      end
+
+      it 'updates the evidence completed_at' do
+        expect(evidence.completed_at).not_to be_nil
+      end
+
+      it 'updates the evidence completed_by' do
+        expect(evidence.completed_by_id).not_to be_nil
+      end
+
       it 'updates the application type' do
         expect(evidence.application.application_type).to eq 'returned'
       end

--- a/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
+++ b/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.feature 'When evidence checkable applications are returned', type: :feature do
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let(:office) { create :office }
+  let(:user) { create :user, office: office }
+
+  let(:application1) { create :application_full_remission, office: office }
+  let!(:evidence1) { create :evidence_check, application: application1 }
+  let(:application2) { create :application_full_remission, office: office }
+  let!(:evidence2) { create :evidence_check, application: application2 }
+
+  before { login_as user }
+
+  context 'when on home page' do
+
+    before { visit root_path }
+
+    scenario 'shows the applications that should be checked for evidence' do
+      within '.waiting-for-evidence' do
+        expect(page).to have_content(application1.reference)
+        expect(page).to have_content(application2.reference)
+      end
+    end
+
+    scenario 'shows "Return application" button' do
+      click_link application1.reference
+      expect(page).to have_content 'Process evidence'
+      expect(page).to have_content application1.applicant.full_name
+      expect(page).to have_link 'Return application'
+    end
+
+    scenario 'when returning application' do
+      click_link application1.reference
+      click_link 'Return application'
+      expect(page).to have_content 'Processing complete'
+      expect(page).to have_link 'Back to start'
+    end
+  end
+end

--- a/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
+++ b/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'When evidence checkable applications are returned', type: :featur
       click_link application1.reference
       expect(page).to have_content 'Process evidence'
       expect(page).to have_content application1.applicant.full_name
+      expect(page).to have_content "What if the applicant hasn't provided evidence?"
       expect(page).to have_link 'Return application'
     end
 

--- a/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
+++ b/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
@@ -37,9 +37,10 @@ RSpec.feature 'When evidence checkable applications are returned', type: :featur
       click_link application1.reference
       click_link 'Return application'
       expect(page).to have_content 'Processing complete'
-      expect(page).to have_link 'Finish'
-      click_link 'Finish'
+      expect(page).to have_button 'Finish'
+      click_button 'Finish'
       expect(page).to have_content 'Start now'
+      expect(page).not_to have_content application1.reference
     end
   end
 end

--- a/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
+++ b/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
@@ -37,7 +37,9 @@ RSpec.feature 'When evidence checkable applications are returned', type: :featur
       click_link application1.reference
       click_link 'Return application'
       expect(page).to have_content 'Processing complete'
-      expect(page).to have_link 'Back to start'
+      expect(page).to have_link 'Finish'
+      click_link 'Finish'
+      expect(page).to have_content 'Start now'
     end
   end
 end

--- a/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
+++ b/spec/features/return_applications/return_evidence_checkable_applications_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'When evidence checkable applications are returned', type: :featur
       click_link application1.reference
       expect(page).to have_content 'Process evidence'
       expect(page).to have_content application1.applicant.full_name
-      expect(page).to have_content "What if the applicant hasn't provided evidence?"
+      expect(page).to have_content "If the evidence can’t be processed"
       expect(page).to have_link 'Return application'
     end
 

--- a/spec/routing/evidence_routing_spec.rb
+++ b/spec/routing/evidence_routing_spec.rb
@@ -37,5 +37,9 @@ RSpec.describe EvidenceController, type: :routing do
     it 'route_to to #return_letter' do
       expect(get: '/evidence/1/return_letter').to route_to('evidence#return_letter', id: '1')
     end
+
+    it 'route_to to #return_application' do
+      expect(post: '/evidence/1/return_application').to route_to('evidence#return_application', id: '1')
+    end
   end
 end

--- a/spec/routing/evidence_routing_spec.rb
+++ b/spec/routing/evidence_routing_spec.rb
@@ -33,5 +33,9 @@ RSpec.describe EvidenceController, type: :routing do
     it 'routes to #evidence_confirmation' do
       expect(get: '/evidence/1/confirmation').to route_to('evidence#confirmation', id: '1')
     end
+
+    it 'route_to to #return_letter' do
+      expect(get: '/evidence/1/return_letter').to route_to('evidence#return_letter', id: '1')
+    end
   end
 end


### PR DESCRIPTION
Allow users to return applications that are due for evidence check, where the applicant has not provided evidence during the required time window.

All it does is generate a letter for the applicant and marks.
