### PR TITLE
Update locale handling

### DIFF
--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -14,24 +14,20 @@ module I18n
           '%'
         else
           @last_match = Regexp.last_match
-          process_value(string, values)
+          check_value_valid(string, values)
         end
       end
     end
 
-    def process_value(string, values)
-      @key = build_key
+    def check_value_valid(string, values)
+      @key = (@last_match[1] || @last_match[2] || @last_match[4]).to_sym
       if values.key?(@key)
         value = values[@key]
         value = value.call(values) if value.respond_to?(:call)
         build_value(value)
       else
-        raise(MissingInterpolationArgument.new(values, string, ''))
+        raise(MissingInterpolationArgument.new(values, string, @key))
       end
-    end
-
-    def build_key
-      (@last_match[1] || @last_match[2] || @last_match[4]).to_sym
     end
 
     def build_value(value)

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,47 @@
+module I18n
+  # Implemented to support method call on translation keys
+  INTERPOLATION_WITH_METHOD_PATTERN = Regexp.union(
+    /%%/,
+    /%\{(\w+)\}/,
+    /%<(\w+)>(.*?\d*\.?\d*[bBdiouxXeEfgGcps])/,
+    /%\{(\w+)\.(\w+)\}/
+  )
+
+  class << self
+    def interpolate_hash(string, values)
+      string.gsub(INTERPOLATION_WITH_METHOD_PATTERN) do |match|
+        if match == '%%'
+          '%'
+        else
+          @last_match = Regexp.last_match
+          process_value(string, values)
+        end
+      end
+    end
+
+    def process_value(string, values)
+      @key = build_key
+      if values.key?(@key)
+        value = values[@key]
+        value = value.call(values) if value.respond_to?(:call)
+        build_value(value)
+      else
+        raise(MissingInterpolationArgument.new(values, string, ''))
+      end
+    end
+
+    def build_key
+      (@last_match[1] || @last_match[2] || @last_match[4]).to_sym
+    end
+
+    def build_value(value)
+      if @last_match[3]
+        sprintf("%#{@last_match[3]}", value)
+      elsif @last_match[5]
+        value.send(@last_match[5])
+      else
+        value
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en-GB:
+  helpers:
+    submit:
+      create: "Create %{model.downcase}"
+      update: "Update %{model.downcase}"
   convert_boolean:
     :true: 'Yes'
     :false: 'No'

--- a/spec/features/admin_can_maintain_business_entities_spec.rb
+++ b/spec/features/admin_can_maintain_business_entities_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Business entity management:', type: :feature do
           find("a[href='#{button_url}']").click
           fill_in 'business_entity_name', with: new_description
           fill_in 'business_entity_code', with: new_code
-          click_button 'Update Business entity'
+          click_button 'Update business entity'
           business_entity.reload
         end
 
@@ -82,7 +82,7 @@ RSpec.feature 'Business entity management:', type: :feature do
           click_link 'Add'
           fill_in 'business_entity_name', with: new_description
           fill_in 'business_entity_code', with: new_code
-          click_button 'Create Business entity'
+          click_button 'Create business entity'
         end
 
         scenario 'the index page reflects the update' do

--- a/spec/features/manager_out_of_the_box_experience_spec.rb
+++ b/spec/features/manager_out_of_the_box_experience_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature 'Manager has to setup their office and preferences', type: :featur
   def when_they_setup_the_office
     jurisdiction = Jurisdiction.first
     check "#{jurisdiction.display_full} (#{BusinessEntity.where(jurisdiction_id: jurisdiction.id).first.code})"
-    click_button 'Update Office'
+    click_button 'Update office'
   end
 
   def when_whey_setup_their_profile

--- a/spec/lib/i18n_spec.rb
+++ b/spec/lib/i18n_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe I18n do
+  it 'interpolates as usual' do
+    expect(described_class.interpolate('Show %{model}', model: 'Office')).to eql 'Show Office'
+  end
+
+  it 'supports method execution' do
+    expect(described_class.interpolate("Show %{model.downcase}", model: 'Office')).to eql 'Show office'
+  end
+end


### PR DESCRIPTION
Content have requested that the default submit buttons should lower case the model names.

This PR adds an I18n extension that allows us to lower case models within the YML file, instead of having to manually set the text on every submit button on every form.