### PR TITLE
Changes to Add new office page

### DIFF
--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -42,8 +42,10 @@ class OfficesController < ApplicationController
     office.assign_attributes(office_params)
     authorize office
 
-    if office.save && manager_setup.in_progress?
-      redirect_to out_of_the_box_redirect
+    if office.save
+      flash[:notice] = 'Office was successfully updated'
+
+      redirect_to update_redirect_path
     else
       respond_with(office)
     end
@@ -65,6 +67,10 @@ class OfficesController < ApplicationController
 
   def manager_setup
     @manager_setup ||= ManagerSetup.new(current_user, session)
+  end
+
+  def update_redirect_path
+    manager_setup.in_progress? ? out_of_the_box_redirect : { action: :show }
   end
 
   def out_of_the_box_redirect

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -1,5 +1,5 @@
 class OfficesController < ApplicationController
-  before_action :list_jurisdictions, only: [:new, :edit, :update]
+  before_action :list_jurisdictions, only: [:edit, :update]
 
   respond_to :html
 
@@ -62,7 +62,7 @@ class OfficesController < ApplicationController
   end
 
   def list_jurisdictions
-    @jurisdictions = Jurisdiction.all
+    @jurisdictions = Jurisdiction.available_for_office(office)
   end
 
   def manager_setup

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -33,9 +33,9 @@ class OfficesController < ApplicationController
     @office = Office.new(office_params)
     authorize @office
 
-    @office.save
+    flash[:notice] = 'Office was successfully created' if @office.save
+
     respond_with(@office)
-    flash[:notice] = 'Office was successfully created'
   end
 
   def update

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -2,9 +2,14 @@ class Jurisdiction < ActiveRecord::Base
 
   has_many :office_jurisdictions
   has_many :offices, through: :office_jurisdictions
+  has_many :business_entities
 
   validates :name, uniqueness: true, presence: true
   validates :abbr, uniqueness: { allow_nil: true }
+
+  scope :available_for_office, lambda { |office|
+    joins(:business_entities).where(business_entities: { office: office })
+  }
 
   def display
     self.abbr ||= name

--- a/app/models/office.rb
+++ b/app/models/office.rb
@@ -9,8 +9,6 @@ class Office < ActiveRecord::Base
   scope :non_digital, -> { where.not(name: 'Digital') }
 
   validates :name, presence: true, uniqueness: true
-  validates :entity_code, presence: true, uniqueness: true
-  validates :jurisdictions, presence: true
 
   def managers
     users.where(office_id: id, role: 'manager')

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -9,8 +9,12 @@
         ul
           li the help with fees application form (EX160)
           li the court or tribunal form related to the application
-        .actions.util_mt-0
-          =link_to 'Start now', create_applications_path, method: :post, class: 'button success util_mb-0'
+
+        - if current_user.office.jurisdictions.empty?
+          p Please ask your manager to assign jurisdictions to your office.
+        - else
+          .actions.util_mt-0
+            =link_to 'Start now', create_applications_path, method: :post, class: 'button success util_mb-0'
 
 - if policy(:application).index?
   .row

--- a/app/views/offices/_form.html.slim
+++ b/app/views/offices/_form.html.slim
@@ -3,30 +3,24 @@
   .row
     .small-12.columns.form-group
       .row
-        .columns.small-12
-          = f.label :name, @office.errors[:name].join(', ').html_safe, class: 'error' if @office.errors[:name].present?
-      .row
         .columns.small-12.medium-8.large-5
           = f.label :name, t('functions.offices.label_name')
+          = f.label :name, @office.errors[:name].join(', '), class: 'error' if @office.errors[:name].present?
           = f.text_field :name, { class: 'form-control' }
-      -if current_user.admin?
-        .row
-          .columns.small-12.medium-8.large-5
-            = f.label :entity_code
-            = f.text_field :entity_code, { class: 'form-control' }
 
