### PR TITLE
BEC fixes

### DIFF
--- a/app/helpers/flash_message_helper.rb
+++ b/app/helpers/flash_message_helper.rb
@@ -8,4 +8,14 @@ module FlashMessageHelper
       end.to_sentence(two_words_connector: ' or ', last_word_connector: ' or ')
     end
   end
+
+  def format_managers_combined_contacts(managers, start_sentence = false)
+    if managers.empty?
+      start_sentence ? 'A manager' : 'a manager'
+    else
+      link_text = 'managers'
+      link_text = link_text.capitalize! if start_sentence
+      "<a href='#{managers.map(&:email).join(';')}'>#{link_text}</a>"
+    end
+  end
 end

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -8,7 +8,9 @@ class Jurisdiction < ActiveRecord::Base
   validates :abbr, uniqueness: { allow_nil: true }
 
   scope :available_for_office, lambda { |office|
-    joins(:business_entities).where(business_entities: { office: office })
+    joins(:business_entities).
+      where(business_entities: { office: office }).
+      where('valid_to IS NULL')
   }
 
   def display

--- a/app/models/views/office_business_entity_state.rb
+++ b/app/models/views/office_business_entity_state.rb
@@ -37,6 +37,10 @@ module Views
       end
     end
 
+    def sequence
+      lookup_state
+    end
+
     private
 
     def can_be_updated?
@@ -50,5 +54,12 @@ module Views
     def can_be_added?
       @business_entity.nil?
     end
+
+    def lookup_state
+      { 'delete' => 0,
+        'edit' => 1,
+        'add' => 2 }[status]
+    end
+
   end
 end

--- a/app/views/business_entities/deactivate.html.slim
+++ b/app/views/business_entities/deactivate.html.slim
@@ -4,5 +4,5 @@ h2 Deactivate #{business_entity.name} for #{office.name}
   .pad-top-fifteen-px.row
     .columns.small-12.medium-8
       .important-notice
-        p = t('business_entities.deactivate_warning', office: office.name)
+        p = t('business_entities.deactivate_warning', office: office.name, today_date: Date.today)
   .actions = f.submit 'Deactivate', class: 'button'

--- a/app/views/business_entities/edit.html.slim
+++ b/app/views/business_entities/edit.html.slim
@@ -1,4 +1,4 @@
-h2 Edit #{business_entity.name} business entity
+h2 Edit business entity
 
 = form_for [office, business_entity], method: :put do |f|
   .row

--- a/app/views/business_entities/index.html.slim
+++ b/app/views/business_entities/index.html.slim
@@ -10,7 +10,7 @@ h2 Business entities for #{office.name}
       .row
         .columns.small-12
           .important-notice
-            p = t('business_entities.remove_warning_html', managers: format_managers_contacts(office.managers).html_safe, office: office.name)
+            p = t('business_entities.remove_warning_html', managers: format_managers_combined_contacts(office.managers, true).html_safe, office: office.name)
     -group[1].each do |j|
       .row
         .columns.small-3

--- a/app/views/business_entities/index.html.slim
+++ b/app/views/business_entities/index.html.slim
@@ -5,27 +5,29 @@ h2 Business Entities for #{office.name}
   .columns.small-2.bold =t('activerecord.attributes.business_entity.code')
   .columns.small-4.bold.end =t('activerecord.attributes.business_entity.name')
 #result_table
-  -@jurisdictions.each do |j|
-    .row
-      .columns.small-3
-        =j.jurisdiction_name
-      .columns.small-2
-        =j.business_entity_code
-      .columns.small-4
-        = j.business_entity_name
-      .columns.small-3.text-right
-        -case j.status
-          -when 'delete'
-            =link_to 'Deactivate', deactivate_office_business_entity_path(office, id: j.business_entity_id)
-            =link_to 'Update', edit_office_business_entity_path(office, id: j.business_entity_id)
-          -when 'edit'
-            =link_to 'Update', edit_office_business_entity_path(office, id: j.business_entity_id)
-          -when 'add'
-            =link_to 'Add', new_office_business_entity_path(office, jurisdiction_id: j.jurisdiction_id)
-      - if j.status.eql?('edit')
-        .columns.small-12 id="remove-#{j.jurisdiction_id}"
+  -@jurisdictions.sort_by(&:sequence).group_by(&:sequence).each do |group|
+    -if group[0]==1
+      .row
+        .columns.small-12
           .important-notice
             p = t('business_entities.remove_warning_html', managers: format_managers_contacts(office.managers).html_safe, office: office.name)
