### PR TITLE
Fix for entity code test fails

### DIFF
--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     end
 
     sequence(:name) { |n| "#{Faker::Company.name} #{n}" }
-    sequence(:entity_code) { |n| "#{Faker::Commerce.color.split('').sample(2).join.upcase}#{n.to_s.ljust(3, '0')}" }
+    sequence(:entity_code) { |n| "#{Faker::Commerce.color.split('').sample(2).join.upcase}#{n.to_s.rjust(3, '0')}" }
 
     jurisdictions { build_list :jurisdiction, jurisdictions_count }
 


### PR DESCRIPTION
## Updated the office factory 
- The factory generates sequences of entity_codes
- Using ljust creates 100, 200, 300, 400...
- Switching to rjust means that 001, 002 sequences are created, this
leads to less opportunities to clash.