### PR TITLE
Trim applicant name fields

### DIFF
--- a/app/models/forms/application/applicant.rb
+++ b/app/models/forms/application/applicant.rb
@@ -24,6 +24,7 @@ module Forms
       define_attributes
 
       before_validation :format_ni_number
+      before_validation :strip_whitespace!
 
       def format_ni_number
         unless ni_number.nil?
@@ -39,6 +40,12 @@ module Forms
       validates :ni_number, format: { with: NI_NUMBER_REGEXP }, allow_blank: true
 
       private
+
+      def strip_whitespace!
+        title.strip! if title
+        first_name.strip! if first_name
+        last_name.strip! if last_name
+      end
 
       def dob_age_valid?
         validate_dob

--- a/spec/models/forms/application/applicant_spec.rb
+++ b/spec/models/forms/application/applicant_spec.rb
@@ -110,6 +110,29 @@ RSpec.describe Forms::Application::Applicant do
         end
       end
     end
+    %w[title first_name last_name].each do |attribute|
+      describe "#{attribute}" do
+        context 'when valid' do
+          before { personal_information[attribute.to_sym] = 'Mr' }
+
+          it 'passes validation' do
+            expect(subject.valid?).to be true
+          end
+        end
+
+        context 'when white space is passed in' do
+          before do
+            personal_information[attribute.to_sym] = ' sm it '
+            subject.valid?
+          end
+
+          it 'strips it away' do
+            expect(subject.send(attribute)).to eql('sm it')
+          end
+        end
+      end
+    end
+
   end
 
   describe 'when Applicant object is passed in' do


### PR DESCRIPTION
The user surname was not being trimmed before being sent to the DWP.

We now trim the name fields before validating to prevent this.

This should prevent transcription errors when users cut and paste from other sources.