### PR TITLE
Force application redirect after completion

### DIFF
--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -128,7 +128,14 @@ module Applications
     end
 
     def check_completed_redirect
+      set_cache_headers
       redirect_to CompletedApplicationRedirect.new(application).path unless application.created?
+    end
+
+    def set_cache_headers
+      response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+      response.headers['Pragma'] = 'no-cache'
+      response.headers['Expires'] = 3.hours.ago.to_formatted_s(:rfc822)
     end
 
     def form_params(type)

--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -129,7 +129,11 @@ module Applications
 
     def check_completed_redirect
       set_cache_headers
-      redirect_to CompletedApplicationRedirect.new(application).path unless application.created?
+      unless application.created?
+        redirect_data = CompletedApplicationRedirect.new(application)
+        flash[:alert] = redirect_data.flash_message
+        redirect_to redirect_data.path
+      end
     end
 
     def set_cache_headers

--- a/app/services/completed_application_redirect.rb
+++ b/app/services/completed_application_redirect.rb
@@ -17,4 +17,8 @@ class CompletedApplicationRedirect
       deleted_application_path(@application)
     end
   end
+
+  def flash_message
+    I18n.t(@application.state, scope: 'application_redirect')
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,11 @@ en-GB:
     error:
       explain: There’s a technical fault with the Department for Work and Pensions checker. Complete processing and check again later.
       progress: <span class="bold">Emergency application?</span> You can also ask the applicant to provide evidence confirming that they’re receiving benefits.
+  application_redirect:
+    processed: 'This application has been processed. You can’t edit any details.'
+    waiting_for_part_payment: 'This application is waiting for part-payment. You can’t edit any details.'
+    waiting_for_evidence: 'This application is waiting for evidence. You can’t edit any details.'
+    deleted: 'This application has been deleted. You can’t edit any details.'
   business_entities:
     not_set:
       manager_html: "Email <a href='mailto:%{email}'>%{email}</a> to get jurisdictions and business entity codes (BEC) assigned. You'll then be able to select them from this page."

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -472,6 +472,10 @@ RSpec.describe Applications::ProcessController, type: :controller do
       it { is_expected.to have_http_status(:redirect) }
 
       it { is_expected.to redirect_to(processed_application_path(application)) }
+
+      it 'is expected to set the flash message' do
+        expect(flash[:alert]).to eql 'This application has been processed. You can’t edit any details.'
+      end
     end
   end
 
@@ -486,6 +490,10 @@ RSpec.describe Applications::ProcessController, type: :controller do
       it { is_expected.to have_http_status(:redirect) }
 
       it { is_expected.to redirect_to(deleted_application_path(application)) }
+
+      it 'is expected to set the flash message' do
+        expect(flash[:alert]).to eql 'This application has been deleted. You can’t edit any details.'
+      end
     end
   end
 
@@ -501,6 +509,10 @@ RSpec.describe Applications::ProcessController, type: :controller do
       it { is_expected.to have_http_status(:redirect) }
 
       it { is_expected.to redirect_to(evidence_show_path(evidence)) }
+
+      it 'is expected to set the flash message' do
+        expect(flash[:alert]).to eql 'This application is waiting for evidence. You can’t edit any details.'
+      end
     end
   end
 
@@ -516,6 +528,10 @@ RSpec.describe Applications::ProcessController, type: :controller do
       it { is_expected.to have_http_status(:redirect) }
 
       it { is_expected.to redirect_to(part_payment_path(part_payment)) }
+
+      it 'is expected to set the flash message' do
+        expect(flash[:alert]).to eql 'This application is waiting for part-payment. You can’t edit any details.'
+      end
     end
   end
 end

--- a/spec/services/completed_application_redirect_spec.rb
+++ b/spec/services/completed_application_redirect_spec.rb
@@ -6,31 +6,63 @@ describe CompletedApplicationRedirect do
   let(:user) { create :user }
   let(:service) { described_class.new(application) }
 
-  subject { service.path }
+  describe '.path' do
+    subject { service.path }
 
-  describe 'when initialised with a processed application' do
-    let(:application) { create :application, :processed_state, office: user.office }
+    describe 'when initialised with a processed application' do
+      let(:application) { create :application, :processed_state, office: user.office }
 
-    it { is_expected.to eql processed_application_path(application) }
+      it { is_expected.to eql processed_application_path(application) }
+    end
+
+    describe 'when initialised with an application awaiting part_payment' do
+      let(:application) { create :application, :waiting_for_part_payment_state, office: user.office }
+      let!(:part_payment) { create(:part_payment, application: application) }
+
+      it { is_expected.to eql part_payment_path(part_payment) }
+    end
+
+    describe 'when initialised with an application awaiting evidence' do
+      let(:application) { create :application, :waiting_for_evidence_state, office: user.office }
+      let!(:evidence) { create :evidence_check, application: application }
+
+      it { is_expected.to eql evidence_show_path(evidence) }
+    end
+
+    describe 'when initialised with a deleted application' do
+      let(:application) { create :application, :deleted_state, office: user.office }
+
+      it { is_expected.to eql deleted_application_path(application) }
+    end
   end
 
-  describe 'when initialised with an application awaiting part_payment' do
-    let(:application) { create :application, :waiting_for_part_payment_state, office: user.office }
-    let!(:part_payment) { create(:part_payment, application: application) }
+  describe '.flash_message' do
+    subject { service.flash_message }
 
-    it { is_expected.to eql part_payment_path(part_payment) }
-  end
+    describe 'when initialised with a processed application' do
+      let(:application) { create :application, :processed_state, office: user.office }
 
-  describe 'when initialised with an application awaiting evidence' do
-    let(:application) { create :application, :waiting_for_evidence_state, office: user.office }
-    let!(:evidence) { create :evidence_check, application: application }
+      it { is_expected.to eql 'This application has been processed. You can’t edit any details.' }
+    end
 
-    it { is_expected.to eql evidence_show_path(evidence) }
-  end
+    describe 'when initialised with an application awaiting part_payment' do
+      let(:application) { create :application, :waiting_for_part_payment_state, office: user.office }
+      let!(:part_payment) { create(:part_payment, application: application) }
 
-  describe 'when initialised with a deleted application' do
-    let(:application) { create :application, :deleted_state, office: user.office }
+      it { is_expected.to eql 'This application is waiting for part-payment. You can’t edit any details.' }
+    end
 
-    it { is_expected.to eql deleted_application_path(application) }
+    describe 'when initialised with an application awaiting evidence' do
+      let(:application) { create :application, :waiting_for_evidence_state, office: user.office }
+      let!(:evidence) { create :evidence_check, application: application }
+
+      it { is_expected.to eql 'This application is waiting for evidence. You can’t edit any details.' }
+    end
+
+    describe 'when initialised with a deleted application' do
+      let(:application) { create :application, :deleted_state, office: user.office }
+
+      it { is_expected.to eql 'This application has been deleted. You can’t edit any details.' }
+    end
   end
 end


### PR DESCRIPTION
Because the pages were stored in the browser history the users could
still use the browser back button.

This was designed to set the application processed page to expire and
force a reload/redirect if trying to view in the same browser session.