-  .row
-    .small-12.large-6.columns.form-group
-      .row
-        .columns.small-12
-          = f.label :jurisdictions
-          = f.label :jurisdictions, @office.errors[:jurisdictions].join(', ').html_safe, class: 'error' if @office.errors[:jurisdictions].present?
-      .row
-        .options.radio
-          =collection_check_boxes(:office, :jurisdiction_ids, @jurisdictions, :id, :display_full) do |b|
-            .columns.small-12.end
-              = b.label do
-                = b.check_box
-                = "#{b.text} (#{@becs[b.value]})"
+  - if with_jurisdictions
+    .row
+      .small-12.large-6.columns.form-group
+        .row
+          .columns.small-12
+            = f.label :jurisdictions
+            = f.label :jurisdictions, @office.errors[:jurisdictions].join(', ').html_safe, class: 'error' if @office.errors[:jurisdictions].present?
+        .row
+          .options.radio
+            =collection_check_boxes(:office, :jurisdiction_ids, @jurisdictions, :id, :display_full) do |b|
+              .columns.small-12.end
+                = b.label do
+                  = b.check_box
+                  = "#{b.text} (#{@becs[b.value]})"
 
   .actions = f.submit class: 'button'

--- a/app/views/offices/edit.html.slim
+++ b/app/views/offices/edit.html.slim
@@ -1,6 +1,6 @@
 h2 Change office details
 
-== render 'form'
+= render 'form', with_jurisdictions: true
 
 .row.pad-top-thirty-px
   .columns.small-12

--- a/app/views/offices/new.html.slim
+++ b/app/views/offices/new.html.slim
@@ -1,5 +1,7 @@
 h2 New office
 
-== render 'form'
+= render 'form', with_jurisdictions: false
 
-= link_to 'Back', offices_path
+.row.pad-top-thirty-px
+  .columns.small-12
+    = link_to 'Back', offices_path

--- a/app/views/offices/show.html.slim
+++ b/app/views/offices/show.html.slim
@@ -5,9 +5,6 @@ h2 Office details
     .columns.small-4.large-2 Name of office
     .columns.small-8.large-10 =@office.name
   .row
-    .columns.small-4.large-2  Entity code
-    .columns.small-8.large-10 =@office.entity_code
-  .row
     .columns.small-4.large-2 Jurisdictions
     .columns.small-8.large-10
       - @office.jurisdictions.each do |j|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -397,8 +397,8 @@ en-GB:
               confirmation: Your password must match the one you entered above
         office:
           attributes:
-            jurisdictions:
-              blank: Please select at least one jurisdiction
+            name:
+              blank: Enter the office name
     attributes:
       user:
         current_password: Current password

--- a/spec/controllers/offices_controller_spec.rb
+++ b/spec/controllers/offices_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe OfficesController, type: :controller do
 
   include Devise::TestHelpers
 
-  let(:office)      { create(:office) }
+  let(:office)      { create(:office, jurisdictions: []) }
   let(:user)        { create :user, office: office }
 
   let(:jurisdiction) { create :jurisdiction }
@@ -106,7 +106,9 @@ RSpec.describe OfficesController, type: :controller do
   end
 
   describe 'GET #edit' do
+    let(:assigned_jurisdiction) { create :jurisdiction }
     before do
+      create :business_entity, office: office, jurisdiction: assigned_jurisdiction
       mock_authorise(office, authorised)
     end
 
@@ -123,6 +125,10 @@ RSpec.describe OfficesController, type: :controller do
 
       it 'assigns the office' do
         expect(assigns(:office)).to eql(office)
+      end
+
+      it 'assigns only available jurisdictions' do
+        expect(assigns(:jurisdictions)).to eq([assigned_jurisdiction])
       end
     end
 

--- a/spec/controllers/offices_controller_spec.rb
+++ b/spec/controllers/offices_controller_spec.rb
@@ -4,276 +4,250 @@ RSpec.describe OfficesController, type: :controller do
 
   include Devise::TestHelpers
 
-  let(:user)        { create :user }
-  let(:admin_user)  { create :admin_user }
-  let(:manager)     { create :manager }
   let(:office)      { create(:office) }
+  let(:user)        { create :user, office: office }
 
   let(:jurisdiction) { create :jurisdiction }
   let(:valid_params) { attributes_for(:office).merge(jurisdiction_ids: [jurisdiction.id]) }
 
-  context 'logged out user' do
-    describe 'GET #index' do
-      it 'redirects to login page' do
-        get :index
-        expect(response).to redirect_to(user_session_path)
-      end
-    end
+  before do
+    bypass_rescue
+    sign_in(user)
+  end
 
-    describe 'GET #show' do
-      it 'redirects to login page' do
-        get :show, id: office.to_param
-        expect(response).to redirect_to(user_session_path)
-      end
-    end
+  def mock_authorise(record, authorised)
+    expectation = receive(:authorize).with(record)
+    expectation.and_raise(Pundit::NotAuthorizedError) unless authorised
 
