### PR TITLE
Update evidence accuracy error handling

### DIFF
--- a/app/views/shared/forms/_accuracy.html.slim
+++ b/app/views/shared/forms/_accuracy.html.slim
@@ -1,6 +1,7 @@
 = form_for form, as: model, url: url, method: :post, html: { autocomplete: 'off', id: 'accuracy-form' } do |f|
   .form-group
     = f.label :correct, t("#{model}.labels.correct")
+    = f.label :correct, form.errors[:correct].join(', '), class: 'error' if form.errors[:correct].present?
     .options.radio
       .option
         label for="#{model}_correct_true"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -402,6 +402,10 @@ en-GB:
           attributes:
             correct:
               inclusion: 'You need to say whether the evidence can be processed'
+        forms/part_payment/accuracy:
+          attributes:
+            correct:
+              inclusion: 'You need to say whether the part payment can be processed'
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,10 @@ en-GB:
               inclusion: Confirm if the evidence is correct
             incorrect_reason:
               blank: Describe the problem
+        forms/evidence/accuracy:
+          attributes:
+            correct:
+              inclusion: 'You need to say whether the evidence can be processed'
   activerecord:
     errors:
       models:


### PR DESCRIPTION
When the user submitted the evidence/accuracy page without
checking either checkbox, the boxes were highlighted in red,
but no error was shown.
<img width="439" alt="screen shot 2016-02-03 at 10 17 57" src="https://cloud.githubusercontent.com/assets/6757677/12779403/aff62f82-ca5f-11e5-8919-97fd6c19711f.png">
This has added an error message to the view and set the text in the
locale file.
<img width="426" alt="screen shot 2016-02-03 at 10 19 39" src="https://cloud.githubusercontent.com/assets/6757677/12779411/bc5dfea8-ca5f-11e5-89c9-89ac910f08fa.png">
