### PR TITLE
Allow the date fee paid to match received date

### DIFF
--- a/app/models/forms/application/detail.rb
+++ b/app/models/forms/application/detail.rb
@@ -44,7 +44,7 @@ module Forms
       with_options if: :refund? do
         validates :date_fee_paid, date: {
           after_or_equal_to: :min_refund_date,
-          before: :max_refund_date,
+          before_or_equal_to: :max_refund_date,
           allow_blank: false
         }
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,7 +312,7 @@ en-GB:
               not_a_date: Enter the date in this format DD/MM/YYYY
               invalid: Enter the date in this format day month, year DD/MM/YYYY
               after_or_equal_to: This date can’t be more than 3 months before the application was received
-              before: This date can’t be after the application was received
+              before_or_equal_to: This date can’t be after the application was received
               blank: The date fee paid should be entered
             date_of_death:
               after: The date of death should be entered

--- a/spec/models/forms/application/detail_spec.rb
+++ b/spec/models/forms/application/detail_spec.rb
@@ -232,6 +232,12 @@ RSpec.describe Forms::Application::Detail do
                 it { is_expected.to eq ['This date can’t be more than 3 months before the application was received'] }
               end
             end
+
+            describe 'on the same day' do
+              let(:date_fee_paid) { Time.zone.local(2014, 11, 15, 12, 30, 0) }
+
+              it { is_expected.to be_valid }
+            end
           end
 
           describe 'minimum boundary is the date_received' do


### PR DESCRIPTION
Allow the date fee paid to be on the same day as the date the
application was received.

Previously it only allowed the paid fee date to be the date before.

:ticket::
https://www.pivotaltracker.com/story/show/109797244