-    describe 'GET #new' do
-      it 'redirects to login page' do
-        get :index
-        expect(response).to redirect_to(user_session_path)
+    expect(controller).to expectation
+    expect(controller).to receive(:verify_authorized) if authorised
+  end
+
+  shared_examples 'when not authorised' do
+    context 'when not authorised' do
+      let(:authorised) { false }
+
+      it 'raises Pundit error' do
+        expect { subject }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end
 
-  context 'standard user' do
-    before(:each) { sign_in user }
+  describe 'GET #index' do
+    before do
+      mock_authorise(:office, authorised)
+    end
 
-    describe 'GET #index' do
-      it 'assigns all offices as @offices' do
-        get :index
-        expect(assigns(:offices)).to include(office)
+    subject { get :index }
+
+    context 'when authorised' do
+      let(:authorised) { true }
+
+      before { subject }
+
+      it 'renders the correct template' do
+        expect(response).to render_template(:index)
+      end
+
+      it 'assigns all offices' do
+        expect(assigns(:offices).size).to eql(Office.count)
       end
     end
 
-    describe 'GET #show' do
-      it 'assigns the requested office as @office' do
-        get :show, id: office.to_param
-        expect(assigns(:office)).to eq office
-      end
-    end
-
-    describe 'GET #new' do
-      it 'raises Pundit error' do
-        bypass_rescue
-        expect {
-          bypass_rescue
-          get :new
-        }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
-
-    describe 'GET #edit' do
-      it 'raises Pundit error' do
-        expect {
-          bypass_rescue
-          get :edit, id: office.to_param
-        }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
-
-    describe 'POST #create' do
-      context 'with valid params' do
-        it 'raises Pundit error' do
-          expect {
-            bypass_rescue
-            post :create, office: valid_params
-          }.to raise_error Pundit::NotAuthorizedError
-        end
-      end
-    end
-
-    describe 'PUT #update' do
-      context 'with valid params' do
-        it 'raises Pundit error' do
-          expect {
-            bypass_rescue
-            put :update, id: office.to_param, office: valid_params
-          }.to raise_error Pundit::NotAuthorizedError
-        end
-      end
-    end
+    include_examples 'when not authorised'
   end
 
-  context 'as a manager' do
-    before(:each) { sign_in manager }
+  describe 'GET #show' do
+    before do
+      mock_authorise(office, authorised)
+    end
 
-    describe 'GET #index' do
-      it 'assigns all offices as @offices' do
-        get :index
-        expect(assigns(:offices)).to include(office)
+    subject { get :show, id: office.id }
+
+    context 'when authorised' do
+      let(:authorised) { true }
+
+      before { subject }
+
+      it 'renders the correct template' do
+        expect(response).to render_template(:show)
+      end
+
+      it 'assigns the office' do
+        expect(assigns(:office)).to eql(office)
       end
     end
 
-    describe 'GET #show' do
-      it 'assigns the requested office as @office' do
-        get :show, id: office.to_param
-        expect(assigns(:office)).to eq office
-      end
-    end
-
-    describe 'GET #new' do
-      it 'raises Pundit error' do
-        expect {
-          bypass_rescue
-          get :new
-        }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
-
-    describe 'GET #edit' do
-      context 'for their own office' do
-        it 'assigns the requested office as @office' do
-          get :edit, id: manager.office.to_param
-          expect(assigns(:office)).to eq(manager.office)
-        end
-      end
-
-      context 'for a different office' do
-        it 'raises Pundit error' do
-          expect {
-            bypass_rescue
-            get :edit, id: create(:office).to_param
-          }.to raise_error Pundit::NotAuthorizedError
-        end
-      end
-    end
-
-    describe 'POST #create' do
-      context 'with valid params' do
-        it 'raises Pundit error' do
-          expect {
-            bypass_rescue
-            post :create, office: valid_params
-          }.to raise_error Pundit::NotAuthorizedError
-        end
-      end
-    end
-
-    describe 'PUT #update' do
-      context 'with valid params' do
-        it 'assigns the requested office as @office' do
-          put :update, id: manager.office.to_param, office: valid_params
-          expect(assigns(:office)).to eq(manager.office)
-        end
-
-        it 'redirects to the office' do
-          put :update, id: manager.office.to_param, office: valid_params
-          expect(response).to redirect_to(manager.office)
-        end
-      end
-
-      context 'with invalid params' do
-        it 'assigns the office as @office' do
-          put :update, id: manager.office.to_param, office: attributes_for(:invalid_office)
-          expect(assigns(:office)).to eq(manager.office)
-        end
-
-        it 're-renders the "edit" template' do
-          put :update, id: manager.office.to_param, office: attributes_for(:invalid_office)
-          expect(response).to render_template('edit')
-        end
-      end
-    end
+    include_examples 'when not authorised'
   end
 
