### PR TITLE
Add more decision columns

### DIFF
--- a/app/services/resolver_cost_calculator.rb
+++ b/app/services/resolver_cost_calculator.rb
@@ -1,35 +1,32 @@
 class ResolverCostCalculator
   def initialize(source)
     @source = source
+    @application = @source.is_a?(Application) ? @source : @source.application
   end
 
   def cost
-    @source.outcome == 'none' ? 0 : incurred_cost(@source)
+    @source.outcome == 'none' ? 0 : incurred_cost
   end
 
   private
 
-  def incurred_cost(source)
-    if source.is_a?(PartPayment)
-      if source.application.evidence_check.present?
-        fee(source) - amount_to_pay(source.application.evidence_check)
-      else
-        fee(source) - amount_to_pay(source.application)
-      end
+  def incurred_cost
+    if @source.is_a?(PartPayment)
+      fee - amount_to_pay
     else
-      fee(source)
+      fee
     end
   end
 
-  def fee(source)
-    if source.is_a?(Application)
-      source.detail.fee
-    else
-      source.application.detail.fee
-    end
+  def fee
+    @application.detail.fee
   end
 
-  def amount_to_pay(source)
-    source.try(:amount_to_pay) || 0
+  def amount_to_pay
+    if @application.evidence_check.present?
+      @application.evidence_check.try(:amount_to_pay) || 0
+    else
+      @application.try(:amount_to_pay) || 0
+    end
   end
 end

--- a/app/services/resolver_cost_calculator.rb
+++ b/app/services/resolver_cost_calculator.rb
@@ -1,0 +1,35 @@
+class ResolverCostCalculator
+  def initialize(source)
+    @source = source
+  end
+
+  def cost
+    @source.outcome == 'none' ? 0 : incurred_cost(@source)
+  end
+
+  private
+
+  def incurred_cost(source)
+    if source.is_a?(PartPayment)
+      if source.application.evidence_check.present?
+        fee(source) - amount_to_pay(source.application.evidence_check)
+      else
+        fee(source) - amount_to_pay(source.application)
+      end
+    else
+      fee(source)
+    end
+  end
+
+  def fee(source)
+    if source.is_a?(Application)
+      source.detail.fee
+    else
+      source.application.detail.fee
+    end
+  end
+
+  def amount_to_pay(source)
+    source.try(:amount_to_pay) || 0
+  end
+end

--- a/app/services/resolver_service.rb
+++ b/app/services/resolver_service.rb
@@ -48,7 +48,7 @@ class ResolverService
       decision: lookup_decision(source.outcome),
       decision_type: derive_object(source),
       decision_date: @time,
-      decision_cost: calculate_cost(source),
+      decision_cost: ResolverCostCalculator.new(source).cost,
       state: :processed
     }
   end
@@ -115,33 +115,5 @@ class ResolverService
 
   def decide_evidence_check(application)
     EvidenceCheckSelector.new(application, Settings.evidence_check.expires_in_days).decide!
-  end
-
-  def calculate_cost(source)
-    source.outcome == 'none' ? 0 : incurred_cost(source)
-  end
-
-  def incurred_cost(source)
-    if source.is_a?(PartPayment)
-      if source.application.evidence_check.present?
-        fee(source) - amount_to_pay(source.application.evidence_check)
-      else
-        fee(source) - amount_to_pay(source.application)
-      end
-    else
-      fee(source)
-    end
-  end
-
-  def fee(source)
-    if source.is_a?(Application)
-      source.detail.fee
-    else
-      source.application.detail.fee
-    end
-  end
-
-  def amount_to_pay(source)
-    source.try(:amount_to_pay) || 0
   end
 end

--- a/app/services/resolver_service.rb
+++ b/app/services/resolver_service.rb
@@ -5,6 +5,7 @@ class ResolverService
   def initialize(object, user)
     @calling_object = object
     @user = user
+    @time = Time.zone.now
   end
 
   def complete
@@ -32,7 +33,7 @@ class ResolverService
 
   def completed_attributes
     {
-      completed_at: Time.zone.now,
+      completed_at: @time,
       completed_by: @user
     }
   end
@@ -46,6 +47,8 @@ class ResolverService
     {
       decision: lookup_decision(source.outcome),
       decision_type: derive_object(source),
+      decision_date: @time,
+      decision_cost: calculate_cost(source),
       state: :processed
     }
   end
@@ -112,5 +115,33 @@ class ResolverService
 
   def decide_evidence_check(application)
     EvidenceCheckSelector.new(application, Settings.evidence_check.expires_in_days).decide!
