### PR TITLE
Business entities

### DIFF
--- a/app/builders/application_builder.rb
+++ b/app/builders/application_builder.rb
@@ -10,22 +10,12 @@ class ApplicationBuilder
     Application.create(
       office_id: @user.office_id,
       user_id: @user.id,
-      reference: generate_reference,
       applicant: build_applicant,
       detail: build_details
     )
   end
 
   private
-
-  def generate_reference
-    entity_code = @user.office.entity_code
-    current_year = Time.zone.now.strftime('%y')
-    code_and_year = "#{entity_code}-#{current_year}"
-    counter = Application.where('reference like ?', "#{code_and_year}-%").count + 1
-
-    "#{code_and_year}-#{counter}"
-  end
 
   def build_applicant
     Applicant.new

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -19,7 +19,7 @@ class Application < ActiveRecord::Base
     deleted: 4
   }
 
-  validates :reference, presence: true, uniqueness: true
+  validates :reference, uniqueness: true, allow_blank: true
 
   # Fixme remove this delegation methods when all tests are clean
   APPLICANT_GETTERS = %i[

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -4,6 +4,7 @@ class Application < ActiveRecord::Base
   belongs_to :completed_by, -> { with_deleted }, class_name: 'User'
   belongs_to :deleted_by, -> { with_deleted }, class_name: 'User'
   belongs_to :office
+  belongs_to :business_entity
   has_many :benefit_checks
   has_one :applicant
   has_one :detail, inverse_of: :application

--- a/app/models/business_entity.rb
+++ b/app/models/business_entity.rb
@@ -1,0 +1,6 @@
+class BusinessEntity < ActiveRecord::Base
+  belongs_to :office
+  belongs_to :jurisdiction
+
+  validates :office, :jurisdiction, :code, :name, presence: true
+end

--- a/app/services/reference_generator.rb
+++ b/app/services/reference_generator.rb
@@ -1,7 +1,34 @@
 class ReferenceGenerator
-  BYTES = 5
+  def initialize(application)
+    @application = application
+  end
 
-  def self.generate
-    SecureRandom.hex(BYTES).upcase
+  def attributes
+    {
+      business_entity: business_entity,
+      reference: reference
+    }
+  end
+
+  private
+
+  def business_entity
+    @business_entity ||= BusinessEntity.where(
+      office: @application.office, jurisdiction: @application.jurisdiction).first
+  end
+
+  def reference_prefix
+    "#{business_entity.code}-#{Time.zone.now.strftime('%y')}-"
+  end
+
+  def reference
+    last_application = Application.where('reference LIKE ?', "#{reference_prefix}%").order(:id).last
+    last_sequence = if last_application
+                      last_application.reference.gsub(reference_prefix, '').to_i
+                    else
+                      0
+                    end
+
+    "#{reference_prefix}#{last_sequence + 1}"
   end
 end

--- a/app/services/reference_generator.rb
+++ b/app/services/reference_generator.rb
@@ -1,0 +1,7 @@
+class ReferenceGenerator
+  BYTES = 5
+
+  def self.generate
+    SecureRandom.hex(BYTES).upcase
+  end
+end

--- a/app/services/resolver_service.rb
+++ b/app/services/resolver_service.rb
@@ -38,7 +38,8 @@ class ResolverService
   end
 
   def completed_application_attributes
-    completed_attributes.merge(reference: ReferenceGenerator.generate)
+    generator = ReferenceGenerator.new(@calling_object)
+    completed_attributes.merge(generator.attributes)
   end
 
   def decided_attributes(source)

--- a/app/services/resolver_service.rb
+++ b/app/services/resolver_service.rb
@@ -37,6 +37,10 @@ class ResolverService
     }
   end
 