-  context 'admin user' do
-
-    before(:each) { sign_in admin_user }
-
-    describe 'GET #index' do
-      it 'assigns all offices as @offices' do
-        get :index
-        expect(assigns(:offices)).to include(office)
-      end
+  describe 'GET #new' do
+    before do
+      mock_authorise(Office, authorised)
     end
 
-    describe 'GET #show' do
-      it 'assigns the requested office as @office' do
-        get :show, id: office.to_param
-        expect(assigns(:office)).to eq(office)
-      end
-    end
+    subject { get :new }
 
-    describe 'GET #new' do
-      it 'assigns a new office as @office' do
-        get :new
+    context 'when authorised' do
+      let(:authorised) { true }
+
+      before { subject }
+
+      it 'renders the correct template' do
+        expect(response).to render_template(:new)
+      end
+
+      it 'assigns a new office' do
         expect(assigns(:office)).to be_a_new(Office)
       end
     end
 
-    describe 'GET #edit' do
-      it 'assigns the requested office as @office' do
-        get :edit, id: office.to_param
-        expect(assigns(:office)).to eq(office)
+    include_examples 'when not authorised'
+  end
+
+  describe 'GET #edit' do
+    before do
+      mock_authorise(office, authorised)
+    end
+
+    subject { get :edit, id: office.id }
+
+    context 'when authorised' do
+      let(:authorised) { true }
+
+      before { subject }
+
+      it 'renders the correct template' do
+        expect(response).to render_template(:edit)
+      end
+
+      it 'assigns the office' do
+        expect(assigns(:office)).to eql(office)
       end
     end
 
-    describe 'POST #create' do
-      context 'with valid params' do
-        let(:created_office) { Office.find_by(name: valid_params[:name]) }
+    include_examples 'when not authorised'
+  end
 
-        before do
-          post :create, office: valid_params
-        end
+  describe 'POST #create' do
+    let(:new_office) { build_stubbed(:office) }
+    let(:params) { valid_params }
 
-        it 'creates a new Office' do
-          expect(created_office).not_to be nil
-        end
+    before do
+      allow(Office).to receive(:new).and_return(new_office)
+      mock_authorise(new_office, authorised)
+    end
 
-        it 'assigns a success flash message' do
-          expect(assigns)
+    subject { post :create, office: params }
+
+    context 'when authorised' do
+      let(:authorised) { true }
+
+      before do
+        allow(new_office).to receive(:errors).and_return(saved ? [] : [double, double])
+        expect(new_office).to receive(:save).and_return(saved)
+        subject
+      end
+
+      context 'when the office can be saved' do
+        let(:saved) { true }
+
+        it 'sets a flash notice' do
           expect(flash[:notice]).to eql('Office was successfully created')
         end
 
-        it 'redirects to the created office show page' do
-          expect(response).to redirect_to(office_path(created_office))
+        it 'redirects to the office show page' do
+          expect(response).to redirect_to(office_path(new_office))
         end
       end
 
-      context 'with invalid params' do
-        before do
-          post :create, office: attributes_for(:invalid_office)
+      context 'when the office can not be saved' do
+        let(:saved) { false }
+
+        it 'does not redirect' do
+          expect(response).not_to be_redirect
         end
 
-        it 'assigns a newly created but unsaved office as @office' do
-          expect(assigns(:office)).to be_a_new(Office)
+        it 'renders the new template' do
+          # binding.pry
+          expect(response).to render_template(:new)
         end
 
