### PR TITLE
Fix for running db:migrate from scratch

### DIFF
--- a/db/migrate/20150508131347_add_fields_to_dwp_check.rb
+++ b/db/migrate/20150508131347_add_fields_to_dwp_check.rb
@@ -2,6 +2,12 @@ class AddFieldsToDwpCheck < ActiveRecord::Migration
   def change
     add_column :dwp_checks, :our_api_token, :string
     add_reference :dwp_checks, :office, index: true, foreign_key: true
-    DwpCheck.connection.execute('UPDATE dwp_checks SET office_id = users.office_id FROM users WHERE users.id = dwp_checks.created_by_id;')
+    migrate_sql = <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE dwp_checks
+      |SET office_id = users.office_id
+      |FROM users
+      |WHERE users.id = dwp_checks.created_by_id;
+    SQL
+    execute(migrate_sql)
   end
 end


### PR DESCRIPTION
Because the DwpCheck model had been deleted, this would cause db:migrate to fail
when run from scratch.

Switched the script to execute SQL rather the use the ActiveRecord::connection method.