### PR TITLE
Rake task to execute a local sql file

### DIFF
--- a/lib/tasks/run_sql.rake
+++ b/lib/tasks/run_sql.rake
@@ -1,0 +1,22 @@
+namespace :run_sql do
+  desc 'Execute local file, save your file with a .sql extension'
+  task :from_file, [:file] => :environment do |_t, args|
+    abort('Please submit filename') unless args[:file]
+    abort('Please submit a .sql filename') unless args[:file].ends_with?('.sql')
+    filename = args[:file].gsub('~', ENV['HOME'])
+    puts "Reading #{filename}"
+    instructions = File.read(filename)
+    commands = instructions.split(';')
+    command_count = commands.count
+    ActiveRecord::Base.transaction do
+      commands.each_with_index do |command, i|
+        begin
+          ActiveRecord::Base.connection.execute(command)
+          puts "Executed command #{i + 1} of #{command_count}"
+        rescue
+          abort("Executing command #{i + 1} of #{command_count} failed: Transaction rolled-back")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will allow users to scp a file to the sever and execute it without having to launch sql.
It replaces a ~/ with ENV['HOME'] so the file can be referenced without the absolute path.
The task is designed to abort gracefully if the file is missing, or not suffixed as .sql
It runs as a transaction so that, if an individual command fails, none will be committed. 

Usage:
rake run_sql:from_file[~/path/filename.sql]
 