### PR TITLE
Updated management views

### DIFF
--- a/app/views/offices/show.html.slim
+++ b/app/views/offices/show.html.slim
@@ -2,17 +2,13 @@ h2 Office details
 
 #result_table
   .row
-    .columns.small-4.large-2
-      label Name of office
-    .columns.small-8.large-10
-      =@office.name
-    .columns.small-4.large-2
-      label Entity code
-    .columns.small-8.large-10
-      =@office.entity_code
+    .columns.small-4.large-2 Name of office
+    .columns.small-8.large-10 =@office.name
   .row
-    .columns.small-4.large-2
-      label Jurisdictions
+    .columns.small-4.large-2  Entity code
+    .columns.small-8.large-10 =@office.entity_code
+  .row
+    .columns.small-4.large-2 Jurisdictions
     .columns.small-8.large-10
       - @office.jurisdictions.each do |j|
         div =j.display

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -2,28 +2,19 @@ h2 Staff details
 
 #result_table
   .row
-    .columns.small-4.large-2
-      label Full name
-    .columns.small-6.large-10
-      =@user.name
+    .columns.small-4.large-2 Full name
+    .columns.small-6.large-10 =@user.name
   .row
-    .columns.small-4.large-2
-      label Email
-    .columns.small-6.large-10
-      =@user.email
+    .columns.small-4.large-2 Email
+    .columns.small-6.large-10 =@user.email
   .row
-    .columns.small-4.large-2
-      label Role
-    .columns.small-6.large-10
-      =@user.role.humanize
+    .columns.small-4.large-2 label Role
+    .columns.small-6.large-10 =@user.role.humanize
   .row
-    .columns.small-4.large-2
-      label Office
-    .columns.small-6.large-10
-      =@user.office.name
+    .columns.small-4.large-2 Office
+    .columns.small-6.large-10 =@user.office.name
   .row
-    .columns.small-4.large-2
-      label Main jurisdiction
+    .columns.small-4.large-2 Main jurisdiction
     .columns.small-6.large-10
       =@user.jurisdiction.name if @user.jurisdiction.present?
 .row.pad-top-thirty-px


### PR DESCRIPTION
Following a CSS update the management views for office and staff
had become... sub-optimal
![screen shot 2015-12-04 at 11 20 14](https://cloud.githubusercontent.com/assets/6757677/11588505/145db6e6-9a79-11e5-981e-6b5d8a7eb741.png)![screen shot 2015-12-04 at 11 20 27](https://cloud.githubusercontent.com/assets/6757677/11588508/17774892-9a79-11e5-979a-019567fb0a30.png)

This update corrects the spacing and adds a row for the BE code.

This means that users will have a better experience on the management side of the app, until the 'merging staff and office' ticket reaches the backlog.