-        it 're-renders the "new" template' do
-          expect(response).to render_template('new')
+        it 'assigns the office' do
+          expect(assigns(:office)).to eql(new_office)
+        end
+      end
+    end
+
+    include_examples 'when not authorised'
+  end
+
+  describe 'PUT #update' do
+    let(:existing_office) { office }
+    let(:params) { valid_params }
+
+    before do
+      allow(Office).to receive(:find).with(existing_office.to_param.to_s).and_return(existing_office)
+      mock_authorise(existing_office, authorised)
+    end
+
+    subject { put :update, id: existing_office.id, office: params }
+
+    context 'when authorised' do
+      let(:authorised) { true }
+      let(:manager_setup) { double(setup_profile?: false, in_progress?: false) }
+
+      before do
+        allow(ManagerSetup).to receive(:new).and_return(manager_setup)
+        allow(ManagerSetup).to receive(:new).and_return(manager_setup)
+        allow(existing_office).to receive(:errors).and_return(saved ? [] : [double, double])
+        expect(existing_office).to receive(:save).and_return(saved)
+        subject
+      end
+
+      context 'when the office can be saved' do
+        let(:saved) { true }
+
+        it 'sets a flash notice' do
+          expect(flash[:notice]).to eql('Office was successfully updated')
+        end
+
+        context 'when the user is a manager setting up a new office' do
+          context 'when the manager needs to setup their profile' do
+            let(:manager_setup) { double(setup_profile?: true, in_progress?: true) }
+
+            it 'redirects to the user edit profile page' do
+              expect(response).to redirect_to(edit_user_path(user))
+            end
+          end
+          context 'when the manager does not need to setup their profile' do
+            let(:manager_setup) { double(setup_profile?: false, in_progress?: true) }
+            it 'redirects to the home page' do
+              expect(response).to redirect_to(root_path)
+            end
+          end
+        end
+
+        context 'when the user is not a manager setting up a new office' do
+          it 'redirects to the office show page' do
+            expect(response).to redirect_to(office_path(existing_office))
+          end
+        end
+      end
+
+      context 'when the office can not be saved' do
+        let(:saved) { false }
+
+        it 'renders the new template' do
+          expect(response).to render_template(:edit)
+        end
+
+        it 'assigns the office' do
+          expect(assigns(:office)).to eql(existing_office)
         end
       end
     end
 
-    describe 'PUT #update' do
-      context 'with valid params' do
-        it 'updates the requested office' do
-          put :update, id: office.to_param, office: attributes_for(:invalid_office)
-          office.reload
-        end
-
-        it 'assigns the requested office as @office' do
-          put :update, id: office.to_param, office: valid_params
-          expect(assigns(:office)).to eq(office)
-        end
-
-        it 'redirects to the office' do
-          put :update, id: office.to_param, office: valid_params
-          expect(response).to redirect_to(office)
-        end
-      end
-
-      context 'with invalid params' do
-        it 'assigns the office as @office' do
-          put :update, id: office.to_param, office: attributes_for(:invalid_office)
-          expect(assigns(:office)).to eq(office)
-        end
-
-        it 're-renders the "edit" template' do
-          put :update, id: office.to_param, office: attributes_for(:invalid_office)
-          expect(response).to render_template('edit')
-        end
-      end
-    end
+    include_examples 'when not authorised'
   end
 end

--- a/spec/controllers/offices_controller_spec.rb
+++ b/spec/controllers/offices_controller_spec.rb
@@ -210,32 +210,36 @@ RSpec.describe OfficesController, type: :controller do
 
     describe 'POST #create' do
       context 'with valid params' do
+        let(:created_office) { Office.find_by(name: valid_params[:name]) }
+
+        before do
+          post :create, office: valid_params
+        end
+
         it 'creates a new Office' do
-          expect {
-            post :create, office: valid_params
-          }.to change(Office, :count).by(1)
+          expect(created_office).not_to be nil
         end
 
-        it 'assigns a newly created office as @office' do
-          post :create, office: valid_params
-          expect(assigns(:office)).to be_a(Office)
-          expect(assigns(:office)).to be_persisted
+        it 'assigns a success flash message' do
+          expect(assigns)
+          expect(flash[:notice]).to eql('Office was successfully created')
         end
 
-        it 'redirects to the created office' do
-          post :create, office: valid_params
-          expect(response).to redirect_to(Office.last)
+        it 'redirects to the created office show page' do
+          expect(response).to redirect_to(office_path(created_office))
         end
       end
 
       context 'with invalid params' do
-        it 'assigns a newly created but unsaved office as @office' do
+        before do
           post :create, office: attributes_for(:invalid_office)
+        end
+
+        it 'assigns a newly created but unsaved office as @office' do
           expect(assigns(:office)).to be_a_new(Office)
         end
 
         it 're-renders the "new" template' do
-          post :create, office: attributes_for(:invalid_office)
           expect(response).to render_template('new')
         end
       end

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -4,8 +4,19 @@ RSpec.describe Jurisdiction, type: :model do
 
   let(:jurisdiction) { create(:jurisdiction) }
 
