### PR TITLE
Reference number display update

### DIFF
--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -3,16 +3,23 @@ header
     .small-12.medium-12.large-12.columns
       h2 Processing complete
 
-= display_reference(@application)
-
 .row
   .small-12.medium-8.large-5.columns
+    - if after_desired_date?
+      .row
+        .small-12.columns
+          h4 Reference
+          .row.collapse.medium-10.large-8
+            #result.callout.evidence-check-reference
+              h3.bold = display_reference(@application)
+
     = build_section 'Results', @confirm, @confirm.all_fields
     .row
       .small-12.columns
         .row.collapse.medium-10.large-8
           #result.callout class="callout-#{@confirm.result}"
             h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
+
     .row.collapse.medium-10.large-8
       = link_to 'Back to start', root_path, class: 'button primary'
 
@@ -21,7 +28,8 @@ header
       h4 Next steps
       ul
         -if @application.outcome.eql?('full')
-          li Complete the remission register with the application details
+          -unless after_desired_date?
+            li Complete the remission register with the application details
           li Write the reference number on the top right corner of the paper form
           li Copy the reference number into the case management system
           li The applicant’s process can now be issued

--- a/app/views/evidence/confirmation.html.slim
+++ b/app/views/evidence/confirmation.html.slim
@@ -15,7 +15,8 @@ header
       h4 Next steps
       ul
         -if @confirmation.outcome == 'full'
-          li Complete the remission register with the application details
+          - unless after_desired_date?
+            li Complete the remission register with the application details
           li Write the reference number on the top right corner of the paper form
           li Copy the reference number into the case management system
           li The applicant’s process can now be issued
@@ -25,7 +26,8 @@ header
           li You don't need to complete the remission register until part-payment has been received 
           li Write the reference number on the top right corner of the paper form
         -else
-          li Complete the remission register with the application details
+          - unless after_desired_date? 
+            li Complete the remission register with the application details
           li Write the reference number on the top right corner of the paper form
           li Copy the reference number into the case management system
           li Write to the applicant and send back all the documents

--- a/app/views/part_payments/confirmation.html.slim
+++ b/app/views/part_payments/confirmation.html.slim
@@ -14,10 +14,12 @@ header
       h4 Next steps      
       ul
         -if @result.callout == 'yes'
-          li complete the remission register with the application details
+          - unless after_desired_date?
+            li complete the remission register with the application details
           li copy reference into the case management system
         - else
-          li complete the remission register with the application details
+          - unless after_desired_date?
+            li complete the remission register with the application details
           li write to applicant using the template provided
           li add the reference to the letter
           li post the letter and all the documents back to the applicant

--- a/spec/features/applications/remission_confirmation_spec.rb
+++ b/spec/features/applications/remission_confirmation_spec.rb
@@ -46,8 +46,7 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
     context 'who has full remission' do
       let(:application) { create(:application_full_remission) }
       let(:full_remission_copy) do
-        ['Complete the remission register with the application details',
-         'Write the reference number on the top right corner of the paper form',
+        ['Write the reference number on the top right corner of the paper form',
          'Copy the reference number into the case management system',
          'The applicant’s process can now be issued']
       end
@@ -68,8 +67,7 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
     context 'who has no remission' do
       let(:application) { create(:application_no_remission) }
       let(:no_remission_copy) do
-        ['Complete the remission register with the application details',
-         'Write the reference number on the top right corner of the paper form',
+        ['Write the reference number on the top right corner of the paper form',
          'Copy the reference number into the case management system',
          'Write to the applicant and send back all the documents']
       end

--- a/spec/features/applications/temporary_reference_number_spec.rb
+++ b/spec/features/applications/temporary_reference_number_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Reference number is displayed', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let(:user) { create :user, office: create(:office) }
+  let(:application) { create(:application, :confirm, reference: 'AB123-14-0001') }
+
+  context 'before the set reference_date is reached' do
+    context 'as a signed in user', js: true do
+      before do
+        Capybara.current_driver = :webkit
+        dwp_api_response 'Yes'
+        login_as user
+      end
+
+      after { Capybara.use_default_driver }
+
+      context 'after user continues from summary' do
+        before do
+          Timecop.freeze(Date.new(2016, 4, 1)) {
+            visit application_confirmation_path(application_id: application.id)
+          }
+        end
+
+        scenario 'the reference number is not displayed' do
+          expect(page).to have_no_content application.reference
+        end
+
+        scenario 'the remission register right hand guidance is shown' do
+          expect(page).to have_content 'remission register'
+        end
+      end
+    end
+  end
+
+  context 'when the reference_date is passed' do
+    context 'as a signed in user', js: true do
+      before do
+        Capybara.current_driver = :webkit
+        dwp_api_response 'Yes'
+        login_as user
+      end
+
+      after { Capybara.use_default_driver }
+
+      context 'after user continues from summary' do
+        before do
+          Timecop.freeze(Date.new(2016, 8, 1)) {
+            visit application_confirmation_path(application_id: application.id)
+          }
+        end
+
+        scenario 'the reference number is not displayed' do
+          expect(page).to have_content application.reference
+        end
+
+        scenario 'the remission register right hand guidance is not shown' do
+          expect(page).to have_no_content 'remission register'
+        end
+      end
+    end
+  end
+end

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -204,6 +204,32 @@ RSpec.feature 'Evidence check flow', type: :feature do
 
     it { expect(page).to have_content 'Processing complete' }
 
+    context 'before the set reference_date is reached' do
+      let(:outcome) { 'full' }
+      before do
+        Timecop.freeze(Date.new(2016, 4, 1)) {
+          visit evidence_confirmation_path(id: evidence.id)
+        }
+      end
+
+      scenario 'the remission register right hand guidance is shown' do
+        expect(page).to have_content 'remission register'
+      end
+    end
+
+    context 'when the reference_date is passed' do
+      let(:outcome) { 'full' }
+      before do
+        Timecop.freeze(Date.new(2016, 8, 1)) {
+          visit evidence_confirmation_path(id: evidence.id)
+        }
+      end
+
+      scenario 'the remission register right hand guidance is not shown' do
+        expect(page).to have_no_content 'remission register'
+      end
+    end
+
     context 'when the remission is' do
       context 'full' do
         let(:outcome) { 'full' }

--- a/spec/features/part_payments/part_payments_flow_spec.rb
+++ b/spec/features/part_payments/part_payments_flow_spec.rb
@@ -94,6 +94,33 @@ RSpec.feature 'Part Payments flow', type: :feature do
           expect(page).to have_content 'We have received your part-payment however we are unable to accept it.'
         end
       end
+
+      context 'when on part_payment confirmation" page' do
+        context 'before the set reference_date is reached' do
+          before do
+            Timecop.freeze(Date.new(2016, 4, 1)) {
+              visit confirmation_part_payment_path(id: part_payment.id)
+            }
+          end
+
+          scenario 'the remission register right hand guidance is shown' do
+            expect(page).to have_content 'remission register'
+          end
+        end
+
+        context 'when the reference_date is passed' do
+          let(:outcome) { 'full' }
+          before do
+            Timecop.freeze(Date.new(2016, 8, 1)) {
+              visit confirmation_part_payment_path(id: part_payment.id)
+            }
+          end
+
+          scenario 'the remission register right hand guidance is not shown' do
+            expect(page).to have_no_content 'remission register'
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* Added tests for hiding remission register text and showing reference number
* Updated optional display/style of confirmation block
* only display the right hand guidance on remission register for 
evidence_check and part_payments when the reference date has passed
* styled the reference number display when completing an application form