### PR TITLE
show support email on sign in page

### DIFF
--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -28,7 +28,4 @@
       div.bold Don't have an account
       div Contact your manager to set up your account.
       div.bold.pad-top-fifteen-px Having technical issues
-      details
-        summary
-          span.summary Contact us
-        div Email: #{link_to Settings.mail.tech_support, "mailto:#{Settings.mail.tech_support}"}
+      p Email: #{link_to Settings.mail.tech_support, "mailto:#{Settings.mail.tech_support}"}


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/111955271)

Before
---
1.
![screen shot 2016-01-21 at 11 35 52](https://cloud.githubusercontent.com/assets/988436/12479490/3cb80aee-c033-11e5-9429-93624d859ba5.png)
2.
![screen shot 2016-01-21 at 11 36 01](https://cloud.githubusercontent.com/assets/988436/12479491/3f0cba9c-c033-11e5-8399-973bbe26e7b4.png)

After
---
![screen shot 2016-01-21 at 11 36 15](https://cloud.githubusercontent.com/assets/988436/12479500/4462a22c-c033-11e5-8f81-42f09730edc9.png)