-  it 'passes factory build' do
-    expect(jurisdiction).to be_valid
+  it { is_expected.to have_many(:business_entities) }
+
+  describe '.available_for_office' do
+    # The office factory creates BusinessEntity automatically, so we don't have to create it manually.
+    let!(:office) { create :office, jurisdictions: [jurisdiction2] }
+    let!(:jurisdiction1) { create :jurisdiction }
+    let!(:jurisdiction2) { create :jurisdiction }
+
+    subject { described_class.available_for_office(office) }
+
+    it 'includes jurisdictions which have business entity present' do
+      is_expected.to eq([jurisdiction2])
+    end
   end
 
   describe 'validation' do

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -14,23 +14,16 @@ RSpec.describe Office, type: :model do
   end
 
   context 'validations' do
-    it { is_expected.to validate_presence_of(:jurisdictions) }
-
     it 'is invalid with no name' do
       office = build(:invalid_office)
       expect(office).to_not be_valid
-      expect(office.errors[:name]).to eq ["can't be blank"]
+      expect(office.errors[:name]).to eq ['Enter the office name']
     end
 
     it 'must have a unique name' do
       original = create(:office)
       duplicate = build(:office, name: original.name)
       expect(duplicate).to be_invalid
-    end
-
-    it 'must have entity_code' do
-      office.entity_code = ''
-      expect(office).to be_invalid
     end
   end
 

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "home/index.html.slim", type: :view do
 
   include Devise::TestHelpers
 
-  let(:user) { create :user }
+  let(:office) { create :office }
+  let(:user) { create :user, office: office }
 
   let(:application_new?) { false }
   let(:application_index?) { false }
@@ -25,9 +26,22 @@ RSpec.describe "home/index.html.slim", type: :view do
     context 'when user has permissions to process application' do
       let(:application_new?) { true }
 
-      it 'is rendered' do
+      it 'renders title' do
         is_expected.to have_text 'Process application'
-        is_expected.to have_link 'Start now'
+      end
+
+      context 'when the office has some jurisdictions assigned' do
+        it 'renders the Start now button' do
+          is_expected.to have_text 'Start now'
+        end
+      end
+
+      context 'when the office has no jurisdictions assigned' do
+        let(:office) { create :office, jurisdictions: [] }
+
+        it 'renders the message that manager has to first assign jurisdictions' do
+          is_expected.to have_text 'Please ask your manager to assign jurisdictions to your office.'
+        end
       end
     end
 

--- a/spec/views/offices/edit.html.slim_spec.rb
+++ b/spec/views/offices/edit.html.slim_spec.rb
@@ -31,14 +31,6 @@ RSpec.describe 'offices/edit', type: :view do
     it 'does not render a link to the list' do
       expect(rendered).not_to have_xpath("//a[@href='#{offices_path}']")
     end
-
-    it 'does not show the business entity code input for the office' do
-      expect(rendered).not_to have_xpath('//input[@name="office[entity_code]"]')
-    end
-
-    it 'does not show the business entity code label for the office' do
-      expect(rendered).not_to have_content('Entity code')
-    end
   end
 
   context 'as an admin' do
@@ -51,14 +43,6 @@ RSpec.describe 'offices/edit', type: :view do
 
     it 'renders a link to the list' do
       expect(rendered).to have_xpath("//a[@href='#{offices_path}']")
-    end
-
-    it 'renders the business entity code input for the office' do
-      expect(rendered).to have_xpath('//input[@name="office[entity_code]"]')
-    end
-
-    it 'renders the business entity code label for the office' do
-      expect(rendered).to have_content('Entity code')
     end
   end
 end

--- a/spec/views/offices/new.html.slim_spec.rb
+++ b/spec/views/offices/new.html.slim_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe 'offices/new', type: :view do
     sign_in manager
     render
 
-    expect(rendered).to have_xpath('//input[@name="office[jurisdiction_ids][]"]', count: jurisdictions.count + 1)
     assert_select 'form[action=?][method=?]', offices_path, 'post' do
       assert_select 'input#office_name[name=?]', 'office[name]'
     end


### PR DESCRIPTION
When admin tries to add a new office, now it only requires a name. 

This PR also removes the validation on `Office` to have at least one `OfficeJurisdiction`. 
To prevent staff creating applications and then not being able to progress through application details, the `Start now` button only appears when there is at least 1 jurisdiction. Otherwise there's a message to contact a manager.