### PR TITLE
make green buttons consistent

### DIFF
--- a/app/views/evidence/confirmation.html.slim
+++ b/app/views/evidence/confirmation.html.slim
@@ -6,7 +6,7 @@ header
     - unless @confirmation.outcome == 'full'
       = render(partial: "confirmation_#{@confirmation.outcome}_remission", locals: { confirmation: @confirmation })
 
-    = link_to 'Back to start', root_path, class: 'button success'
+    = link_to 'Back to start', root_path, class: 'button'
 
   .large-5.columns
     .guidance

--- a/app/views/evidence/result.html.slim
+++ b/app/views/evidence/result.html.slim
@@ -5,7 +5,7 @@ header
   .small-12.medium-8.large-5.columns
     =render(partial: 'shared/remission_type', locals: { source: @result })
 
-    = link_to 'Next', evidence_summary_path(@evidence), class: 'button success'
+    = link_to 'Next', evidence_summary_path(@evidence), class: 'button'
 
   .large-5.columns
     .guidance

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -7,7 +7,7 @@
         .panel
           h3 Generate reports
           p Export national finance reports related to Help with fees applications and download monthly summary data.
-          = link_to 'Generate reports', '/reports/finance_report', class: 'button success util_mb-0'
+          = link_to 'Generate reports', '/reports/finance_report', class: 'button util_mb-0'
       .small-12.medium-6.columns
         .panel
           h3 View offices
@@ -30,7 +30,7 @@
             p Please ask your manager to assign jurisdictions to your office.
           - else
             .actions.util_mt-0
-              =link_to 'Start now', create_applications_path, method: :post, class: 'button success util_mb-0'
+              =link_to 'Start now', create_applications_path, method: :post, class: 'button util_mb-0'
 
 - if policy(:application).index?
   .row

--- a/app/views/part_payments/confirmation.html.slim
+++ b/app/views/part_payments/confirmation.html.slim
@@ -5,7 +5,7 @@ header
   .small-12.medium-8.large-5.columns
     - if @result.callout == 'no'
       = render('failed_letter', locals: { confirmation: @confirmation })
-    = link_to 'Back to start', root_path, class: 'button success'
+    = link_to 'Back to start', root_path, class: 'button'
 
   .large-5.columns
     .guidance

--- a/app/views/part_payments/show.html.slim
+++ b/app/views/part_payments/show.html.slim
@@ -5,7 +5,7 @@ header
   .small-12.columns
     .panel
       h4 Process part-payment
-      = link_to 'Start now', accuracy_part_payment_path(@part_payment), class: 'button success util_mb-medium'
+      = link_to 'Start now', accuracy_part_payment_path(@part_payment), class: 'button util_mb-medium'
       details
         summary
           span.summary.primary If the part-payment can’t be processed


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/112148431)

Seems to be caused by actually applying the class 'success' to some buttons, so that's been removed.

🚫
![button-before](https://cloud.githubusercontent.com/assets/988436/12515388/162ebbdc-c120-11e5-836c-525f85418cc0.png)

👌
![button-after](https://cloud.githubusercontent.com/assets/988436/12515398/2625f1fe-c120-11e5-9b84-e6ad25c3b496.png)
