### PR TITLE
Removing the Ruby version from Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 sudo: false
-rvm:
-- 2.3.0
 cache: bundler
 before_script:
 - psql -c 'create role fr login createdb;' -U postgres


### PR DESCRIPTION
Previously there was a reason for specifiying the Ruby version in both
.travis.yml and .ruby-version. Hoping that this is no longer the case,
since maintaining the Ruby version in two places is error prone.