### PR TITLE
Update the Business Entity seed script

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,17 +15,15 @@ Jurisdiction.create([{ name: 'County', abbr: nil },
 Office.create(name: 'Digital', entity_code: 'MA105', jurisdiction_ids: [1])
 Office.create(name: 'Bristol', entity_code: 'DB402', jurisdiction_ids: [1])
 
-Office.all.each do |o|
-  Jurisdiction.all.each do |j|
-    BusinessEntity.create(
-      office: o,
-      jurisdiction: j,
-      code: o.entity_code,
-      name: "#{o.name} - #{j.name}"
-    )
-  end
+OfficeJurisdiction.all.each do |oj|
+  BusinessEntity.create(
+      office: oj.office,
+      jurisdiction: oj.jurisdiction,
+      code: oj.office.entity_code,
+      name: "#{oj.office.name} - #{oj.jurisdiction.name}",
+      valid_from: Time.zone.now
+  )
 end
-
 
 unless ENV=='production'
   User.create([{


### PR DESCRIPTION
It now only creates a BEC entry from the previously created office_jurisdiction objects.

This will allow users to create applications on the demo environments without having to manually create BEC codes.