### PR TITLE
Restore graph data for admin

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,7 @@ class HomeController < ApplicationController
 
   def index
     manager_setup_progress
+    load_graphs_for_admin
     load_waiting_applications
   end
 
@@ -11,6 +12,13 @@ class HomeController < ApplicationController
   def manager_setup_progress
     manager_setup = ManagerSetup.new(current_user, session)
     manager_setup.finish! if manager_setup.in_progress?
+  end
+
+  def load_graphs_for_admin
+    if current_user.admin?
+      @total_type_count = BenefitCheck.group(:dwp_result).count
+      @time_of_day_count = BenefitCheck.group_by_hour_of_day("created_at", format: '%l %p').count
+    end
   end
 
   def load_waiting_applications


### PR DESCRIPTION
During a rather too agressive refactoring, all of the code for
the collation of graph data was moved to the reports controller
and subsequently deleted when it was not needed.

This returns the two front page graphs to their correct state.

[finishes #112616861]