### PR TITLE
Allow users to edit their own passwords

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,12 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
+
+    before_action :authorize_for_current_user
+
+    def edit
+      super
+    end
+
     def update
       if account_update_params[:password].present?
         super
@@ -8,6 +15,16 @@ module Users
         resource.errors.add(:password, error_message)
         respond_with resource
       end
+    end
+
+    private
+
+    def their_own?
+      current_user.id.eql?(params[:id].to_i)
+    end
+
+    def authorize_for_current_user
+      authorize current_user if their_own?
     end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,13 +1,13 @@
 module Users
   class RegistrationsController < Devise::RegistrationsController
 
-    before_action :authorize_for_current_user
-
     def edit
+      authorize User.find(params[:id]), :edit_password?
       super
     end
 
     def update
+      authorize User.find(params[:id]), :update_password?
       if account_update_params[:password].present?
         super
       else
@@ -15,16 +15,6 @@ module Users
         resource.errors.add(:password, error_message)
         respond_with resource
       end
-    end
-
-    private
-
-    def their_own?
-      current_user.id.eql?(params[:id].to_i)
-    end
-
-    def authorize_for_current_user
-      authorize current_user if their_own?
     end
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -37,6 +37,12 @@ class UserPolicy < BasePolicy
     !user_themselves? && ((manager? && same_office?) || admin?)
   end
 
+  def edit_password?
+    user_themselves?
+  end
+
+  alias_method :update_password?, :edit_password?
+
   class Scope < BasePolicy::Scope
     def resolve
       if admin?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,7 @@ Rails.application.routes.draw do
   }
   resources :users
   as :user do
-    get 'users/:id/change_password' => 'devise/registrations#edit', as: 'edit_user_registration'
+    get 'users/:id/change_password' => 'users/registrations#edit', as: 'edit_user_registration'
     patch 'users/:id/change_password' => 'users/registrations#update', as: 'user_registration'
   end
 end

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'User profile', type: :feature do
 
       scenario 'prevent users to edit somebody elses password' do
         visit edit_user_registration_path another_user.id
-        expect(page).to have_text 'Pundit::AuthorizationNotPerformedError'
+        expect(page).to have_text "You don’t have permission to do this"
       end
     end
 

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -34,6 +34,19 @@ RSpec.feature 'User profile', type: :feature do
       end
     end
 
+    context 'password edit' do
+      scenario 'allow users to change their password' do
+        visit edit_user_registration_path user.id
+        expect(page).to have_text 'Current password'
+        expect(page).not_to have_text 'Pundit::AuthorizationNotPerformedError'
+      end
+
+      scenario 'prevent users to edit somebody elses password' do
+        visit edit_user_registration_path another_user.id
+        expect(page).to have_text 'Pundit::AuthorizationNotPerformedError'
+      end
+    end
+
     context 'edit' do
       before(:each) { visit edit_user_path user.id }
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe UserPolicy, type: :policy do
 
       it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:edit) }
+      it { is_expected.to permit_action(:edit_password) }
+      it { is_expected.to permit_action(:update_password) }
 
       context 'when the role is staff' do
         before do
@@ -57,6 +59,8 @@ RSpec.describe UserPolicy, type: :policy do
       it { is_expected.not_to permit_action(:show) }
       it { is_expected.not_to permit_action(:edit) }
       it { is_expected.not_to permit_action(:update) }
+      it { is_expected.not_to permit_action(:edit_password) }
+      it { is_expected.not_to permit_action(:update_password) }
     end
   end
 
@@ -79,6 +83,8 @@ RSpec.describe UserPolicy, type: :policy do
         let(:subject_user) { dup_user(user) }
 
         it { is_expected.not_to permit_action(:destroy) }
+        it { is_expected.to permit_action(:edit_password) }
+        it { is_expected.to permit_action(:update_password) }
 
         context 'when trying to set a role to admin' do
           before do
@@ -91,6 +97,8 @@ RSpec.describe UserPolicy, type: :policy do
 
       context 'when the subject_user is not the manager themselves' do
         it { is_expected.to permit_action(:destroy) }
+        it { is_expected.not_to permit_action(:edit_password) }
+        it { is_expected.not_to permit_action(:update_password) }
 
         context 'when role set to manager' do
           let(:subject_user) { build_stubbed(:user, office: office, role: 'manager') }
@@ -148,10 +156,14 @@ RSpec.describe UserPolicy, type: :policy do
       let(:subject_user) { dup_user(user) }
 
       it { is_expected.not_to permit_action(:destroy) }
+      it { is_expected.to permit_action(:edit_password) }
+      it { is_expected.to permit_action(:update_password) }
     end
 
     context 'when the subject_user is not the admin themselves' do
       it { is_expected.to permit_action(:destroy) }
+      it { is_expected.not_to permit_action(:edit_password) }
+      it { is_expected.not_to permit_action(:update_password) }
     end
   end
 


### PR DESCRIPTION
Since the introduction of Pundit, the users were unable to change their
own passwords. This change allows them to do that again.