+    -group[1].each do |j|
+      .row
+        .columns.small-3
+          =j.jurisdiction_name
+        .columns.small-2
+          =j.business_entity_code
+        .columns.small-4
+          = j.business_entity_name
+        .columns.small-3.text-right
+          -case j.status
+            -when 'delete'
+              =link_to 'Deactivate', deactivate_office_business_entity_path(office, id: j.business_entity_id)
+              =link_to 'Update', edit_office_business_entity_path(office, id: j.business_entity_id)
+            -when 'edit'
+              =link_to 'Update', edit_office_business_entity_path(office, id: j.business_entity_id)
+            -when 'add'
+              =link_to 'Add', new_office_business_entity_path(office, jurisdiction_id: j.jurisdiction_id)
 
 .row.pad-top-thirty-px
   .columns.small-12

--- a/app/views/business_entities/index.html.slim
+++ b/app/views/business_entities/index.html.slim
@@ -1,4 +1,4 @@
-h2 Business Entities for #{office.name}
+h2 Business entities for #{office.name}
 
 .row
   .columns.small-3.bold Jurisdiction

--- a/app/views/offices/_form.html.slim
+++ b/app/views/offices/_form.html.slim
@@ -9,18 +9,23 @@
           = f.text_field :name, { class: 'form-control' }
 
   - if with_jurisdictions
-    .row
-      .small-12.large-6.columns.form-group
-        .row
-          .columns.small-12
-            = f.label :jurisdictions
-            = f.label :jurisdictions, @office.errors[:jurisdictions].join(', ').html_safe, class: 'error' if @office.errors[:jurisdictions].present?
-        .row
-          .options.radio
-            =collection_check_boxes(:office, :jurisdiction_ids, @jurisdictions, :id, :display_full) do |b|
-              .columns.small-12.end
-                = b.label do
-                  = b.check_box
-                  = "#{b.text} (#{@becs[b.value]})"
+    -if @jurisdictions.count.eql?(0)
+      .pad-top-fifteen-px.row
+        .columns.small-12.medium-8.large-5
+            =t('business_entities.not_set')
+    -else
+      .row
+        .small-12.large-6.columns.form-group
+          .row
+            .columns.small-12
+              = f.label :jurisdictions
+              = f.label :jurisdictions, @office.errors[:jurisdictions].join(', ').html_safe, class: 'error' if @office.errors[:jurisdictions].present?
+          .row
+            .options.radio
+              =collection_check_boxes(:office, :jurisdiction_ids, @jurisdictions, :id, :display_full) do |b|
+                .columns.small-12.end
+                  = b.label do
+                    = b.check_box
+                    = "#{b.text} (#{@becs[b.value]})"
 
   = f.submit class: 'button'

--- a/app/views/offices/_form.html.slim
+++ b/app/views/offices/_form.html.slim
@@ -12,7 +12,7 @@
     -if @jurisdictions.count.eql?(0)
       .pad-top-fifteen-px.row
         .columns.small-12.medium-8.large-5
-            =t('business_entities.not_set')
+            =t("#{@current_user.elevated? ? 'manager' : 'user'}_html", scope:'business_entities.not_set', email: Settings.mail.tech_support)
     -else
       .row
         .small-12.large-6.columns.form-group

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,7 @@ en-GB:
       progress: <span class="bold">Emergency application?</span> You can also ask the applicant to provide evidence confirming that they’re receiving benefits.
   business_entities:
     edit_warning: "Changing the code above will mean staff in %{office} will be issuing references with the new code and this may cause duplication in the financial reports."