+  end
+
+  def calculate_cost(source)
+    source.outcome == 'none' ? 0 : incurred_cost(source)
+  end
+
+  def incurred_cost(source)
+    if source.is_a?(PartPayment)
+      if source.application.evidence_check.present?
+        fee(source) - amount_to_pay(source.application.evidence_check)
+      else
+        fee(source) - amount_to_pay(source.application)
+      end
+    else
+      fee(source)
+    end
+  end
+
+  def fee(source)
+    if source.is_a?(Application)
+      source.detail.fee
+    else
+      source.application.detail.fee
+    end
+  end
+
+  def amount_to_pay(source)
+    source.try(:amount_to_pay) || 0
   end
 end

--- a/db/migrate/20151215144022_migrate_decision_to_application.rb
+++ b/db/migrate/20151215144022_migrate_decision_to_application.rb
@@ -1,0 +1,8 @@
+class MigrateDecisionToApplication < ActiveRecord::Migration
+  def up
+    DecisionMigration.new.run!
+  end
+
+  def down
+  end
+end

--- a/db/migrate/20151215154501_add_decision_date_and_decision_cost_to_application.rb
+++ b/db/migrate/20151215154501_add_decision_date_and_decision_cost_to_application.rb
@@ -1,0 +1,14 @@
+class AddDecisionDateAndDecisionCostToApplication < ActiveRecord::Migration
+  def change
+    change_table :applications do |t|
+      t.datetime :decision_date, null: true, index: true
+      t.decimal :decision_cost, null: true
+    end
+
+    reversible do |dir|
+      dir.up do
+        DecisionDateAndCostMigration.new.run!
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151214170243) do
+ActiveRecord::Schema.define(version: 20151215144022) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151215144022) do
+ActiveRecord::Schema.define(version: 20151215154501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,8 @@ ActiveRecord::Schema.define(version: 20151215144022) do
     t.datetime "deleted_at"
     t.integer  "deleted_by_id"
     t.integer  "business_entity_id"
+    t.datetime "decision_date"
+    t.decimal  "decision_cost"
   end
 
   add_index "applications", ["business_entity_id"], name: "index_applications_on_business_entity_id", using: :btree

--- a/lib/decision_date_and_cost_migration.rb
+++ b/lib/decision_date_and_cost_migration.rb
@@ -1,0 +1,97 @@
+class DecisionDateAndCostMigration
+  def run! # rubocop:disable AbcSize
+    # the order of these migration sqls is important
+    ActiveRecord::Base.connection.execute(decision_date_part_payment)
+    ActiveRecord::Base.connection.execute(decision_date_evidence_check)
+    ActiveRecord::Base.connection.execute(decision_date_application)
+
+    ActiveRecord::Base.connection.execute(decision_cost_none)
+    ActiveRecord::Base.connection.execute(decision_cost_full)
+    ActiveRecord::Base.connection.execute(decision_cost_part_evidence_check)
+    ActiveRecord::Base.connection.execute(decision_cost_part_application)
+  end
+
+  private
+
+  def decision_date_part_payment
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision_date = part_payments.completed_at
+      |FROM part_payments
+      |WHERE
+      |  part_payments.application_id = applications.id AND
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision_type LIKE 'part_payment'
+    SQL
+  end
+
+  def decision_date_evidence_check
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision_date = evidence_checks.completed_at
+      |FROM evidence_checks
+      |WHERE
+      |  evidence_checks.application_id = applications.id AND
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision_type LIKE 'evidence_check'
+    SQL
+  end
+
+  def decision_date_application
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision_date = completed_at
+      |WHERE
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision_type LIKE 'application'
+    SQL
+  end
+
+  def decision_cost_none
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision_cost = 0
+      |WHERE
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision LIKE 'none'
+    SQL
+  end
+
+  def decision_cost_full
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision_cost = details.fee
+      |FROM details
+      |WHERE
+      |  details.application_id = applications.id AND
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision LIKE 'full'
+    SQL
+  end
+
+  def decision_cost_part_evidence_check
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision_cost = (details.fee - evidence_checks.amount_to_pay)
+      |FROM details, evidence_checks
+      |WHERE
+      |  details.application_id = applications.id AND
+      |  evidence_checks.application_id = applications.id AND
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision LIKE 'part'
+    SQL
+  end
+
+  def decision_cost_part_application
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision_cost = (details.fee - amount_to_pay)
+      |FROM details
+      |WHERE
+      |  details.application_id = applications.id AND
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision LIKE 'part' AND
+      |  applications.decision_cost IS NULL
+    SQL
+  end
+end

--- a/lib/decision_migration.rb
+++ b/lib/decision_migration.rb
@@ -1,0 +1,50 @@
+# rubocop:disable MethodLength
+class DecisionMigration
+  def run!
+    # these queries have to run in this exact order
+    ActiveRecord::Base.connection.execute(part_payment_sql)
+    ActiveRecord::Base.connection.execute(evidence_check_sql)
+    ActiveRecord::Base.connection.execute(application_sql)
+  end
+
+  private
+
+  def part_payment_sql
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision    = REPLACE(part_payments.outcome, 'return', 'none'),
+      |  decision_type = 'part_payment'
+      |FROM part_payments
+      |WHERE
+      |  part_payments.application_id = applications.id AND
+      |  part_payments.completed_at IS NOT NULL AND
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision IS NULL
+    SQL
+  end
+
+  def evidence_check_sql
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision    = REPLACE(evidence_checks.outcome, 'return', 'none'),
+      |  decision_type = 'evidence_check'
+      |FROM evidence_checks
+      |WHERE
+      |  evidence_checks.application_id = applications.id AND
+      |  evidence_checks.completed_at IS NOT NULL AND
+      |  applications.state = #{Application.states[:processed]} AND
+      |  applications.decision IS NULL
+    SQL
+  end
+
+  def application_sql
+    <<-SQL.gsub(/^\s+\|/, '')
+      |UPDATE applications
+      |SET decision    = outcome,
+      |  decision_type = 'application'
+      |WHERE
+      |  state = 3 AND
+      |  decision IS NULL
+    SQL
+  end
+end

--- a/spec/factories/part_payments.rb
+++ b/spec/factories/part_payments.rb
@@ -7,6 +7,10 @@ FactoryGirl.define do
       outcome 'part'
     end
 
+    factory :part_payment_none_outcome do
+      outcome 'none'
+    end
+
     trait :completed do
       completed_at Time.zone.yesterday
       association :completed_by, factory: :user

--- a/spec/lib/decision_date_and_cost_migration_spec.rb
+++ b/spec/lib/decision_date_and_cost_migration_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe DecisionDateAndCostMigration do
+  subject(:migration) { described_class.new }
+
+  let!(:application1) do
+    create(:application_full_remission, :processed_state, fee: 500, decision: 'full', decision_date: nil, decision_cost: nil)
+  end
+
+  let!(:application2) do
+    create(:application_part_remission, :processed_state, decision_type: 'part_payment', fee: 500, amount_to_pay: 100, decision: 'part', decision_date: nil, decision_cost: nil) do |a|
+      create(:part_payment_part_outcome, :completed, application: a)
+    end
+  end
+
+  let!(:application3) do
+    create(:application_part_remission, :processed_state, decision_type: 'part_payment', fee: 500, amount_to_pay: 100, decision: 'part', decision_date: nil, decision_cost: nil) do |a|
+      create(:evidence_check_part_outcome, :completed, amount_to_pay: 150, application: a)
+      create(:part_payment_part_outcome, :completed, application: a)
+    end
+  end
+
+  let!(:application4) do
+    create(:application_full_remission, :processed_state, decision_type: 'evidence_check', fee: 500, decision: 'full', decision_date: nil, decision_cost: nil) do |a|
+      create(:evidence_check_full_outcome, :completed, application: a)
+    end
+  end
+
+  let!(:application5) do
+    create(:application_no_remission, :processed_state, fee: 500, decision: 'none', decision_date: nil, decision_cost: nil)
+  end
+
+  describe '#run!' do
+    before do
+      migration.run!
+    end
+
+    it 'sets the correct decision_date and decision_cost' do
+      # for processed application without evidence check or part payment
+      application1.reload
+      expect(application1.decision_date).to eql(application1.completed_at)
+      expect(application1.decision_cost).to eq(500)
+
+      # for processed application without evidence check but with part payment
+      application2.reload
+      expect(application2.decision_date).to eql(application2.part_payment.completed_at)
+      expect(application2.decision_cost).to eql(400)
+
+      # for processed application with evidence check but with part payment
+      application3.reload
+      expect(application3.decision_date).to eql(application3.part_payment.completed_at)
+      expect(application3.decision_cost).to eql(350)
+
+      # for processed application with evidence check but without part payment
+      application4.reload
+      expect(application4.decision_date).to eql(application4.evidence_check.completed_at)
+      expect(application4.decision_cost).to eql(500)
+
+      # for no remission application
+      application5.reload
+      expect(application5.decision_date).to eql(application5.completed_at)
+      expect(application5.decision_cost).to eql(0)
+    end
+  end
+end

--- a/spec/lib/decision_migration_spec.rb
+++ b/spec/lib/decision_migration_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe DecisionMigration do
+
+  subject(:migration) { described_class.new }
+
+  let!(:application1) do
+    create(:application_full_remission, state: :processed, decision: nil, decision_type: nil).tap do |a|
+      create(:evidence_check_part_outcome, :completed, application: a)
+    end
+  end
+
+  let!(:application2) do
+    create(:application_full_remission, state: :processed, decision: nil, decision_type: nil).tap do |a|
+      create(:evidence_check_part_outcome, :completed, outcome: 'return', application: a)
+    end
+  end
+
+  let!(:application3) do
+    create(:application_full_remission, state: :waiting_for_evidence, decision: nil, decision_type: nil).tap do |a|
+      create(:evidence_check_part_outcome, application: a)
+    end
+  end
+
+  let!(:application4) do
+    create(:application_part_remission, state: :processed, decision: nil, decision_type: nil).tap do |a|
+      create(:part_payment_part_outcome, :completed, application: a)
+    end
+  end
+
+  let!(:application5) do
+    create(:application_part_remission, state: :processed, decision: nil, decision_type: nil).tap do |a|
+      create(:part_payment_part_outcome, :completed, outcome: 'return', application: a)
+    end
+  end
+
+  let!(:application6) do
+    create(:application_part_remission, state: :waiting_for_part_payment, decision: nil, decision_type: nil).tap do |a|
+      create(:part_payment_part_outcome, application: a)
+    end
+  end
+
+  let!(:application7) do
+    create(:application_full_remission, state: :processed, decision: nil, decision_type: nil)
+  end
+
+  describe '#run!' do
+    before do
+      migration.run!
+    end
+
+    it 'sets decision and decision_type for processed applications when missing' do
+      # application with a completed evidence check takes its outcome as decision
+      application1.reload
+      expect(application1.decision).to eql('part')
+      expect(application1.decision_type).to eql('evidence_check')
+
+      # application with a completed evidence check as return marks decision as none
+      application2.reload
+      expect(application2.decision).to eql('none')
+      expect(application2.decision_type).to eql('evidence_check')
+
+      # application with a uncompleted evidence check does not set decision
+      application3.reload
+      expect(application3.decision).to be nil
+      expect(application3.decision_type).to be nil
+
+      # application with a completed part payment takes its outcome as decision
+      application4.reload
+      expect(application4.decision).to eql('part')
+      expect(application4.decision_type).to eql('part_payment')
+
+      # application with a completed part payment as return marks decision as none
+      application5.reload
+      expect(application5.decision).to eql('none')
+      expect(application5.decision_type).to eql('part_payment')
+
+      # application with a uncompleted part payment does not set decision
+      application6.reload
+      expect(application6.decision).to be nil
+      expect(application6.decision_type).to be nil
+
+      # completed application
+      application7.reload
+      expect(application7.decision).to eql('full')
+      expect(application7.decision_type).to eql('application')
+    end
+  end
+end

--- a/spec/services/resolver_cost_calculator_spec.rb
+++ b/spec/services/resolver_cost_calculator_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe ResolverCostCalculator, type: :service do
+  subject(:calculator) { described_class.new(source) }
+
+  describe '#cost' do
+    let(:detail) { build_stubbed(:detail, fee: 950) }
+    let(:application) { build_stubbed(:application_full_remission, detail: detail) }
+
+    subject { calculator.cost }
+
+    context 'for Application' do
+      let(:source) { application }
+
+      context 'for none outcome' do
+        let(:application) { build_stubbed(:application_no_remission) }
+
+        it { is_expected.to eql(0) }
+      end
+
+      context 'for full outcome' do
+        it 'equals the full fee' do
+          is_expected.to eql(950)
+        end
+      end
+    end
+
+    context 'for EvidenceCheck' do
+      let(:source) { evidence_check }
+
+      context 'for none outcome' do
+        let(:evidence_check) { build_stubbed(:evidence_check_incorrect) }
+
+        it { is_expected.to eql(0) }
+      end
+
+      context 'for full outcome' do
+        let(:evidence_check) { build_stubbed(:evidence_check_full_outcome, application: application) }
+
+        it 'equals the full fee' do
+          is_expected.to eql(950)
+        end
+      end
+    end
+
+    context 'for PartPayment' do
+      let(:source) { part_payment }
+
+      context 'for none outcome' do
+        let(:part_payment) { build_stubbed(:part_payment_none_outcome, application: application) }
+
+        it { is_expected.to eql(0) }
+      end
+
+      context 'for part outcome' do
+        let(:application) { build_stubbed(:application_full_remission, detail: detail, amount_to_pay: 100) }
+        let(:part_payment) { build_stubbed(:part_payment_part_outcome, application: application) }
+
+        context 'when the application was also evidence checked' do
+          before do
+            build_stubbed(:evidence_check_part_outcome, application: application, amount_to_pay: 300)
+          end
+
+          it 'equals fee minus the amount the applicant has to pay' do
+            is_expected.to eql(650)
+          end
+        end
+
+        context 'when the application was not evidence checked' do
+          it 'equals fee minus the amount the applicant has to pay' do
+            is_expected.to eql(850)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `decision_date` and `decision_cost` to `Application`. The main purpose is to be able to easily access the summary of decided application. After this we may consider taking all the `decision_` columns to a separate table, which then can be used for various stats (like finance).

It also migrates all existing processed applications to have all the decision columns filled in (including `decision` and `decision_type`. 