### PR TITLE
BECs labelling update

### DIFF
--- a/app/views/business_entities/edit.html.slim
+++ b/app/views/business_entities/edit.html.slim
@@ -4,13 +4,13 @@ h2 Edit #{business_entity.name} business entity
   .row
     .small-12.medium-8.large-5.columns
       .form-group
-        = f.label :name
-        = f.label :name, business_entity.errors[:name].join(', '), class: 'error' if business_entity.errors[:name].present?
-        = f.text_field :name, { class: 'form-control' }
-      .form-group
         = f.label :code
         = f.label :code, business_entity.errors[:code].join(', '), class: 'error' if business_entity.errors[:code].present?
         = f.text_field :code, { class: 'form-control' }
+      .form-group
+        = f.label :name
+        = f.label :name, business_entity.errors[:name].join(', '), class: 'error' if business_entity.errors[:name].present?
+        = f.text_field :name, { class: 'form-control' }
   .pad-top-fifteen-px.row
     .columns.small-12.medium-8.large-5
       .important-notice

--- a/app/views/business_entities/index.html.slim
+++ b/app/views/business_entities/index.html.slim
@@ -2,8 +2,8 @@ h2 Business Entities for #{office.name}
 
 .row
   .columns.small-3.bold Jurisdiction
-  .columns.small-2.bold BEC
-  .columns.small-4.bold.end BEC Description
+  .columns.small-2.bold =t('activerecord.attributes.business_entity.code')
+  .columns.small-4.bold.end =t('activerecord.attributes.business_entity.name')
 #result_table
   -@jurisdictions.each do |j|
     .row
@@ -16,7 +16,7 @@ h2 Business Entities for #{office.name}
       .columns.small-3.text-right
         -case j.status
           -when 'delete'
-            =link_to 'Delete', deactivate_office_business_entity_path(office, id: j.business_entity_id)
+            =link_to 'Deactivate', deactivate_office_business_entity_path(office, id: j.business_entity_id)
             =link_to 'Update', edit_office_business_entity_path(office, id: j.business_entity_id)
           -when 'edit'
             =link_to 'Update', edit_office_business_entity_path(office, id: j.business_entity_id)

--- a/app/views/business_entities/new.html.slim
+++ b/app/views/business_entities/new.html.slim
@@ -4,13 +4,13 @@ h2 New business entity for #{jurisdiction.name} in #{office.name}
   .row
     .small-12.medium-8.large-5.columns
       .form-group
-        = f.label :name
-        = f.label :name, business_entity.errors[:name].join(', '), class: 'error' if business_entity.errors[:name].present?
-        = f.text_field :name, { class: 'form-control' }
-      .form-group
         = f.label :code
         = f.label :code, business_entity.errors[:code].join(', '), class: 'error' if business_entity.errors[:code].present?
         = f.text_field :code, { class: 'form-control' }
+      .form-group
+        = f.label :name
+        = f.label :name, business_entity.errors[:name].join(', '), class: 'error' if business_entity.errors[:name].present?
+        = f.text_field :name, { class: 'form-control' }
         = f.hidden_field :office_id, value: office.id
         = f.hidden_field :jurisdiction_id, value: jurisdiction.id
   .actions = f.submit class: 'button'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -430,6 +430,9 @@ en-GB:
         new_password: New password
         new_password_hint: Use at least 8 numbers or letters for your password.
         password_confirmation: Confirm new password
+      business_entity:
+        name: BEC description
+        code: BEC
       feedback:
         experience: 'What is your experience of using the service so far?'
         ideas: 'Do you have any ideas for how this service could be improved?'

--- a/spec/features/admin_can_maintain_business_entities_spec.rb
+++ b/spec/features/admin_can_maintain_business_entities_spec.rb
@@ -42,8 +42,8 @@ RSpec.feature 'Business entity management:', type: :feature do
         expect(page).to have_xpath('//a', text: 'Update', count: 2)
       end
 
-      scenario 'it displays expected delete links' do
-        expect(page).to have_xpath('//a', text: 'Delete', count: 1)
+      scenario 'it displays expected deactivate links' do
+        expect(page).to have_xpath('//a', text: 'Deactivate', count: 1)
       end
 
       scenario 'it displays expected addition link' do
@@ -97,7 +97,7 @@ RSpec.feature 'Business entity management:', type: :feature do
 
       context 'by deleting' do
         before do
-          click_link 'Delete'
+          click_link 'Deactivate'
           click_button 'Deactivate'
         end
 
@@ -105,8 +105,8 @@ RSpec.feature 'Business entity management:', type: :feature do
           expect(page).to have_xpath('//a', text: 'Add', count: 2)
         end
 
-        scenario 'no more jurisdictions can be added' do
-          expect(page).to have_no_xpath('//a', text: 'delete')
+        scenario 'no more jurisdictions can be deactivated' do
+          expect(page).to have_no_xpath('//a', text: 'Deactivate')
         end
       end
     end


### PR DESCRIPTION
The `Delete` button took users to a `deactivate` view.

The index page columns was titled BEC description, the edit page called the field Name

Index column sequence was code > name, the edit view was name > code.

These have all been resolved.