### PR TITLE
Validate refund date relative to date received

### DIFF
--- a/app/models/applikation/forms/application_detail.rb
+++ b/app/models/applikation/forms/application_detail.rb
@@ -43,8 +43,9 @@ module Applikation
 
       with_options if: :refund? do
         validates :date_fee_paid, date: {
-          after_or_equal_to: :min_date,
-          before: :tomorrow
+          after_or_equal_to: :min_refund_date,
+          before: :max_refund_date,
+          allow_blank: false
         }
       end
 
@@ -56,6 +57,14 @@ module Applikation
 
       def min_date
         3.months.ago.midnight
+      end
+
+      def min_refund_date
+        date_received - 3.months unless date_received.blank?
+      end
+
+      def max_refund_date
+        date_received unless date_received.blank?
       end
 
       def tomorrow

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -366,8 +366,8 @@ en-GB:
             date_fee_paid:
               not_a_date: Enter the date in this format 01/01/2015
               invalid: Enter the date in this format day month, year DD/MM/YYYY
-              after_or_equal_to: The application must have been made in the last 3 months
-              before: The application cannot be a future date
+              after_or_equal_to: This date can’t be more than 3 months before the application was received
+              before: This date can’t be after the application was received
               blank: The date fee paid should be entered
             date_of_death:
               after: The date of death should be entered


### PR DESCRIPTION
This changes validation of the refund date form field. It now has to be:
* up to 3 months before the date application received
* not later than date application received