### PR TITLE
Prevent deleted user errors

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,11 +14,9 @@ module Users
     end
 
     def create
-      user_for_authorisation
       authorize user_for_authorisation
-      if user_for_authorisation.deleted?
+      if @user.deleted?
         flash[:alert] = t('devise.invitations.user_exists', email: Settings.mail.tech_support)
-        @user = user_for_authorisation
         render :new
       else
         super
@@ -40,7 +38,7 @@ module Users
     end
 
     def user_for_authorisation
-      deleted_user_exists? || User.new(invite_params)
+      @user ||= deleted_user_exists? || User.new(invite_params)
     end
 
     def deleted_user_exists?

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,10 +14,15 @@ module Users
     end
 
     def create
-      user_for_authorisation = User.new(invite_params)
+      user_for_authorisation
       authorize user_for_authorisation
-
-      super
+      if user_for_authorisation.deleted?
+        flash[:alert] = t('devise.invitations.user_exists')
+        @user = user_for_authorisation
+        render :new
+      else
+        super
+      end
     end
 
     private
@@ -32,6 +37,14 @@ module Users
 
     def invite_params
       params.require(:user).permit(:email, :role, :name, :office_id)
+    end
+
+    def user_for_authorisation
+      deleted_user_exists? || User.new(invite_params)
+    end
+
+    def deleted_user_exists?
+      User.with_deleted.find_by(email: invite_params[:email])
     end
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -17,7 +17,7 @@ module Users
       user_for_authorisation
       authorize user_for_authorisation
       if user_for_authorisation.deleted?
-        flash[:alert] = t('devise.invitations.user_exists')
+        flash[:alert] = t('devise.invitations.user_exists', email: Settings.mail.tech_support)
         @user = user_for_authorisation
         render :new
       else

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -3,7 +3,7 @@ en-GB:
     failure:
       invited: 'You have a pending invitation, accept it to finish creating your account.'
     invitations:
-      user_exists: 'That user has previously been deleted, please contact support to restore them'
+      user_exists: "That user has previously been deleted, please  <a href='mailto:%{email}?subject=Restore%20user'>contact us</a> to restore them"
       send_instructions: 'An invitation email has been sent to %{email}.'
       invitation_token_invalid: 'The invitation token provided is not valid!'
       updated: 'Your password was set successfully. You are now signed in.'

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -3,6 +3,7 @@ en-GB:
     failure:
       invited: 'You have a pending invitation, accept it to finish creating your account.'
     invitations:
+      user_exists: 'That user has previously been deleted, please contact support to restore them'
       send_instructions: 'An invitation email has been sent to %{email}.'
       invitation_token_invalid: 'The invitation token provided is not valid!'
       updated: 'Your password was set successfully. You are now signed in.'

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Users::InvitationsController, type: :controller do
         end
 
         it 'renders a flash warning' do
-          expect(flash[:alert]).to eql('That user has previously been deleted, please contact support to restore them')
+          expect(flash[:alert]).to include('That user has previously been deleted')
         end
       end
     end

--- a/spec/controllers/users/invitations_controller_spec.rb
+++ b/spec/controllers/users/invitations_controller_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe Users::InvitationsController, type: :controller do
           }.to raise_error Pundit::NotAuthorizedError
         end
       end
+
+      context 'when manager tries to invite a deleted user' do
+        let!(:deleted_user) { create :deleted_user, email: user.email, office: office }
+
+        before { post :create, user: manager_invitation }
+
+        it 'restores and invites the user' do
+          expect(response).to render_template(:new)
+        end
+
+        it 'renders a flash warning' do
+          expect(flash[:alert]).to eql('That user has previously been deleted, please contact support to restore them')
+        end
+      end
     end
 
     context 'Admin user' do

--- a/spec/features/user_invite_spec.rb
+++ b/spec/features/user_invite_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'User management,', type: :feature do
       end
 
       scenario 'the deleted user warning is shown' do
-        expect(page).to have_content('That user has previously been deleted, please contact support to restore them')
+        expect(page).to have_content('That user has previously been deleted')
       end
     end
   end

--- a/spec/features/user_invite_spec.rb
+++ b/spec/features/user_invite_spec.rb
@@ -50,5 +50,25 @@ RSpec.feature 'User management,', type: :feature do
       expect(page).to have_xpath('//div[contains(@class, "field_with_errors")]/label[@for="user_email" and @class="error"]', text: /not able to create an account with this email address/)
       expect(page).to have_xpath("//input[@value='#{new_email}']")
     end
+
+    context 'when inviting user that has been deleted' do
+      let!(:deleted_user) { create :deleted_user }
+
+      before do
+        login_as(admin_user, scope: :user)
+        visit new_user_invitation_path
+
+        fill_in 'user_email', with: deleted_user.email
+        fill_in 'user_name', with: deleted_user.name
+        select('User', from: 'user_role')
+        select('Bristol', from: 'user_office_id')
+
+        click_button 'Send an invitation'
+      end
+
+      scenario 'the deleted user warning is shown' do
+        expect(page).to have_content('That user has previously been deleted, please contact support to restore them')
+      end
+    end
   end
 end


### PR DESCRIPTION
Show warning message when deleted user is invited

This should prevent the `PG::UniqueViolation: ERROR:  duplicate key
value violates unique constraint "index_users_on_email"` sentry warnings.