### PR TITLE
Don't raise error on date_fee_paid validation

### DIFF
--- a/app/models/forms/application/detail.rb
+++ b/app/models/forms/application/detail.rb
@@ -41,7 +41,7 @@ module Forms
         }
       end
 
-      with_options if: :refund? do
+      with_options if: :validate_date_fee_paid? do
         validates :date_fee_paid, date: {
           after_or_equal_to: :min_refund_date,
           before_or_equal_to: :max_refund_date,
@@ -65,6 +65,10 @@ module Forms
 
       def max_refund_date
         date_received unless date_received.blank?
+      end
+
+      def validate_date_fee_paid?
+        refund? && (date_received.is_a?(Date) || date_received.is_a?(Time))
       end
 
       def tomorrow

--- a/spec/features/applications/application_form_application_details_spec.rb
+++ b/spec/features/applications/application_form_application_details_spec.rb
@@ -70,7 +70,9 @@ RSpec.feature 'Completing the application details page of an application form', 
           before { click_button 'Next' }
 
           scenario 'renders errors' do
-            expect(page).to have_xpath('//label[@class="error"]', count: '3')
+            # The date_fee_paid can't be validated until date_received is filled in,
+            # therefore there's no error for that field
+            expect(page).to have_xpath('//label[@class="error"]', count: '2')
           end
         end
       end


### PR DESCRIPTION
The field is now not validated until `date_received` is a valid date. 

The error message on `date_received` field is not ideal, because if the format is incorrect, it simply says "The application must have been made in the last 3 months". We should create a new card to improve that message in case of an incorrect date. 

The `date_validator` would work well in case of being used with `ActiveRecord`, which provides `...before_type_cast` methods. But because we're only using `ActiveModel` and `Virtus`, that gem doesn't work as expected. But I think we can achieve similar thing maybe using a **custom Virtus coercer** or so.