### PR TITLE
Nokogiri upgrade due to security vuln

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ group :development do
   gem 'rack-livereload'
 end
 
+gem 'nokogiri', '~> 1.6.7.rc4'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,14 +204,14 @@ GEM
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
     mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0.rc2)
     minitest (5.8.3)
     multi_json (1.11.1)
     multipart-post (2.0.0)
     nenv (0.2.0)
     netrc (0.10.3)
-    nokogiri (1.6.6.4)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.7.rc4)
+      mini_portile2 (~> 2.0.0.rc2)
     notiffany (0.0.6)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -425,6 +425,7 @@ DEPENDENCIES
   jquery-turbolinks
   launchy
   logstasher!
+  nokogiri (~> 1.6.7.rc4)
   paranoia (~> 2.0)
   pg
   pry-rails


### PR DESCRIPTION
A security vulnerability was discovered with libxml2 & libxslt which
affects nokogiri (which uses those libraries).

More information here:

https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.rdoc#167rc4--2015-11-22
https://github.com/sparklemotion/nokogiri/commit/ee52b7be5b47e1029af98f6b7eb6df7fc5ffd359
https://github.com/sparklemotion/nokogiri/commit/0948e9fa38c949661983a33752fdcb94a453e272