### PR TITLE
Updated Nokogiri to 1.6.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :development do
   gem 'rack-livereload'
 end
 
-gem 'nokogiri', '~> 1.6.7.rc4'
+gem 'nokogiri', '~> 1.6.7.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     multipart-post (2.0.0)
     nenv (0.2.0)
     netrc (0.11.0)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     notiffany (0.0.8)
       nenv (~> 0.1)
@@ -422,7 +422,7 @@ DEPENDENCIES
   jquery-turbolinks
   launchy
   logstasher!
-  nokogiri (~> 1.6.7.rc4)
+  nokogiri (~> 1.6.7.1)
   paranoia (~> 2.0)
   pg
   pry-rails


### PR DESCRIPTION
Updated Nokogiri to the latest stable version due to the security
vulnerability issue:

* https://groups.google.com/forum/#!topic/ruby-security-ann/aSbgDiwb24s
* https://github.com/sparklemotion/nokogiri/pull/1378