### PR TITLE
Fix for married applicant savings validation

### DIFF
--- a/app/views/applications/process/savings_investments.html.slim
+++ b/app/views/applications/process/savings_investments.html.slim
@@ -17,6 +17,7 @@
           .columns.small-12
             = f.label :threshold_exceeded, t(@application.married ? 'married' : 'single', scope: @form.i18n_scope)
             = f.label :threshold_exceeded, @form.errors[:threshold_exceeded].join(', '), class: 'error' if @form.errors[:threshold_exceeded].present?
+            = f.hidden_field :threshold_exceeded, value: nil
             .options.radio
               .option
                 label for='application_threshold_exceeded_false'

--- a/spec/features/applications/application_savings_and_investments_spec.rb
+++ b/spec/features/applications/application_savings_and_investments_spec.rb
@@ -78,5 +78,28 @@ RSpec.feature 'Application for savings and investments bug', type: :feature do
         end
       end
     end
+
+    context 'the applicant is married', js: true do
+      before do
+        start_new_application
+
+        fill_in 'application_last_name', with: 'Smith'
+        fill_in 'application_date_of_birth', with: Time.zone.today - 25.years
+        choose 'application_married_true'
+        click_button 'Next'
+        fill_in 'application_fee', with: '300'
+        find(:xpath, '(//input[starts-with(@id,"application_jurisdiction_id_")])[1]').click
+        fill_in 'application_date_received', with: Time.zone.today - 3.days
+        click_button 'Next'
+      end
+
+      context 'when the savings investment Next button is clicked' do
+        before { click_button 'Next' }
+
+        scenario 'the error message is displayed' do
+          expect(page).to have_content 'You must answer the savings question'
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When a user processes a married applicants form and submitted
the savings and investment view without answering the first
question, a 500 error was raised.

This improves the logic to invalidate the object and render
the validation message on the view.

[finishes #110493440]