### PR TITLE
Removed 'focus' tags from specs

### DIFF
--- a/spec/controllers/evidence_controller_spec.rb
+++ b/spec/controllers/evidence_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe EvidenceController, type: :controller do
     end
   end
 
-  describe 'POST #accuracy_save', focus: true do
+  describe 'POST #accuracy_save' do
     let(:form) { double }
     let(:expected_form_params) { { correct: true, incorrect_reason: 'reason' } }
 

--- a/spec/controllers/part_payments_controller_spec.rb
+++ b/spec/controllers/part_payments_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe PartPaymentsController, type: :controller do
     end
   end
 
-  describe 'POST #accuracy_save', focus: true do
+  describe 'POST #accuracy_save' do
     let(:expected_form_params) { { correct: true, incorrect_reason: 'reason' } }
 
     before do

--- a/spec/features/applications/benefit_results_are_rendered_spec.rb
+++ b/spec/features/applications/benefit_results_are_rendered_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Benefit Results', type: :feature do
     end
 
     context 'after user selects yes to benefits' do
-      context 'when NI has not been provided', focus: true do
+      context 'when NI has not been provided' do
         let(:ni_number) { nil }
         let(:error_message) { "The applicant's details could not be checked with the Department for Work and Pensions" }
 


### PR DESCRIPTION
No need for them to be left lying around, so removing them.