### PR TITLE
use cookie to autofill username

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,8 @@
 //= require applicants_partner_over_61
 //= require evidence_confirmation
 //= require guide
+//= require cookies
+//= require login
 
 $(function(){
   Foundation.global.namespace = '';

--- a/app/assets/javascripts/cookies.js
+++ b/app/assets/javascripts/cookies.js
@@ -1,0 +1,47 @@
+var FR = FR || {};
+
+FR.Cookies = {
+  set: function (name, value, options){
+    if (typeof options === 'undefined') {
+      options = {};
+    }
+    var cookieString = name + '=' + value + '; path=/',
+        date;
+    if (options.days) {
+      date = new Date();
+      date.setTime(date.getTime() + (options.days * 24 * 60 * 60 * 1000));
+      cookieString = cookieString + '; expires=' + date.toGMTString();
+    }
+    if (document.location.protocol === 'https:') {
+      cookieString = cookieString + '; Secure';
+    }
+    document.cookie = cookieString;
+  },
+
+  get: function (name){
+    var nameEQ = name + '=',
+        cookies = document.cookie.split(';'),
+        i, len, cookie;
+    // moj.log(cookies);
+    for (i = 0, len = cookies.length; i < len;) {
+      cookie = cookies[i];
+      while (cookie.charAt(0) === ' ') {
+        cookie = cookie.substring(1, cookie.length);
+      }
+      if (cookie.indexOf(nameEQ) === 0) {
+        return decodeURIComponent(cookie.substring(nameEQ.length));
+      }
+      i += 1;
+    }
+    return null;
+  },
+
+  remove: function (name){
+    if (FR.Cookies.get(name) === undefined) {
+      return false;
+    }
+
+    FR.Cookies.set(name, '', { days: -1 });
+    return !FR.Cookies.get(name);
+  }
+};

--- a/app/assets/javascripts/guide.js
+++ b/app/assets/javascripts/guide.js
@@ -1,4 +1,4 @@
-var FR = {};
+var FR = FR || {};
 
 FR.equalHeightBoxes = function(wrapper, panel) {
   var panels = $(wrapper).find(panel);

--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -1,0 +1,31 @@
+var FR = FR || {};
+
+FR.login = {
+  init: function() {
+    var self = this,
+        $form = $('form.new_user');
+
+    if ($form.length) {
+      self.checkLoginCookie();
+      self.writeCookieOnSubmit($form);
+    }
+  },
+
+  checkLoginCookie: function() {
+    var u = FR.Cookies.get('fr_username');
+
+    if (u) {
+      $('#user_email').val(u);
+    }
+  },
+
+  writeCookieOnSubmit: function($form) {
+    $form.on('submit', function() {
+      FR.Cookies.set('fr_username', $form.find('#user_email').val(), {days: 30});
+    });
+  }
+};
+
+$(function() {
+  FR.login.init();
+});

--- a/app/assets/stylesheets/form_elements.scss
+++ b/app/assets/stylesheets/form_elements.scss
@@ -5,3 +5,8 @@ input[type=text]{
     background-color: $grey-3;
   }
 }
+
+input.decoy {
+  // used to prevent browser autofill
+  display: none;
+}

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -2,6 +2,7 @@
   .small-12.medium-6.large-5.columns
     h2.pad-top-thirty-px Sign in
     = form_for(resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: 'off' }) do |f|
+      input.decoy type="password" tabindex="-1"
       .row
         .small-12.columns
           .form-group


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/100523714)

* When user submits the login form, set a cookie to the content of the username (email) field
* When loading the login form, check for that cookie and if present, prefill the username field
* Prevent browser autocomplete of password box using decoy visually hidden password field (`autocomplete="off"` is not respected by most browsers any more)