+  def completed_application_attributes
+    completed_attributes.merge(reference: ReferenceGenerator.generate)
+  end
+
   def decided_attributes(source)
     {
       decision: lookup_decision(source.outcome),
@@ -54,7 +58,7 @@ class ResolverService
   end
 
   def complete_application(application)
-    attributes = completed_attributes.tap do |attrs|
+    attributes = completed_application_attributes.tap do |attrs|
       if decide_evidence_check(application)
         attrs[:state] = :waiting_for_evidence
       elsif decide_part_payment(application)

--- a/db/migrate/20151210152605_create_business_entities.rb
+++ b/db/migrate/20151210152605_create_business_entities.rb
@@ -1,0 +1,34 @@
+class CreateBusinessEntities < ActiveRecord::Migration
+  def up
+    create_table :business_entities do |t|
+      t.references :office, null: false, index: true
+      t.references :jurisdiction, null: false, index: true
+
+      t.string :code, null: false, index: true
+      t.string :name, null: false, index: true
+
+      t.timestamps null: false
+    end
+
+    add_index :business_entities, [:office_id, :jurisdiction_id], unique: true, name: :unique_office_jurisdiction
+
+    insert_sql = <<-SQL.gsub(/^\s+\|/, '')
+      |INSERT INTO business_entities (office_id, jurisdiction_id, code, name, created_at, updated_at)
+      |SELECT
+      |  offices.id,
+      |  jurisdictions.id,
+      |  offices.entity_code,
+      |  concat_ws(' - ', offices.name, jurisdictions.name),
+      |  NOW(),
+      |  NOW()
+      |FROM offices
+      |CROSS JOIN jurisdictions
+    SQL
+    execute(insert_sql)
+  end
+
+  def down
+    remove_index :business_entities, name: :unique_office_jurisdiction
+    drop_table :business_entities
+  end
+end

--- a/db/migrate/20151214170243_add_business_entity_to_application.rb
+++ b/db/migrate/20151214170243_add_business_entity_to_application.rb
@@ -1,0 +1,23 @@
+class AddBusinessEntityToApplication < ActiveRecord::Migration
+  def up
+    add_reference :applications, :business_entity, index: true, null: true, foreign_key: true
+
+    update_sql = <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET business_entity_id = (
+      |  SELECT id
+      |  FROM business_entities
+      |  WHERE
+      |    business_entities.office_id = applications.office_id AND
+      |    business_entities.jurisdiction_id = details.jurisdiction_id
+      |)
+      |FROM details
+      |WHERE applications.id = details.application_id
+    SQL
+    execute(update_sql)
+  end
+
+  def down
+    remove_reference :applications, :business_entity
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151209222512) do
+ActiveRecord::Schema.define(version: 20151210152605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,21 @@ ActiveRecord::Schema.define(version: 20151209222512) do
   end
 
   add_index "benefit_overrides", ["application_id"], name: "index_benefit_overrides_on_application_id", using: :btree
+
+  create_table "business_entities", force: :cascade do |t|
+    t.integer  "office_id",       null: false
+    t.integer  "jurisdiction_id", null: false
+    t.string   "code",            null: false
+    t.string   "name",            null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
+  add_index "business_entities", ["code"], name: "index_business_entities_on_code", using: :btree
+  add_index "business_entities", ["jurisdiction_id"], name: "index_business_entities_on_jurisdiction_id", using: :btree
+  add_index "business_entities", ["name"], name: "index_business_entities_on_name", using: :btree
+  add_index "business_entities", ["office_id", "jurisdiction_id"], name: "unique_office_jurisdiction", unique: true, using: :btree
+  add_index "business_entities", ["office_id"], name: "index_business_entities_on_office_id", using: :btree
 
   create_table "details", force: :cascade do |t|
     t.integer  "application_id",   null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151210152605) do
