### PR TITLE
Make button sizes consistent across the application

### DIFF
--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -3,7 +3,7 @@ var FR = FR || {};
 FR.login = {
   init: function() {
     var self = this,
-        $form = $('form.new_user');
+        $form = $('form.new_user[action$="users/sign_in"]');
 
     if ($form.length) {
       self.checkLoginCookie();

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -204,14 +204,13 @@ a.button.alternative{
   border-top: 5px solid $govuk-blue;
   padding:$gutter-half $gutter-half/2 0;
 }
-input.small-field{
-    width:50%;
-    @media screen and (max-width: upper-bound($small-range)) {
-      width:100%;
-      border:10px solid red;
+input.small-field {
+    width: 50%;
+    @media #{$small-only} {
+      width: 100%;
     }
 }
-input.medium-field{
-    width:70%;
+input.medium-field {
+    width: 70%;
 }
 

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -18,6 +18,10 @@
     margin-top: 30px;
     margin-bottom: 50px;
   }
+
+  @media #{$small-only} {
+    width: 100%;
+  }
 }
 
 // Disabled buttons

--- a/app/views/evidence/show.html.slim
+++ b/app/views/evidence/show.html.slim
@@ -11,7 +11,7 @@ header
           span.summary.primary If the evidence can’t be processed
         div.panel-indent.util_mb-0.util_mt-0
           p Evidence needs to arrive by <strong>#{@processing_details.expires.to_s(:gov_uk_long)}</strong> for this application. If you’re unable to process evidence, choose ‘Return application’ to remove it from ‘Applications waiting for evidence' and return everything to the applicant.
-          = link_to 'Return application', evidence_return_letter_path(@evidence), class: 'button alternative util_mb-0'
+          = link_to 'Return application', evidence_return_letter_path(@evidence), class: 'button alternative small util_mb-0'
 
 =build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status]
 =build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name]

--- a/app/views/evidence/summary.html.slim
+++ b/app/views/evidence/summary.html.slim
@@ -9,4 +9,4 @@
   =build_section 'Result', @result, %w[savings income]
 
   =render(partial: 'shared/remission_type', locals: { source: @result })
-  = f.submit 'Complete processing', :class => 'button primary'
+  = f.submit 'Complete processing', :class => 'button primary large'

--- a/app/views/feedback/_form.html.slim
+++ b/app/views/feedback/_form.html.slim
@@ -82,8 +82,8 @@
           #extra
             .label.inline Please enter details
             = text_field_tag 'feedback[help]'
-  .actions
-    = f.submit 'Send feedback', class: 'button primary'
+
+  = f.submit 'Send feedback', class: 'button primary'
 
 javascript:
   $(document).ready( function() {

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -29,7 +29,7 @@
           - if current_user.office.jurisdictions.empty?
             p Please ask your manager to assign jurisdictions to your office.
           - else
-            .actions.util_mt-0
+            .util_mt-0
               =link_to 'Start now', create_applications_path, method: :post, class: 'button util_mb-0'
 
 - if policy(:application).index?

--- a/app/views/offices/_form.html.slim
+++ b/app/views/offices/_form.html.slim
@@ -23,4 +23,4 @@
                   = b.check_box
                   = "#{b.text} (#{@becs[b.value]})"
 
-  .actions = f.submit class: 'button'
+  = f.submit class: 'button'

--- a/app/views/part_payments/show.html.slim
+++ b/app/views/part_payments/show.html.slim
@@ -11,7 +11,7 @@ header
           span.summary.primary If the part-payment can’t be processed
         div.panel-indent.util_mb-0.util_mt-0
           p Part-payment needs to arrive by <strong>#{@processing_details.expires.to_s(:gov_uk_long)}</strong> for this application. If you’re unable to process the payment, choose ‘Return application’ to remove it from ‘Applications waiting for part-payment' and return everything to the applicant.
-          = link_to 'Return application', return_letter_part_payment_path(@part_payment), class: 'button alternative util_mb-0'
+          = link_to 'Return application', return_letter_part_payment_path(@part_payment), class: 'button alternative small util_mb-0'
 
 =build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status]
 =build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name]

