### PR TITLE
Added validation for income

### DIFF
--- a/app/models/applikation/forms/income.rb
+++ b/app/models/applikation/forms/income.rb
@@ -11,6 +11,8 @@ module Applikation
 
       define_attributes
 
+      validates :income, presence: true
+      validates :income, numericality: { allow_blank: true }
       validates :dependents, inclusion: { in: [true, false] }
       validates :children, numericality: { greater_than: 0, only_integer: true }, if: :dependents?
       validate :number_of_children_when_no_dependents

--- a/spec/models/applikation/forms/income_spec.rb
+++ b/spec/models/applikation/forms/income_spec.rb
@@ -14,8 +14,15 @@ RSpec.describe Applikation::Forms::Income do
   describe 'validation' do
     let(:income) { described_class.new(hash) }
 
+    describe 'income' do
+      let(:hash) { { income: 500, dependents: true, children: 1 } }
+
+      it { is_expected.to validate_presence_of(:income) }
+      it { is_expected.to validate_numericality_of(:income) }
+    end
+
     describe 'dependents' do
-      let(:hash) { { dependents: dependents, children: 1 } }
+      let(:hash) { { income: 500, dependents: dependents, children: 1 } }
 
       context 'when true' do
         let(:dependents) { true }
@@ -37,7 +44,7 @@ RSpec.describe Applikation::Forms::Income do
     end
 
     describe 'children' do
-      let(:hash) { { dependents: dependents, children: children } }
+      let(:hash) { { income: 500, dependents: dependents, children: children } }
 
       context 'when there are dependents' do
         let(:dependents) { true }


### PR DESCRIPTION
The Income form needed validation on the income field.

The page could not be saved without it and was then throwing a 500 error
if the page was saved without an income recorded.