### PR TITLE
Display emergency banner

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,5 +1,10 @@
 =content_for(:javascript) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
 
+.row.pad-top-thirty-px
+  .columns.small-12
+    .page-error There’s a problem with the service. You can't check if applicants are receiving benefits, but you can accept benefits letters. For emergency applications, complete an undertaking. You can process income-based applications as usual.
+
+
 - if policy(:application).new?
   .row
     .small-12.columns


### PR DESCRIPTION
Because the DWP has remained down for 4 days...

Show a warning to users, this will need to be removed manually...

Or we could write a checker to see if it should be displayed automatically!