### PR TITLE
Move graphs from admin/index

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,6 @@ class HomeController < ApplicationController
 
   def index
     manager_setup_progress
-    load_graphs_for_admin
     load_waiting_applications
   end
 
@@ -12,14 +11,6 @@ class HomeController < ApplicationController
   def manager_setup_progress
     manager_setup = ManagerSetup.new(current_user, session)
     manager_setup.finish! if manager_setup.in_progress?
-  end
-
-  def load_graphs_for_admin
-    if current_user.admin?
-      load_graph_data
-      @total_type_count = BenefitCheck.group(:dwp_result).count
-      @time_of_day_count = BenefitCheck.group_by_hour_of_day("created_at", format: '%l %p').count
-    end
   end
 
   def load_waiting_applications
@@ -47,15 +38,5 @@ class HomeController < ApplicationController
 
   def waiting_for_part_payment
     Query::WaitingForPartPayment.new(current_user).find
-  end
-
-  def load_graph_data
-    @report_data = []
-    Office.non_digital.each do |office|
-      @report_data << {
-        name: office.name,
-        benefit_checks: BenefitCheck.by_office_grouped_by_type(office.id).checks_by_day
-      }
-    end
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,6 +21,11 @@ class ReportsController < ApplicationController
     end
   end
 
+  def graphs
+    authorize :report, :graphs?
+    load_graph_data
+  end
+
   private
 
   def form
@@ -32,5 +37,15 @@ class ReportsController < ApplicationController
 
   def report_params
     params.require(:forms_finance_report).permit(:date_from, :date_to)
+  end
+
+  def load_graph_data
+    @report_data = []
+    Office.non_digital.each do |office|
+      @report_data << {
+        name: office.name,
+        benefit_checks: BenefitCheck.by_office_grouped_by_type(office.id).checks_by_day
+      }
+    end
   end
 end

--- a/app/views/home/_graphs.html.slim
+++ b/app/views/home/_graphs.html.slim
@@ -7,9 +7,8 @@
     .columns.small-12
       h2 Time of day
       = column_chart @time_of_day_count, { library: { title: 'Checks by time of day', width: '200px' } }
-  -if @report_data.present?
-    .row
-      -@report_data.each do |data|
-        .columns.small-12.medium-8.large-6.end
-          h3 #{data[:name]} R1
-          = column_chart data[:benefit_checks], colors: ['#dc3912', '#109618', '#ff9900', '#dd4477', '#990099', '#3366cc', '#0099c6'], library: { isStacked: true, title: 'Checks made by date (last 7 days)', vAxis: { format: '#' } }
+
+  .row.collapse
+    .columns.small-12
+      h2 5 day benefit check/court graphs
+      =link_to 'Court graphs', graphs_report_path

--- a/app/views/reports/graphs.html.slim
+++ b/app/views/reports/graphs.html.slim
@@ -1,0 +1,9 @@
+= content_for(:javascript) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
+
+-if policy(:report).graphs?
+  - if @report_data.present?
+    .row
+      - @report_data.each do |data|
+        .columns.small-12.medium-8.large-6.end
+          h3 #{data[:name]} R1
+          = column_chart data[:benefit_checks], colors: ['#dc3912', '#109618', '#ff9900', '#dd4477', '#990099', '#3366cc', '#0099c6'], library: { isStacked: true, title: 'Checks made by date (last 7 days)', vAxis: { format: '#' } }

--- a/app/views/reports/index.html.slim
+++ b/app/views/reports/index.html.slim
@@ -7,4 +7,7 @@ header
       dt =link_to 'Finance report', reports_finance_report_path
       dl
         div Date delimited report of financial expenditure
-        div Something, something, put content here
+      - if policy(:report).graphs?
+        dt =link_to 'Graphs', graphs_report_path
+        dl
+          div 5 day graphs for benefit checks by business unit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
 
   get 'reports' => 'reports#index'
   get 'reports/finance_report' => 'reports#finance_report'
+  get 'reports/graphs' => 'reports#graphs', as: :graphs_report
   put 'reports/finance_report' => 'reports#finance_report_generator'
 
   get '/applications/new' => 'applications/build#create'

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -36,9 +36,6 @@ RSpec.describe HomeController, type: :controller do
         it 'returns http success' do
           expect(response).to have_http_status(:success)
         end
-        it 'populates a list of report_data' do
-          expect(assigns(:report_data).count).to eql(2)
-        end
       end
     end
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -52,5 +52,19 @@ RSpec.describe ReportsController, type: :controller do
         expect(response.headers['Content-Type']).to include('text/csv')
       end
     end
+
+    describe 'GET #graphs' do
+      before { get :graphs }
+
+      subject { response }
+
+      it { is_expected.to have_http_status(:success) }
+
+      it { is_expected.to render_template :graphs }
+
+      it 'populates a list of report_data' do
+        expect(assigns(:report_data).count).to eql(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
As the number of offices has grown, the index page for admins has slowed
down more and more.

This PR aims to make it faster while still allowing relatively quick access to the data

I have migrated the graphs to the reports controller and 
provided a link to new action on front page

<img width="969" alt="screen shot 2016-01-25 at 11 31 06" src="https://cloud.githubusercontent.com/assets/6757677/12549733/286f6c2c-c357-11e5-83c1-ce9c1134e2b8.png">


