### PR TITLE
Updated guide to evidence checks

### DIFF
--- a/app/views/guide/evidence_checks.html.slim
+++ b/app/views/guide/evidence_checks.html.slim
@@ -39,7 +39,8 @@ header
     p You only need to check paper evidence when an application is marked for an evidence check. The statement of truth signed by the applicant is legally binding.
     p See more about #{link_to 'what to do if you suspect fraud', guide_suspected_fraud_path }
     p Evidence checks are a way for HMCTS to make sure that applicants are providing accurate information about their income. 
-    p If an application is marked for an evidence check, write to the applicant and ask them to send evidence of their income. You’ll be provided with a letter to use.  
+    p If an application is marked for an evidence check, write to the applicant and ask them to send evidence of their income. You’ll be provided with a letter to use. 
+    p You won't be able to finish processing the application until you've received the evidence.  
     
     a id="before-start"
     h3 Before you start
@@ -66,7 +67,7 @@ header
 
       h5 To process evidence:
       ul
-        li select the application from the list ‘Awaiting evidence’
+        li select the application from the list ‘Waiting for evidence’
         li select 'Process evidence'
         li calculate the applicant's total monthly income from the evidence received (not the application form)
         li enter the total in the field on the screen


### PR DESCRIPTION
1. Court staff feedback to say needed to be clearer re not accepting /
rejecting applications before evidence is rec’d

2. Applications awaiting evidence > Applications waiting for evidence