-    remove_warning_html: "This jurisdiction is currently in use at the court and cannot be removed.  You will need to contact %{managers} at %{office} to stop using it before you can delete the BEC"
+    remove_warning_html: "The following jurisdictions are currently in use at the court and cannot be removed.  You will need to contact %{managers} at %{office} to stop using them before you can deactivate any of them"
     deactivate_warning: "Deactivating this jurisdiction will remove it from the list of jurisdictions that %{office} can record new applications against.  All applications that have already been created will still be recorded on the relevant reports."
   remissions:
     full: '✓ &nbsp; The applicant doesn’t have to pay the fee'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,10 +147,10 @@ en-GB:
       explain: There’s a technical fault with the Department for Work and Pensions checker. Complete processing and check again later.
       progress: <span class="bold">Emergency application?</span> You can also ask the applicant to provide evidence confirming that they’re receiving benefits.
   business_entities:
-    not_set: 'You will need to contact HMCTS finance to get business entity codes set before you can choose jurisdictions'
-    edit_warning: "Changing the code above will mean staff in %{office} will be issuing references with the new code and this may cause duplication in the financial reports."
-    remove_warning_html: "The following jurisdictions are currently in use at the court and cannot be removed.  You will need to contact %{managers} at %{office} to stop using them before you can deactivate any of them"
-    deactivate_warning: "Deactivating this jurisdiction will remove it from the list of jurisdictions that %{office} can record new applications against.  All applications that have already been created will still be recorded on the relevant reports."
+    not_set: "Email helpwithfees.support@digital.justice.gov.uk to get jurisdictions and business entity codes (BEC) assigned. You'll then be able to select them from this page." 
+    edit_warning: "Creating a new code for %{office} means that more than 1 code may appear in financial reports."
+    remove_warning_html: "%{managers} at %{office} need to unselect these jurisdictions before you can deactivate them."
+    deactivate_warning: "Deactivating this jurisdiction will remove it from the list that %{office} can use. It will still be displayed for any applications processed before %{today_date}."
   remissions:
     full: '✓ &nbsp; The applicant doesn’t have to pay the fee'
     part: The applicant must pay %{amount_to_pay} towards the fee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,8 +147,9 @@ en-GB:
       explain: There’s a technical fault with the Department for Work and Pensions checker. Complete processing and check again later.
       progress: <span class="bold">Emergency application?</span> You can also ask the applicant to provide evidence confirming that they’re receiving benefits.
   business_entities:
-    manager_not_set: "Email helpwithfees.support@digital.justice.gov.uk to get jurisdictions and business entity codes (BEC) assigned. You'll then be able to select them from this page." 
-    user_not_set: "Jursidictions and business entity codes need to be set up for your office. Contact your manager to do this."
+    not_set:
+      manager_html: "Email <a href='mailto:%{email}'>%{email}</a> to get jurisdictions and business entity codes (BEC) assigned. You'll then be able to select them from this page."
+      user_html: "Jursidictions and business entity codes need to be set up for your office. Contact your manager to do this."
     edit_warning: "Creating a new code for %{office} means that more than 1 code may appear in financial reports."
     remove_warning_html: "%{managers} at %{office} need to unselect these jurisdictions before you can deactivate them."
     deactivate_warning: "Deactivating this jurisdiction will remove it from the list that %{office} can use. It will still be displayed for any applications processed before %{today_date}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,7 +147,8 @@ en-GB:
       explain: There’s a technical fault with the Department for Work and Pensions checker. Complete processing and check again later.
       progress: <span class="bold">Emergency application?</span> You can also ask the applicant to provide evidence confirming that they’re receiving benefits.
   business_entities:
-    not_set: "Email helpwithfees.support@digital.justice.gov.uk to get jurisdictions and business entity codes (BEC) assigned. You'll then be able to select them from this page." 
+    manager_not_set: "Email helpwithfees.support@digital.justice.gov.uk to get jurisdictions and business entity codes (BEC) assigned. You'll then be able to select them from this page." 
+    user_not_set: "Jursidictions and business entity codes need to be set up for your office. Contact your manager to do this."
     edit_warning: "Creating a new code for %{office} means that more than 1 code may appear in financial reports."
     remove_warning_html: "%{managers} at %{office} need to unselect these jurisdictions before you can deactivate them."
     deactivate_warning: "Deactivating this jurisdiction will remove it from the list that %{office} can use. It will still be displayed for any applications processed before %{today_date}."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en-GB:
       explain: There’s a technical fault with the Department for Work and Pensions checker. Complete processing and check again later.
       progress: <span class="bold">Emergency application?</span> You can also ask the applicant to provide evidence confirming that they’re receiving benefits.
   business_entities:
