### PR TITLE
Created application redirect service

### DIFF
--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -2,6 +2,7 @@ module Applications
   # rubocop:disable ClassLength
   class ProcessController < ApplicationController
     before_action :authorise_application_update, except: :create
+    before_action :check_completed_redirect, except: [:create, :confirmation]
 
     def create
       application = ApplicationBuilder.new(current_user).build
@@ -124,6 +125,10 @@ module Applications
 
     def authorise_application_update
       authorize application, :update?
+    end
+
+    def check_completed_redirect
+      redirect_to CompletedApplicationRedirect.new(application).path unless application.created?
     end
 
     def form_params(type)

--- a/app/services/completed_application_redirect.rb
+++ b/app/services/completed_application_redirect.rb
@@ -1,0 +1,20 @@
+class CompletedApplicationRedirect
+  include Rails.application.routes.url_helpers
+
+  def initialize(application)
+    @application = application
+  end
+
+  def path
+    case @application.state
+    when 'processed'
+      processed_application_path(@application)
+    when 'waiting_for_part_payment'
+      part_payment_path(@application.part_payment)
+    when 'waiting_for_evidence'
+      evidence_show_path(@application.evidence_check)
+    when 'deleted'
+      deleted_application_path(@application)
+    end
+  end
+end

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -460,4 +460,62 @@ RSpec.describe Applications::ProcessController, type: :controller do
       expect(assigns(:confirm)).to be_a_kind_of(Views::Confirmation::Result)
     end
   end
+
+  context 'after an application is processed' do
+    let!(:application) { create :application, :processed_state, office: user.office }
+
+    describe 'when accessing the personal_details view' do
+      before { get :personal_information, application_id: application.id }
+
+      subject { response }
+
+      it { is_expected.to have_http_status(:redirect) }
+
+      it { is_expected.to redirect_to(processed_application_path(application)) }
+    end
+  end
+
+  context 'after an application is deleted' do
+    let!(:application) { create :application, :deleted_state, office: user.office }
+
+    describe 'when accessing the personal_details view' do
+      before { get :personal_information, application_id: application.id }
+
+      subject { response }
+
+      it { is_expected.to have_http_status(:redirect) }
+
+      it { is_expected.to redirect_to(deleted_application_path(application)) }
+    end
+  end
+
+  context 'when an application is awaiting evidence' do
+    let!(:application) { create :application, :waiting_for_evidence_state, office: user.office }
+    let!(:evidence) { create :evidence_check, application: application }
+
+    describe 'when accessing the personal_details view' do
+      before { get :personal_information, application_id: application.id }
+
+      subject { response }
+
+      it { is_expected.to have_http_status(:redirect) }
+
+      it { is_expected.to redirect_to(evidence_show_path(evidence)) }
+    end
+  end
+
+  context 'when an application is part_payment' do
+    let(:application) { create :application, :waiting_for_part_payment_state, office: user.office }
+    let!(:part_payment) { create(:part_payment, application: application) }
+
+    describe 'when accessing the personal_details view' do
+      before { get :personal_information, application_id: application.id }
+
+      subject { response }
+
+      it { is_expected.to have_http_status(:redirect) }
+
+      it { is_expected.to redirect_to(part_payment_path(part_payment)) }
+    end
+  end
 end

--- a/spec/services/completed_application_redirect_spec.rb
+++ b/spec/services/completed_application_redirect_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe CompletedApplicationRedirect do
+  include Rails.application.routes.url_helpers
+
+  let(:user) { create :user }
+  let(:service) { described_class.new(application) }
+
+  subject { service.path }
+
+  describe 'when initialised with a processed application' do
+    let(:application) { create :application, :processed_state, office: user.office }
+
+    it { is_expected.to eql processed_application_path(application) }
+  end
+
+  describe 'when initialised with an application awaiting part_payment' do
+    let(:application) { create :application, :waiting_for_part_payment_state, office: user.office }
+    let!(:part_payment) { create(:part_payment, application: application) }
+
+    it { is_expected.to eql part_payment_path(part_payment) }
+  end
+
+  describe 'when initialised with an application awaiting evidence' do
+    let(:application) { create :application, :waiting_for_evidence_state, office: user.office }
+    let!(:evidence) { create :evidence_check, application: application }
+
+    it { is_expected.to eql evidence_show_path(evidence) }
+  end
+
+  describe 'when initialised with a deleted application' do
+    let(:application) { create :application, :deleted_state, office: user.office }
+
+    it { is_expected.to eql deleted_application_path(application) }
+  end
+end


### PR DESCRIPTION
When a user has clicked 'completed processing' on the summary page,
any attempts to view the individual process views should be redirected
to the current state's end point, e.g. deleted, processed, awaiting
payment, awaiting evidence.

The controller calls the service class which returns the relevant path,
this is overridden for create and confirmation to allow new items to be
created(!) and the final page to be re-shown if users need to get the
letters from the view.