### PR TITLE
Lock down invites for managers

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -38,6 +38,6 @@ class Users::InvitationsController < Devise::InvitationsController
   end
 
   def user_not_admin_and_role_is_admin?
-    current_inviter.role.eql?('manager') && invite_params['role'].eql?('admin')
+    !current_inviter.role.eql?('admin') && invite_params['role'].eql?('admin')
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -12,7 +12,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   def create
     if user_not_admin_and_role_is_admin?
-      raise 'Unpriviledged invitation error: Non-admin user is inviting an admin.'
+      raise 'Unprivileged invitation error: Non-admin user is inviting an admin.'
     else
       self.resource = invite_resource
       respond_with resource, location: after_invite_path_for(resource)

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -12,7 +12,7 @@ class Users::InvitationsController < Devise::InvitationsController
 
   def create
     if user_not_admin_and_role_is_admin?
-      raise 'Foo'
+      raise 'Unpriviledged invitation error: Non-admin user is inviting an admin.'
     else
       self.resource = invite_resource
       respond_with resource, location: after_invite_path_for(resource)

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -10,6 +10,15 @@ class Users::InvitationsController < Devise::InvitationsController
     render :new
   end
 
+  def create
+    if user_not_admin_and_role_is_admin?
+      raise 'Foo'
+    else
+      self.resource = invite_resource
+      respond_with resource, location: after_invite_path_for(resource)
+    end
+  end
+
   private
 
   def build_role_list
@@ -26,5 +35,9 @@ class Users::InvitationsController < Devise::InvitationsController
 
   def invite_params
     params.require(:user).permit(:email, :role, :name, :office_id)
+  end
+
+  def user_not_admin_and_role_is_admin?
+    current_inviter.role.eql?('manager') && invite_params['role'].eql?('admin')
   end
 end

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Users::InvitationsController, type: :controller do
       it 'does not allow you to invite admins as a manager' do
         expect {
           post :create, user: admin_invitation
-        }.to raise_error 'Unpriviledged invitation error: Non-admin user is inviting an admin.'
+        }.to raise_error 'Unprivileged invitation error: Non-admin user is inviting an admin.'
       end
     end
 

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Users::InvitationsController, type: :controller do
 
   let(:invited_user) { User.where(email: user.email).first }
 
-  before { @request.env["devise.mapping"] = Devise.mappings[:user] }
+  before { request.env["devise.mapping"] = Devise.mappings[:user] }
 
   context 'Manager user' do
     describe 'POST #create' do

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -1,0 +1,53 @@
+# coding: utf-8
+require 'rails_helper'
+
+RSpec.describe Users::InvitationsController, type: :controller do
+
+  include Devise::TestHelpers
+
+  let(:manager_user) { create :manager }
+  let(:user) { build :user }
+
+  context 'Manager user' do
+    describe 'POST #create' do
+      before do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+        sign_in manager_user
+      end
+
+      let(:invitation) do
+        {
+          name: user.name,
+          email: user.email,
+          role: 'manager',
+          office_id: '1'
+        }
+      end
+
+      let(:admin_invitation) do
+        {
+          name: user.name,
+          email: user.email,
+          role: 'admin',
+          office_id: '1'
+        }
+      end
+
+      let(:invited_user) { User.where(email: user.email).first }
+
+      it 'does allow you to invite managers as a manager' do
+        post :create, user: invitation
+
+        expect(invited_user['email']).to eq user.email
+        expect(invited_user['invited_by_id']).to eq manager_user.id
+      end
+
+      it 'does not allow you to invite admins as a manager' do
+        expect {
+          post :create, user: admin_invitation
+        }.to raise_error
+      end
+
+    end
+  end
+end

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Users::InvitationsController, type: :controller do
       it 'does not allow you to invite admins as a manager' do
         expect {
           post :create, user: admin_invitation
-        }.to raise_error
+        }.to raise_error 'Unpriviledged invitation error: Non-admin user is inviting an admin.'
       end
     end
 


### PR DESCRIPTION
This PR fixes this privilege escalation issue: https://www.pivotaltracker.com/story/show/102069424

Don't allow the managers to invite admins.

In fact this was not allowed, but the PR prevents even the malicious attempts at privileged invitation attempt.

I'm aware that some of the controller tests can be interpreted as feature tests, but since this is a security related, I'm happy to violate test purity for the sake of security.