### PR TITLE
process application module changes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -27,4 +27,5 @@
  *= require details
  *= require phase_banner
  *= require headings
+ *= require utilities
  */

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -1,0 +1,15 @@
+// utility classes used as overrides, therefore valid use of !important
+// https://css-tricks.com/when-using-important-is-the-right-choice/
+
+// margin utility classes
+.util_mt-0 {
+  margin-top: 0 !important;
+}
+
+.util_mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.util_margin-0 {
+  margin: 0 !important;
+}

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -5,22 +5,17 @@
     h1 Help with fees
     p Use this service to process applications for <strong> help with fees </strong> (EX160)
 
-.row.equal-heightboxes
-  - if policy(:application).new?
-    .small-12.medium-8.large-6.columns
+- if policy(:application).new?
+  .row
+    .small-12.columns
       .panel
-        h3.bold Process application
-        p You'll need:
+        h3 Process application
+        p.util_mb-0 You'll need:
         ul
           li the help with fees application form (EX160)
           li the court or tribunal form related to the application
-        .actions
-          =link_to 'Start now', create_applications_path, method: :post, class: 'button success'
-  .small-12.medium-8.large-6.columns.end
-    .panel
-      h3.bold Staff guides
-      p How to process an application, deal with evidence checks, part-payments, appeals, and fraud.
-      p =link_to 'See the guides', guide_path
+        .actions.util_mt-0
+          =link_to 'Start now', create_applications_path, method: :post, class: 'button success util_mb-0'
 
 - if policy(:application).index?
   .row


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/110953430)

Before
---
![screen shot 2016-01-15 at 16 23 15](https://cloud.githubusercontent.com/assets/988436/12358296/707db9e8-bba4-11e5-8f11-413077ead045.png)

After
---
![screen shot 2016-01-15 at 16 23 30](https://cloud.githubusercontent.com/assets/988436/12358300/76abec86-bba4-11e5-9b57-65efdfe80dcc.png)


Note the Pivotal story says to remove the space between the bulleted list and the 'Start now' button, but this looks too cramped. Removing the top margin from the button container has reduced the space, which looks good.

Here is the cramped version:
![screen shot 2016-01-15 at 15 49 07](https://cloud.githubusercontent.com/assets/988436/12358315/8e41c906-bba4-11e5-90ee-b68aa73cfe78.png)

