### PR TITLE
make staff guide panels responsive

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -171,23 +171,23 @@ header {
 }
 
 .guide-cols {
-  width: 18%;
-  display: inline-block;
-  float: left;
-  margin:0 15px 0 0;
-  min-height:240px;
-  position: relative;
   a {
     text-decoration: none;
     display: block;
+    text-align: center;
   }
   img {
-    padding:0;
-    display: block;
-    padding:20px;
-    position: absolute;
-    top:20%;
-    left:0;
+    padding: 10px;
+    width: auto;
+    max-height: 150px;
+    margin: auto;
+  }
+
+  h5 {
+    span {
+      display: block;
+      min-height: 2.5rem;
+    }
   }
 }
 .icon-column img{

--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -69,14 +69,14 @@
 // $base-line-height: 150%;
 
 // We use this to control whether or not CSS classes come through in the gem files.
-//$include-html-classes: true;
+$include-html-classes: true;
 // $include-print-styles: true;
 //$include-html-global-classes: $include-html-classes;
 
 // b. Grid
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
-// $include-html-grid-classes: $include-html-classes;
+$include-html-grid-classes: $include-html-classes;
 // $include-xl-html-grid-classes: false;
 
 // $row-width: rem-calc(1000);
@@ -373,13 +373,13 @@ $xxlarge-only: "#{$screen} and (min-width:#{lower-bound($xxlarge-range)}) and (m
 // 03. Block Grid
 // - - - - - - - - - - - - - - - - - - - - - - - - -
 
-// $include-html-block-grid-classes: $include-html-classes;
+$include-html-block-grid-classes: $include-html-classes;
 // $include-xl-html-block-grid-classes: false;
 
 // We use this to control the maximum number of block grid elements per row
-// $block-grid-elements: 12;
-// $block-grid-default-spacing: rem-calc(20);
-// $align-block-grid-to-grid: false;
+$block-grid-elements: 12;
+$block-grid-default-spacing: rem-calc(20);
+$align-block-grid-to-grid: false;
 
 // Enables media queries for block-grid classes. Set to false if writing semantic HTML.
 // $block-grid-media-queries: true;

--- a/app/views/guide/appeals.html.slim
+++ b/app/views/guide/appeals.html.slim
@@ -57,31 +57,31 @@ header
 
 .row
   .small-12.columns
-    .row
-      .small-12.medium-6.large-3.columns
-        .panel
+    ul.small-block-grid-2.medium-block-grid-4
+      li
+        .panel.guide-cols
           h5
             = link_to guide_process_application_path
-              | Process application
+              span Process application
               = image_tag("icon-process.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_evidence_checks_path
-              | Evidence checks
+              span Evidence checks
               = image_tag("icon-evidence.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_part_payments_path
-              | Part payments
+              span Part payments
               = image_tag("icon-part-fee.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_suspected_fraud_path
-              | Suspected fraud
+              span Suspected fraud
               = image_tag("icon-fraud.png")

--- a/app/views/guide/evidence_checks.html.slim
+++ b/app/views/guide/evidence_checks.html.slim
@@ -191,32 +191,32 @@ header
 
 .row
   .small-12.columns
-    .row
-      .small-12.medium-6.large-3.columns
-        .panel
+    ul.small-block-grid-2.medium-block-grid-4
+      li
+        .panel.guide-cols
           h5
             = link_to guide_process_application_path
-              | Process application
+              span Process application
               = image_tag("icon-process.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_part_payments_path
-              | Part payments
+              span Part payments
               = image_tag("icon-part-fee.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_appeals_path
-              | Appeals
+              span Appeals
               = image_tag("icon-appeals.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_suspected_fraud_path
-              | Suspected fraud
+              span Suspected fraud
               = image_tag("icon-fraud.png")
 

--- a/app/views/guide/index.html.slim
+++ b/app/views/guide/index.html.slim
@@ -4,33 +4,40 @@ header
       h2 See the guides
       h4 style="font-weight:normal;" How to process an application, deal with evidence checks, part-payments, appeals, and fraud.
 
-.row.equal-heightboxes
-  .panel.guide-cols
-    h5
-      = link_to guide_process_application_path
-        | Process application
-        = image_tag("icon-process.png")
+.row
+  .small-12.columns
+    ul.small-block-grid-2.medium-block-grid-4.large-block-grid-5
+      li
+        .panel.guide-cols
+          h5
+            = link_to guide_process_application_path
+              span Process application
+              = image_tag("icon-process.png")
 
-  .panel.guide-cols
-    h5
-      = link_to guide_evidence_checks_path
-        | Evidence checks
-        = image_tag("icon-evidence.png")
+      li
+        .panel.guide-cols
+          h5
+            = link_to guide_evidence_checks_path
+              span Evidence checks
+              = image_tag("icon-evidence.png")
 
-  .panel.guide-cols
-    h5
-      = link_to guide_part_payments_path
-        | Part-payments
-        = image_tag("icon-part-fee.png")
+      li
+        .panel.guide-cols
+          h5
+            = link_to guide_part_payments_path
+              span Part-payments
+              = image_tag("icon-part-fee.png")
 
-  .panel.guide-cols
-    h5
-      = link_to guide_appeals_path
-        | Appeals
-        = image_tag("icon-appeals.png")
+      li
+        .panel.guide-cols
+          h5
+            = link_to guide_appeals_path
+              span Appeals
+              = image_tag("icon-appeals.png")
 
-  .panel.guide-cols
-    h5
-      = link_to guide_suspected_fraud_path
-        | Suspected fraud
-        = image_tag("icon-fraud.png")
+      li
+        .panel.guide-cols
+          h5
+            = link_to guide_suspected_fraud_path
+              span Suspected fraud
+              = image_tag("icon-fraud.png")

--- a/app/views/guide/part_payments.html.slim
+++ b/app/views/guide/part_payments.html.slim
@@ -66,31 +66,31 @@ header
 
 .row
   .small-12.columns
-    .row
-      .small-12.medium-6.large-3.columns
-        .panel
+    ul.small-block-grid-2.medium-block-grid-4
+      li
+        .panel.guide-cols
           h5
             = link_to guide_process_application_path
-              | Process application
+              span Process application
               = image_tag("icon-process.png")
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_evidence_checks_path
-              | Evidence checks
+              span Evidence checks
               = image_tag("icon-evidence.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_appeals_path
-              | Appeals
+              span Appeals
               = image_tag("icon-appeals.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_suspected_fraud_path
-              | Suspected fraud
+              span Suspected fraud
               = image_tag("icon-fraud.png")
 

--- a/app/views/guide/process_application.html.slim
+++ b/app/views/guide/process_application.html.slim
@@ -432,30 +432,30 @@ header
 
 .row
   .small-12.columns
-    .row
-      .small-12.medium-6.large-3.columns
-        .panel
+    ul.small-block-grid-2.medium-block-grid-4
+      li
+        .panel.guide-cols
           h5
             = link_to guide_evidence_checks_path
-              | Evidence checks
+              span Evidence checks
               = image_tag("icon-evidence.png")
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_part_payments_path
-              | Part payments
+              span Part payments
               = image_tag("icon-part-fee.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_appeals_path
-              | Appeals
+              span Appeals
               = image_tag("icon-appeals.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_suspected_fraud_path
-              | Suspected fraud
+              span Suspected fraud
               = image_tag("icon-fraud.png")

--- a/app/views/guide/suspected_fraud.html.slim
+++ b/app/views/guide/suspected_fraud.html.slim
@@ -66,29 +66,29 @@ header
 
 .row
   .small-12.columns
-    .row
-      .small-12.medium-6.large-3.columns
-        .panel
+    ul.small-block-grid-2.medium-block-grid-4
+      li
+        .panel.guide-cols
           h5
             = link_to guide_process_application_path
-              | Process application
+              span Process application
               = image_tag("icon-process.png")
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_evidence_checks_path
-              | Evidence checks
+              span Evidence checks
               = image_tag("icon-evidence.png")
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_part_payments_path
-              | Part payments
+              span Part payments
               = image_tag("icon-part-fee.png")
 
-      .small-12.medium-6.large-3.columns
-        .panel
+      li
+        .panel.guide-cols
           h5
             = link_to guide_appeals_path
-              | Appeals
+              span Appeals
               = image_tag("icon-appeals.png")


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/111965025)

Guides home page
---
Before
![guides-index-before](https://cloud.githubusercontent.com/assets/988436/12512580/1ad11db0-c111-11e5-9c57-f3ef9f41b9ec.png)
After
![guides-index-after](https://cloud.githubusercontent.com/assets/988436/12512583/1e8aa6b0-c111-11e5-8859-859d43ca512d.png)

Guides detail "more guides" section
---
Before
![more-guides-before](https://cloud.githubusercontent.com/assets/988436/12512591/29316c34-c111-11e5-915d-c9eb27e54b6f.png)
After
![more-guides-after](https://cloud.githubusercontent.com/assets/988436/12512595/2c652670-c111-11e5-89e1-6dcb12b7c5c8.png)
