### PR TITLE
Hide office BE Codes from managers

### DIFF
--- a/app/views/offices/_form.html.slim
+++ b/app/views/offices/_form.html.slim
@@ -9,8 +9,11 @@
         .columns.small-12.medium-8.large-5
           = f.label :name, t('functions.offices.label_name')
           = f.text_field :name, { class: 'form-control' }
-          = f.label :entity_code
-          = f.text_field :entity_code, { class: 'form-control' }
+      -if current_user.admin?
+        .row
+          .columns.small-12.medium-8.large-5
+            = f.label :entity_code
+            = f.text_field :entity_code, { class: 'form-control' }
 
   .row
     .small-12.large-6.columns.form-group

--- a/spec/views/offices/edit.html.slim_spec.rb
+++ b/spec/views/offices/edit.html.slim_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe 'offices/edit', type: :view do
     it 'does not render a link to the list' do
       expect(rendered).not_to have_xpath("//a[@href='#{offices_path}']")
     end
+
+    it 'does not show the business entity code input for the office' do
+      expect(rendered).not_to have_xpath('//input[@name="office[entity_code]"]')
+    end
+
+    it 'does not show the business entity code label for the office' do
+      expect(rendered).not_to have_content('Entity code')
+    end
   end
 
   context 'as an admin' do
@@ -46,6 +54,14 @@ RSpec.describe 'offices/edit', type: :view do
 
     it 'renders a link to the list' do
       expect(rendered).to have_xpath("//a[@href='#{offices_path}']")
+    end
+
+    it 'renders the business entity code input for the office' do
+      expect(rendered).to have_xpath('//input[@name="office[entity_code]"]')
+    end
+
+    it 'renders the business entity code label for the office' do
+      expect(rendered).to have_content('Entity code')
     end
   end
 end

--- a/spec/views/offices/new.html.slim_spec.rb
+++ b/spec/views/offices/new.html.slim_spec.rb
@@ -2,11 +2,14 @@ require 'rails_helper'
 
 RSpec.describe 'offices/new', type: :view do
 
+  include Devise::TestHelpers
+
   before(:each) { assign(:office, Office.new) }
   let(:jurisdictions) { assign(:jurisdictions, create_list(:jurisdiction, 4)) }
+  let(:manager)       { create(:manager) }
 
   it 'renders new office form' do
-
+    sign_in manager
     jurisdictions
     render
 


### PR DESCRIPTION
When editing an office, managers should not see the office entity code
or be able to edit it.

Updated the tests for new office to match

[finishes #110499670]

[Ticket](https://www.pivotaltracker.com/story/show/110499670)