### PR TITLE
add two new modules to admin dashboard

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,5 +1,20 @@
 =content_for(:javascript) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
 
+-if current_user.admin?
+  header
+    .row.equal-heightboxes
+      .small-12.medium-6.columns
+        .panel
+          h3 Generate reports
+          p Export national finance reports related to Help with fees applications and download monthly summary data.
+          = link_to 'Generate reports', '/reports/finance_report', class: 'button success util_mb-0'
+      .small-12.medium-6.columns
+        .panel
+          h3 View offices
+          p View all the offices in England and Wales that process Help with fees applications, and update BEC codes.
+          = link_to 'View offices', offices_path
+
+
 - if policy(:application).new?
   .row
     .small-12.columns

--- a/app/views/reports/finance_report.html.slim
+++ b/app/views/reports/finance_report.html.slim
@@ -1,6 +1,6 @@
 = form_for @form, url: reports_finance_report_path, method: :put, html: { autocomplete: 'off' } do |f|
   header
-    h2 Finance report
+    h2 Generate report
 
   .row
     .small-12.medium-8.large-5.columns
@@ -16,4 +16,4 @@
         = f.label :date_to, @form.errors[:date_to].join(', '), class: 'error' if @form.errors[:date_to].present?
         = f.text_field :date_to, { class: 'form-control small-field' }
 
-      = f.submit 'Get data as CSV', class: 'button primary'
+      = f.submit 'Generate report', class: 'button primary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -227,9 +227,9 @@ en-GB:
         form_name: Form
         full_name: Applicant
       forms/finance_report:
-        date_from: 'Start of date range'
-        date_to: 'End of date range'
-        date_hint: Enter the date in this format DD/MM/YYYY
+        date_from: 'Date from'
+        date_to: 'Date to'
+        date_hint: For example DD/MM/YYYY
       forms/application/applicant:
         undetermined: 'The details you’ve entered are incorrect, check and try again'
         title: Title


### PR DESCRIPTION
Looky likey:

![screen shot 2016-01-20 at 14 10 38](https://cloud.githubusercontent.com/assets/988436/12451165/a335bd66-bf7f-11e5-8a2f-3711468dd62e.png)

Note that there is a subsequent ticket to move the graphs below off the admin dashboard onto their own page.