+ActiveRecord::Schema.define(version: 20151214170243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,8 +55,10 @@ ActiveRecord::Schema.define(version: 20151210152605) do
     t.string   "deleted_reason"
     t.datetime "deleted_at"
     t.integer  "deleted_by_id"
+    t.integer  "business_entity_id"
   end
 
+  add_index "applications", ["business_entity_id"], name: "index_applications_on_business_entity_id", using: :btree
   add_index "applications", ["office_id"], name: "index_applications_on_office_id", using: :btree
   add_index "applications", ["reference"], name: "index_applications_on_reference", unique: true, using: :btree
   add_index "applications", ["user_id"], name: "index_applications_on_user_id", using: :btree
@@ -225,6 +227,7 @@ ActiveRecord::Schema.define(version: 20151210152605) do
   add_index "users", ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
+  add_foreign_key "applications", "business_entities"
   add_foreign_key "applications", "offices"
   add_foreign_key "applications", "users"
   add_foreign_key "benefit_checks", "applications"

--- a/spec/builders/application_builder_spec.rb
+++ b/spec/builders/application_builder_spec.rb
@@ -46,26 +46,8 @@ RSpec.describe ApplicationBuilder do
         expect(subject.detail.jurisdiction).to eql(user.jurisdiction)
       end
 
-      describe 'the generated reference' do
-        subject(:reference) { create_result.reference }
-
-        it 'starts with the office entity code' do
-          is_expected.to match(/^#{user.office.entity_code}/)
-        end
-
-        it 'contains the current year' do
-          is_expected.to match(/-#{current_year}-/)
-        end
-
-        it 'increments counter for the same office and year' do
-          first_reference = application_builder.create.reference
-          first_counter = /-([0-9]+)$/.match(first_reference)[1].to_i
-
-          second_reference = subject
-          second_counter = /-([0-9]+)$/.match(second_reference)[1].to_i
-
-          expect(second_counter - first_counter).to be(1)
-        end
+      it 'does not have reference set' do
+        expect(subject.reference).to be nil
       end
     end
   end

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -455,8 +455,11 @@ RSpec.describe Applications::ProcessController, type: :controller do
     let(:current_time) { Time.zone.now }
     let(:user) { create :user }
     let(:application) { create :application_full_remission }
+    let(:resolver) { double(complete: nil) }
 
     before do
+      expect(ResolverService).to receive(:new).with(application, user).and_return(resolver)
+
       Timecop.freeze(current_time) do
         sign_in user
         post :summary_save, application_id: application.id
@@ -471,9 +474,8 @@ RSpec.describe Applications::ProcessController, type: :controller do
       expect(response).to redirect_to(application_confirmation_path(application.id))
     end
 
-    it 'updates the payment completed_at and completed_by' do
-      expect(application.completed_at).to eql(current_time)
-      expect(application.completed_by).to eql(user)
+    it 'completes the application using the ResolverService' do
+      expect(resolver).to have_received(:complete)
     end
   end
 

--- a/spec/factories/applications.rb
+++ b/spec/factories/applications.rb
@@ -1,4 +1,6 @@
 FactoryGirl.define do
+  sequence(:reference_number) { |n| "AB001-#{Time.zone.now.strftime('%y')}-#{n}" }
+
   factory :application do
     transient do
       ni_number nil
@@ -16,7 +18,6 @@ FactoryGirl.define do
       emergency_reason nil
     end
 
-    sequence(:reference) { |n| "AB001-#{Time.zone.now.strftime('%y')}-#{n}" }
     benefits true
     dependents true
     children 1
@@ -64,20 +65,24 @@ FactoryGirl.define do
     end
 
     trait :processed_state do
+      reference { generate(:reference_number) }
       decision { outcome }
       decision_type 'application'
       state :processed
     end
 
     trait :waiting_for_evidence_state do
+      reference { generate(:reference_number) }
       state :waiting_for_evidence
     end
 
     trait :waiting_for_part_payment_state do
+      reference { generate(:reference_number) }
       state :waiting_for_part_payment
     end
 
     trait :deleted_state do
+      reference { generate(:reference_number) }
       decision { outcome }
       decision_type 'application'
       state :deleted

--- a/spec/factories/business_entities.rb
+++ b/spec/factories/business_entities.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :business_entity do
+    office
+    jurisdiction
+    code { 'SD123' }
+    name { 'Special division' }
+  end
+end

--- a/spec/factories/offices.rb
+++ b/spec/factories/offices.rb
@@ -12,5 +12,11 @@ FactoryGirl.define do
     factory :invalid_office do
       name nil
     end
+
+    after(:create) do |office, _|
+      office.jurisdictions.each do |jurisdiction|
+        create(:business_entity, office: office, jurisdiction: jurisdiction)
+      end
+    end
   end
 end

--- a/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
+++ b/spec/features/evidence-checks/evidence_check_page_displayed_instead_of_confirmation_spec.rb
@@ -5,21 +5,21 @@ RSpec.feature 'Evidence check page displayed instead of confirmation', type: :fe
   include Warden::Test::Helpers
   Warden.test_mode!
 
-  let(:user) { create :user }
+  let(:jurisdiction) { create :jurisdiction }
+  let(:office) { create :office, jurisdictions: [jurisdiction] }
+  let(:user) { create :user, office: office }
 
   before do
     login_as user
   end
 
-  let(:application) { create :application_full_remission, reference: Random.srand }
+  let(:application) { create :application_full_remission, office: office, jurisdiction: jurisdiction }
 
   scenario 'User continues from the summary page when building the application and is redirected to evidence check' do
     create_list :application_full_remission, 9
 
-    visit application_income_path(application)
+    visit application_summary_path(application)
 
-    click_button 'Next'
-    click_link 'Next'
     click_button 'Complete processing'
 
     expect(page).to have_content 'Evidence of income needs to be checked for this application'

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe Application, type: :model do
   it { is_expected.to have_one(:part_payment) }
   it { is_expected.not_to validate_presence_of(:part_payment) }
 
-  it { is_expected.to validate_presence_of(:reference) }
-  it { is_expected.to validate_uniqueness_of(:reference) }
+  it { is_expected.to validate_uniqueness_of(:reference).allow_blank }
 
   it { is_expected.to define_enum_for(:state).with([:created, :waiting_for_evidence, :waiting_for_part_payment, :processed, :deleted]) }
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Application, type: :model do
   it { is_expected.to belong_to(:completed_by).class_name('User') }
   it { is_expected.to belong_to(:deleted_by).class_name('User') }
   it { is_expected.to belong_to(:office) }
+  it { is_expected.to belong_to(:business_entity) }
 
   it { is_expected.to have_one(:applicant) }
   it { is_expected.to have_one(:detail) }

--- a/spec/models/business_entity_spec.rb
+++ b/spec/models/business_entity_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe BusinessEntity, type: :model do
+  it { is_expected.to belong_to(:office) }
+  it { is_expected.to belong_to(:jurisdiction) }
+
+  it { is_expected.to validate_presence_of(:office) }
+  it { is_expected.to validate_presence_of(:jurisdiction) }
+  it { is_expected.to validate_presence_of(:code) }
+  it { is_expected.to validate_presence_of(:name) }
+end

--- a/spec/services/reference_generator_spec.rb
+++ b/spec/services/reference_generator_spec.rb
@@ -1,16 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe ReferenceGenerator, type: :service do
-  describe '.generate' do
-    let(:random_string) { 'ab3c' }
-    before do
-      allow(SecureRandom).to receive(:hex).and_return(random_string)
+  let(:current_time) { Time.zone.parse('2016-03-01 10:20:30') }
+  let!(:office) { create :office }
+  let!(:jurisdiction) { create :jurisdiction }
+  let!(:business_entity) { create :business_entity, office: office, jurisdiction: jurisdiction, code: 'AB987' }
+
+  subject(:generator) { described_class.new(application) }
+
+  describe '#attributes' do
+    let(:application) { create :application, office: office, jurisdiction: jurisdiction, business_entity: nil, reference: nil }
+
+    subject do
+      Timecop.freeze(current_time) do
+        generator.attributes
+      end
     end
 
-    subject { described_class.generate }
+    context 'when there is no existing reference number for the same entity code' do
+      it 'returns hash with the relevant business entity' do
+        expect(subject[:business_entity]).to eql(business_entity)
+      end
 
-    it 'returns a random string with capital leters and numbers' do
-      is_expected.to eql('AB3C')
+      it 'returns hash with the new reference' do
+        expect(subject[:reference]).to eql('AB987-16-1')
+      end
+    end
+
+    context 'when there is an existing reference number for the same entity code' do
+      let!(:existing_application) { create :application, :processed_state, reference: 'AB987-16-19' }
+
+      it 'returns hash with the relevant business entity' do
+        expect(subject[:business_entity]).to eql(business_entity)
+      end
+
+      it 'returns hash with the reference next in sequence' do
+        expect(subject[:reference]).to eql('AB987-16-20')
+      end
     end
   end
 end

--- a/spec/services/reference_generator_spec.rb
+++ b/spec/services/reference_generator_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe ReferenceGenerator, type: :service do
+  describe '.generate' do
+    let(:random_string) { 'ab3c' }
+    before do
+      allow(SecureRandom).to receive(:hex).and_return(random_string)
+    end
+
+    subject { described_class.generate }
+
+    it 'returns a random string with capital leters and numbers' do
+      is_expected.to eql('AB3C')
+    end
+  end
+end

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -59,9 +59,11 @@ describe ResolverService do
     end
 
     context 'for Application' do
+      let(:reference) { 'ABC' }
       let(:object) { application }
 
       before do
+        allow(ReferenceGenerator).to receive(:generate).and_return(reference)
         allow(PartPaymentBuilder).to receive(:new).with(application, Fixnum).and_return(part_payment_builder)
       end
 
@@ -77,16 +79,28 @@ describe ResolverService do
         let(:evidence_check_decision) { true }
 
         include_examples 'application, evidence check or part payment completed', 'application', 'waiting_for_evidence', false
+
+        it 'generates and the reference number' do
+          expect(updated_application.reference).to eql(reference)
+        end
       end
 
       context 'when the application needs part payment' do
         let(:part_payment_decision) { true }
 
         include_examples 'application, evidence check or part payment completed', 'application', 'waiting_for_part_payment', false
+
+        it 'generates and the reference number' do
+          expect(updated_application.reference).to eql(reference)
+        end
       end
 
       context 'when the application has outcome and does not need evidence check or part payment' do
         include_examples 'application, evidence check or part payment completed', 'application', 'processed', true
+
+        it 'generates and the reference number' do
+          expect(updated_application.reference).to eql(reference)
+        end
       end
     end
 

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -60,10 +60,13 @@ describe ResolverService do
 
     context 'for Application' do
       let(:reference) { 'ABC' }
+      let(:business_entity) { create(:business_entity) }
+      let(:generator) { double(attributes: { reference: reference, business_entity: business_entity }) }
+
       let(:object) { application }
 
       before do
-        allow(ReferenceGenerator).to receive(:generate).and_return(reference)
+        allow(ReferenceGenerator).to receive(:new).and_return(generator)
         allow(PartPaymentBuilder).to receive(:new).with(application, Fixnum).and_return(part_payment_builder)
       end
 
@@ -80,8 +83,12 @@ describe ResolverService do
 
         include_examples 'application, evidence check or part payment completed', 'application', 'waiting_for_evidence', false
 
-        it 'generates and the reference number' do
+        it 'generates and stores the reference' do
           expect(updated_application.reference).to eql(reference)
+        end
+
+        it 'stores the business entity used to generate the reference' do
+          expect(updated_application.business_entity).to eql(business_entity)
         end
       end
 
@@ -90,16 +97,24 @@ describe ResolverService do
 
         include_examples 'application, evidence check or part payment completed', 'application', 'waiting_for_part_payment', false
 
-        it 'generates and the reference number' do
+        it 'generates and stores the reference' do
           expect(updated_application.reference).to eql(reference)
+        end
+
+        it 'stores the business entity used to generate the reference' do
+          expect(updated_application.business_entity).to eql(business_entity)
         end
       end
 
       context 'when the application has outcome and does not need evidence check or part payment' do
         include_examples 'application, evidence check or part payment completed', 'application', 'processed', true
 
-        it 'generates and the reference number' do
+        it 'generates and stores the reference' do
           expect(updated_application.reference).to eql(reference)
+        end
+
+        it 'stores the business entity used to generate the reference' do
+          expect(updated_application.business_entity).to eql(business_entity)
         end
       end
     end


### PR DESCRIPTION
This introduces `BusinessEntity` model which will be managed by HQ. `BusinessEntity` has to exist for each combination of `Office` and `Jurisdiction` in use. Editing of business entities will be added later.

A big change is that `reference` for `Application` is now only created on completion of application. Until then it's `NULL`. Because the prefix for the reference is now taken from the relevant `BusinessEntity`, reference to it is also stored to `Application`.