--- a/app/views/users/invitations/edit.html.slim
+++ b/app/views/users/invitations/edit.html.slim
@@ -4,5 +4,4 @@ header
 = form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f|
   = f.hidden_field :invitation_token
   =render(partial: '/users/shared/change_password', locals: { f: f })
-  .actions
-    = f.submit t("devise.invitations.edit.submit_button"), class: 'button'
+  = f.submit t("devise.invitations.edit.submit_button"), class: 'button'

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -17,5 +17,4 @@ header
         = f.label :password_confirmation
         = f.label :password_confirmation, resource.errors[:password_confirmation].join(', ').html_safe, class: 'error' if resource.errors[:password_confirmation].present?
         = f.password_field :password_confirmation, autofocus: true, autocomplete: "off"
-  .actions
-    = f.submit t('devise.invitations.edit.submit_button'), class: 'button'
+  = f.submit t('devise.invitations.edit.submit_button'), class: 'button'

--- a/app/views/users/passwords/new.html.slim
+++ b/app/views/users/passwords/new.html.slim
@@ -9,7 +9,6 @@ header
         = f.label :email
         = f.label :email, resource.errors[:email].join('').html_safe, class: 'error' if resource.errors[:email].present?
         = f.text_field :email, { class: 'form-control' }
-  .actions
-    = f.submit t('devise.passwords.new.submit_button'), class: 'button'
+  = f.submit t('devise.passwords.new.submit_button'), class: 'button'
 hr
 = render "users/shared/links"

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -15,8 +15,7 @@
           .form-group
             = f.label :password
             = f.password_field :password, autocomplete: "off"
-      .actions
-        = f.submit "Sign in", class: 'button'
+      = f.submit "Sign in", class: 'button'
       .actions
         = link_to "Forgot your password?", new_password_path(resource_name)
 

--- a/app/views/users/shared/_form.html.slim
+++ b/app/views/users/shared/_form.html.slim
@@ -7,7 +7,7 @@
         = f.text_field :name, { class: 'form-control' }
   .row
     .small-12.columns
-      .form-group style="margin-bottom:16px;"
+      .form-group.util_mb-small
         .row
           .columns.small-12.medium-8.large-5
             = f.label :email
@@ -19,5 +19,5 @@
 
   = render(partial: 'users/shared/form_jurisdiction', locals: {f: f})
 
-  .actions = f.submit 'Save changes', class: 'button'
+  = f.submit 'Save changes', class: 'button'
 

--- a/app/views/users/shared/_form_roles.html.slim
+++ b/app/views/users/shared/_form_roles.html.slim
@@ -1,18 +1,18 @@
 .row
   .columns.small-12.medium-8.large-5.columns.form-group
-    .form-group
-      = f.label(:roles, 'Role')
-      = f.label :roles, @user.errors[:role].join(', ').html_safe, class: 'error' if @user.errors[:role].present?
-      -if current_user.elevated?
-        .row.collapse
-          .columns.small-4.large-2
-          - if (@user.manager? && (@user == current_user))
+    = f.label(:roles, 'Role')
+    = f.label :roles, @user.errors[:role].join(', ').html_safe, class: 'error' if @user.errors[:role].present?
+    -if current_user.elevated?
+      .row.collapse
+        .columns.small-4.large-2
+        - if (@user.manager? && (@user == current_user))
+          .util_mb-small
             = current_user.role.humanize
-          - else
-            .options.radio
-              =collection_radio_buttons(:user, :role, @roles, :to_s, :humanize) do |b|
-                = b.label do
-                  = b.radio_button(class: 'form-control')
-                  = b.text
-      -else
-        .form-control #{@user.role.humanize}
+        - else
+          .options.radio
+            =collection_radio_buttons(:user, :role, @roles, :to_s, :humanize) do |b|
+              = b.label do
+                = b.radio_button(class: 'form-control')
+                = b.text
+    -else
+      .form-control.util_mb-small #{@user.role.humanize}


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/112236157)

I think I've caught everything here - best if @kelliematheson checks though...

* make all green buttons the same size across the application, except
* 'Complete processing' on the three summary pages should be large, and
* blue 'Return application' and 'Delete application' buttons should use class `small` for smaller font size