+    not_set: 'You will need to contact HMCTS finance to get business entity codes set before you can choose jurisdictions'
     edit_warning: "Changing the code above will mean staff in %{office} will be issuing references with the new code and this may cause duplication in the financial reports."
     remove_warning_html: "The following jurisdictions are currently in use at the court and cannot be removed.  You will need to contact %{managers} at %{office} to stop using them before you can deactivate any of them"
     deactivate_warning: "Deactivating this jurisdiction will remove it from the list of jurisdictions that %{office} can record new applications against.  All applications that have already been created will still be recorded on the relevant reports."

--- a/spec/helpers/flash_message_helper_spec.rb
+++ b/spec/helpers/flash_message_helper_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe FlashMessageHelper, type: :helper do
+
+  it { expect(helper).to be_a described_class }
+
+  describe '#format_managers_combined_contacts' do
+    context ' when not expected to start a sentence' do
+      subject { helper.format_managers_combined_contacts(managers) }
+
+      context 'when passed a collection of Users' do
+        let(:managers) { create_list :manager, 2 }
+        it 'returns a single html mailto link with all managers' do
+          is_expected.to eql("<a href='user_1@digital.justice.gov.uk;user_2@digital.justice.gov.uk'>managers</a>")
+        end
+      end
+
+      context 'when passed no users' do
+        let(:managers) { [] }
+        it 'returns a  string' do
+          is_expected.to eql('a manager')
+        end
+      end
+    end
+
+    context 'when expected to start a sentence' do
+      subject { helper.format_managers_combined_contacts(managers, true) }
+
+      context 'when passed a collection of Users' do
+        let(:managers) { create_list :manager, 2 }
+        it 'returns a single html mailto link with all managers with capitalised text' do
+          is_expected.to eql("<a href='user_1@digital.justice.gov.uk;user_2@digital.justice.gov.uk'>Managers</a>")
+        end
+      end
+
+      context 'when passed no users' do
+        let(:managers) { [] }
+        it 'returns a capitalised string' do
+          is_expected.to eql('A manager')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe Jurisdiction, type: :model do
     it 'includes jurisdictions which have business entity present' do
       is_expected.to eq([jurisdiction2])
     end
+
+    context 'if a business entity is removed' do
+      before { office.business_entities.first.update_attributes(valid_to: Time.zone.now) }
+
+      it 'no longer returns it as available' do
+        is_expected.to match_array []
+      end
+    end
   end
 
   describe 'validation' do

--- a/spec/models/views/office_business_entity_state_spec.rb
+++ b/spec/models/views/office_business_entity_state_spec.rb
@@ -94,4 +94,31 @@ RSpec.describe Views::OfficeBusinessEntityState do
       it { is_expected.to eq 'add' }
     end
   end
+
+  describe '#sequence' do
+    before do
+      office.business_entities.delete_all
+      OfficeJurisdiction.delete_all
+    end
+
+    subject { view.sequence }
+
+    context 'when a business_entity object exists' do
+      before { create :business_entity, office: office, jurisdiction: jurisdiction }
+
+      context 'it is currently in use by the office' do
+        before { create :office_jurisdiction, office: office, jurisdiction: jurisdiction }
+
+        it { is_expected.to eq 1 }
+      end
+
+      context 'it is not currently in use by the office' do
+        it { is_expected.to eq 0 }
+      end
+    end
+
+    context 'when a business_entity object does not exist' do
+      it { is_expected.to eq 2 }
+    end
+  end
 end


### PR DESCRIPTION
A collection of small fixes to BEC handling 
* Show warning on office when no BEC assigned
* Add a state to the view object to allow sorting
* Sort the BEC index so that types of BEC are grouped
* Only show the deactivate warning once on the index page