### PR TITLE
Make confirmation pages consistent

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,6 +31,7 @@
 @import 'buttons';
 @import 'application_form';
 @import 'base';
+@import 'confirmation_letters';
 @import 'evidence_check';
 @import 'evidence';
 @import 'form_elements';

--- a/app/assets/stylesheets/confirmation_letters.scss
+++ b/app/assets/stylesheets/confirmation_letters.scss
@@ -1,0 +1,7 @@
+@import "measurements";
+
+.confirmation-letter {
+  border: 1px solid $grey-3;
+  background-color: $grey-4;
+  padding: $gutter-half;
+}

--- a/app/assets/stylesheets/evidence_check.scss
+++ b/app/assets/stylesheets/evidence_check.scss
@@ -5,12 +5,6 @@
   margin-bottom: $gutter;
 }
 
-.evidence-check-letter {
-  border: 1px solid $grey-3;
-  background-color: $grey-4;
-  padding: $gutter-half;
-}
-
 .waiting-for-evidence, .waiting-for-part_payment,
 table.completed-applications, table.processed-applications,
 table.deleted-applications {

--- a/app/assets/stylesheets/result_bar.scss
+++ b/app/assets/stylesheets/result_bar.scss
@@ -9,9 +9,9 @@
 }
 
 #result.callout {
-  padding:30px 15px;
+  padding: 30px 15px;
   margin-bottom: 2em;
-  color:#ffffff;
+  color: #ffffff;
   background-color: $orange;
   h3 {
     color: $page-colour;
@@ -28,9 +28,17 @@
   }
   &.evidence-check-reference {
     background-color: $grey-1;
+    text-align: center;
+    padding: 30px;
+    .check {
+      display: inline-block;
+      padding-right: 15px;
+    }
+    .reference-number {
+      display: block;
+    }
   }
-  p
-  {
-    margin:0;
+  p {
+    margin: 0;
   }
 }

--- a/app/assets/stylesheets/utilities.scss
+++ b/app/assets/stylesheets/utilities.scss
@@ -1,44 +1,36 @@
+// utility classes used as overrides, therefore valid use of !important
+// https://css-tricks.com/when-using-important-is-the-right-choice/
+
 // margin utility classes
+.util_margin-0 {
+  margin: 0 !important;
+}
+.util_mt-0 {
+  margin-top: 0 !important;
+}
+.util_mb-0 {
+  margin-bottom: 0 !important;
+}
 .util_mt-medium {
-  margin-top: 2rem;
+  margin-top: 2rem !important;
 }
-
 .util_mb-medium {
-  margin-bottom: 2rem;
+  margin-bottom: 2rem !important;
 }
-
 .util_mb-small {
-  margin-bottom: 1rem;
+  margin-bottom: 1rem !important;
 }
 
 // padding utility classes
 .util_pt-medium {
-  padding-top: 2rem;
+  padding-top: 2rem !important;
 }
-
-// utility classes used as overrides, therefore valid use of !important
-// https://css-tricks.com/when-using-important-is-the-right-choice/
-.util_mt-0 {
-  margin-top: 0 !important;
-}
-
-.util_mb-0 {
-  margin-bottom: 0 !important;
-}
-
-.util_margin-0 {
-  margin: 0 !important;
-}
-
-// padding utility classes
 .util_pt-0 {
   padding-top: 0 !important;
 }
-
 .util_pb-0 {
   padding-bottom: 0 !important;
 }
-
 .util_padding-0 {
   padding: 0 !important;
 }

--- a/app/helpers/summary_helper.rb
+++ b/app/helpers/summary_helper.rb
@@ -48,7 +48,8 @@ module SummaryHelper
      (
       {
         '✓' => ' summary-result passed',
-        '✗' => ' summary-result failed'
+        '✗' => ' summary-result failed',
+        'W' => ' summary-result part'
       }[value.to_s.first] || '')
     ].join
   end

--- a/app/models/views/confirmation/result.rb
+++ b/app/models/views/confirmation/result.rb
@@ -28,7 +28,13 @@ module Views
 
       def income_passed?
         if application_type_is?('income')
-          convert_to_pass_fail(%w[full part].include?(@application.outcome).to_s)
+          if @application.waiting_for_evidence?
+            I18n.t('activemodel.attributes.views/confirmation/result.income_evidence')
+          elsif @application.waiting_for_part_payment?
+            I18n.t('activemodel.attributes.views/confirmation/result.income_part')
+          else
+            convert_to_pass_fail(%w[full part].include?(@application.outcome).to_s)
+          end
         end
       end
 

--- a/app/models/views/confirmation/result.rb
+++ b/app/models/views/confirmation/result.rb
@@ -27,15 +27,16 @@ module Views
       end
 
       def income_passed?
-        if application_type_is?('income')
-          if @application.waiting_for_evidence?
-            I18n.t('activemodel.attributes.views/confirmation/result.income_evidence')
-          elsif @application.waiting_for_part_payment?
-            I18n.t('activemodel.attributes.views/confirmation/result.income_part')
-          else
-            convert_to_pass_fail(%w[full part].include?(@application.outcome).to_s)
-          end
-        end
+        return unless application_type_is?('income')
+        path = 'activemodel.attributes.views/confirmation/result'
+
+        income_evidence = I18n.t('income_evidence', scope: path)
+        return income_evidence if @application.waiting_for_evidence?
+
+        part_payment = I18n.t('income_part', scope: path)
+        return part_payment if @application.waiting_for_part_payment?
+
+        convert_to_pass_fail(%w[full part].include?(@application.outcome).to_s)
       end
 
       def result

--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -14,6 +14,17 @@
 #result.callout class="callout-#{@confirm.result}"
   h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
 
+-if @application.waiting_for_part_payment?
+  .evidence-check-letter
+    = t('letters.part-payment.send_part_payment_html',
+        reference: @application.reference,
+        full_name: @application.full_name,
+        user_name: current_user.name,
+        part_payment_amount: number_to_currency(@application.amount_to_pay, precision: 0),
+        total_income: number_to_currency(@application.income, precision: 0),
+        children: @application.children,
+        date_for_part_payment: @application.part_payment.expires_at.try(:strftime, Date::DATE_FORMATS[:gov_uk_long]))
+
 .guidance
   h4 Next steps
   ul

--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -9,7 +9,7 @@
         = @application.reference
 
 .util_mt-medium
-  = build_section 'Results', @confirm, @confirm.all_fields
+  = build_section 'Result', @confirm, @confirm.all_fields
 
 #result.callout class="callout-#{@confirm.result}"
   h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe

--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -1,45 +1,39 @@
-header
-  h2 Processing complete
+- if after_desired_date? or @application.outcome.eql?('part')
+  h4.util_mt-medium Reference
+  #result.callout.evidence-check-reference
+    h3.bold
+      span.check
+        | ✓
+      | The reference number is
+      span.reference-number
+        = @application.reference
 
-.row
-  .small-12.medium-8.large-7.columns
-    - if after_desired_date?
-      .row
-        .small-12.columns
-          h4 Reference
-          .row.collapse.medium-10.large-8
-            #result.callout.evidence-check-reference
-              h3.bold = display_reference(@application)
+.util_mt-medium
+  = build_section 'Results', @confirm, @confirm.all_fields
 
-    = build_section 'Results', @confirm, @confirm.all_fields
-    .row
-      .small-12.columns
-        .row.collapse.medium-10.large-8
-          #result.callout class="callout-#{@confirm.result}"
-            h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
+#result.callout class="callout-#{@confirm.result}"
+  h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
 
-    .row.collapse.medium-10.large-8
-      = link_to 'Back to start', root_path, class: 'button primary'
+.guidance
+  h4 Next steps
+  ul
+    -if @application.outcome.eql?('full')
+      -unless after_desired_date?
+        li Complete the remission register with the application details
+      li Write the reference number on the top right corner of the paper form
+      li Copy the reference number into the case management system
+      li The applicant’s process can now be issued
+    -elsif @application.outcome.eql?('part')
+      li Write to the applicant with details of how much they have to pay
+      li Store the application form in a secure location until you receive the part-payment
+      li You don't need to complete the remission register until part-payment has been received
+      li Write the reference number on the top right corner of the paper form
+    -else
+      li Complete the remission register with the application details
+      li Write the reference number on the top right corner of the paper form
+      li Copy the reference number into the case management system
+      li Write to the applicant and send back all the documents
 
-  .large-5.columns
-    .guidance
-      h4 Next steps
-      ul
-        -if @application.outcome.eql?('full')
-          -unless after_desired_date?
-            li Complete the remission register with the application details
-          li Write the reference number on the top right corner of the paper form
-          li Copy the reference number into the case management system
-          li The applicant’s process can now be issued
-        -elsif @application.outcome.eql?('part')
-          li Write to the applicant with details of how much they have to pay
-          li Store the application form in a secure location until you receive the part-payment
-          li You don't need to complete the remission register until part-payment has been received
-          li Write the reference number on the top right corner of the paper form
-        -else
-          li Complete the remission register with the application details
-          li Write the reference number on the top right corner of the paper form
-          li Copy the reference number into the case management system
-          li Write to the applicant and send back all the documents
+  p: strong = link_to 'See the guides', guide_path, target: 'blank'
 
-      p: strong = link_to 'See the guides', guide_path, target: 'blank'
+= link_to 'Back to start', root_path, class: 'button primary'

--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -15,7 +15,7 @@
   h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
 
 -if @application.waiting_for_part_payment?
-  .evidence-check-letter
+  .confirmation-letter
     = t('letters.part-payment.send_part_payment_html',
         reference: @application.reference,
         full_name: @application.full_name,

--- a/app/views/evidence_checks/show.html.slim
+++ b/app/views/evidence_checks/show.html.slim
@@ -18,7 +18,7 @@ h4.util_mt-medium Reference
     - t('evidence_check.next_steps.steps').each do |step|
       li =step
 
-.evidence-check-letter
+.confirmation-letter
   =t('letters.evidence.send_evidence_html', reference: @application.reference, full_name: @application.full_name, user_name: current_user.name, expiry_date: @evidence_check.expires_at.to_date)
 
 =link_to t('evidence_check.back_to_start'), root_path, class: 'button primary'

--- a/app/views/evidence_checks/show.html.slim
+++ b/app/views/evidence_checks/show.html.slim
@@ -1,34 +1,24 @@
-header
-  h2 Processing complete
+h4.util_mt-medium Reference
+#result.callout.evidence-check-reference
+  h3.bold
+    span.check
+      | ✓
+    | The reference number is
+    span.reference-number
+      = @application.reference
 
-.row
-  .small-12.medium-10.large-9.columns
-    = build_section 'Results', @confirm, @confirm.all_fields
-    .row
-      .small-12.columns
-        .row.collapse.medium-10.large-8
-          #result.callout class="callout-#{@confirm.result}"
-            h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
-    .evidence-check
-    .row
-      .small-12.columns
-        h4 Reference
-        .row.collapse.medium-10.large-8
-          #result.callout.evidence-check-reference
-            h3.bold =@application.reference
-    .row.guidance.collapse
-      .row
-        .small-12.medium-12.large-12.columns
-          h4 =t('evidence_check.next_steps.title')
-          ul
-            - t('evidence_check.next_steps.steps').each do |step|
-              li =step
+= build_section 'Results', @confirm, @confirm.all_fields
 
-    .row
-      .small-12.medium-12.large-12.columns
-        .evidence-check-letter
-          =t('letters.evidence.send_evidence_html', reference: @application.reference, full_name: @application.full_name, user_name: current_user.name, expiry_date: @evidence_check.expires_at.to_date)
+#result.callout class="callout-#{@confirm.result}"
+  h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
 
-  .row
-    .small-12.medium-12.large-12.columns
-      =link_to t('evidence_check.back_to_start'), root_path, class: 'button primary'
+.guidance
+  h4 =t('evidence_check.next_steps.title')
+  ul
+    - t('evidence_check.next_steps.steps').each do |step|
+      li =step
+
+.evidence-check-letter
+  =t('letters.evidence.send_evidence_html', reference: @application.reference, full_name: @application.full_name, user_name: current_user.name, expiry_date: @evidence_check.expires_at.to_date)
+
+=link_to t('evidence_check.back_to_start'), root_path, class: 'button primary'

--- a/app/views/evidence_checks/show.html.slim
+++ b/app/views/evidence_checks/show.html.slim
@@ -7,7 +7,7 @@ h4.util_mt-medium Reference
     span.reference-number
       = @application.reference
 
-= build_section 'Results', @confirm, @confirm.all_fields
+= build_section 'Result', @confirm, @confirm.all_fields
 
 #result.callout class="callout-#{@confirm.result}"
   h3.bold = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,8 +165,8 @@ en-GB:
     remove_warning_html: "%{managers} at %{office} need to unselect these jurisdictions before you can deactivate them."
     deactivate_warning: "Deactivating this jurisdiction will remove it from the list that %{office} can use. It will still be displayed for any applications processed before %{today_date}."
   remissions:
-    full: '✓ &nbsp; Eligible for help with fees'
-    part: Must pay %{amount_to_pay} towards the fee
+    full: 'Eligible for help with fees'
+    part: The applicant must pay %{amount_to_pay} towards the fee
     none: '✗ &nbsp; Not eligible for help with fees'
     callout: Evidence of income needs to be checked
   evidence_check:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,9 +197,11 @@ en-GB:
         children: Number of children
         income: Total monthly income
       views/confirmation/result:
-        savings_passed?: Savings
+        savings_passed?: Savings and investments
         benefits_passed?: Benefits
         income_passed?: Income
+        income_part: 'Waiting for part-payment'
+        income_evidence: 'Waiting for evidence'
       views/processing_details:
         reference: Reference
         processed_by: Processed by

--- a/config/locales/letters_en.yml
+++ b/config/locales/letters_en.yml
@@ -126,17 +126,15 @@ en-GB:
         <p>Your total monthly income: %{total_income}</p>
         <p>Number of children: %{children}</p>
         <p>Amount to pay: %{part_payment_amount}</p>
-        <br>
-        <p><strong>How to pay</strong></p> 
+        <p><strong>How to pay</strong></p>
         <ul> 
           <li>by post with a cheque written out to ‘HM Courts and Tribunals Service’ for the amount</li>
           <li>by debit card over the phone</li> 
           <li>in person with a cheque, cash or debit card at the court counter</li>
-        <br> 
+        </ul>
         <p>Please make sure you pay this amount by %{date_for_part_payment}</p>
-        <br>
-        <p><strong>If you don’t agree with the amount you have to pay</strong></p>  
-        <p>If you disagree with our decision about the amount you have to pay, you can appeal to %{name_delivery_manager}, Delivery Manager at %{court_tribunal_name}. You need to do this by %{date_for_appeal}.</p>  
+        <p><strong>If you don’t agree with the amount you have to pay</strong></p>
+        <p>If you disagree with our decision about the amount you have to pay, you can appeal to the court or tribunal's Delivery Manager within 14 days of receiving this letter.</p>
         <p>Yours sincerely,</p>
         <p>%{user_name}</p> 
       no_part_payment_received_html: |

--- a/spec/features/applications/application_form_stories_spec.rb
+++ b/spec/features/applications/application_form_stories_spec.rb
@@ -251,7 +251,7 @@ RSpec.feature 'Completing the application details', type: :feature do
                   before { click_button 'Complete processing' }
 
                   scenario 'the confirmation is shown' do
-                    expect(page).to have_xpath('//h2', text: 'Processing complete')
+                    expect(page).to have_xpath('//div[contains(@class,"callout")]/h3[@class="bold"]')
                   end
 
                   context 'when the user clicks Back to Start' do

--- a/spec/features/applications/application_savings_and_investments_spec.rb
+++ b/spec/features/applications/application_savings_and_investments_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Application for savings and investments bug', type: :feature do
                   click_button 'Next'
                   click_button 'Complete processing'
 
-                  expect(page).to have_text '✓ Eligible for help with fees'
+                  expect(page).to have_text 'Eligible for help with fees'
                 end
               end
             end

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -24,7 +24,6 @@ RSpec.feature 'Confirmation page', type: :feature do
       end
 
       scenario 'the correct view is rendered' do
-        expect(page).to have_xpath('//h2', text: 'Processing complete')
         expect(page).to have_xpath('//div[contains(@class,"callout")]/h3[@class="bold"]')
       end
 

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature 'Confirmation page', type: :feature do
 
   let(:office) { create(:office) }
   let(:user) { create :user, office: office }
-  let(:application) { create(:application, :confirm, office: office) }
 
   context 'as a signed in user', js: true do
     before do
@@ -19,9 +18,9 @@ RSpec.feature 'Confirmation page', type: :feature do
     after { Capybara.use_default_driver }
 
     context 'after user continues from summary' do
-      before do
-        visit application_confirmation_path(application_id: application.id)
-      end
+      let(:application) { create(:application, :confirm, office: office) }
+
+      before { visit application_confirmation_path(application) }
 
       scenario 'the correct view is rendered' do
         expect(page).to have_xpath('//div[contains(@class,"callout")]/h3[@class="bold"]')
@@ -29,6 +28,27 @@ RSpec.feature 'Confirmation page', type: :feature do
 
       scenario 'the next button is rendered' do
         expect(page).to have_link('Back to start')
+      end
+    end
+
+    context 'when application ends with part payment' do
+      let!(:part_payment) { create(:part_payment, application: application) }
+      let!(:application) { create :application_full_remission, :waiting_for_part_payment_state, office: office }
+
+      before { visit application_confirmation_path(application) }
+
+      scenario 'the income label displays correctly' do
+        expect(page).to have_xpath('//div[contains(@class,"summary-result") and contains(@class,"part")]', text: 'Waiting for part-payment')
+      end
+    end
+
+    context 'when application requires evidence' do
+      let(:application) { create :application_part_remission, :waiting_for_evidence_state, office: office }
+
+      before { visit application_confirmation_path(application) }
+
+      scenario 'the income label displays correctly' do
+        expect(page).to have_xpath('//div[contains(@class,"summary-result") and contains(@class,"part")]', text: 'Waiting for evidence')
       end
     end
   end

--- a/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
+++ b/spec/features/applications/over_61_applicants_can_complete_form_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Completing the application details', type: :feature do
     end
 
     scenario 'shows the proper summary page' do
-      expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-part")]/h3[@class="bold"]', text: 'Must pay £40 towards the fee')
+      expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "callout-part")]/h3[@class="bold"]', text: 'The applicant must pay £40 towards the fee')
     end
   end
 

--- a/spec/features/applications/show_result_on_confirmation_spec.rb
+++ b/spec/features/applications/show_result_on_confirmation_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'The result is shown on the confirmation page', type: :feature do
 
           context 'the confirmation page' do
             scenario 'shows the correct outcomes' do
-              expect(page).to have_content 'Savings✓ Passed'
+              expect(page).to have_content 'Savings and investments✓ Passed'
               expect(page).to have_content 'Benefits✓ Passed'
             end
 
@@ -109,7 +109,7 @@ RSpec.feature 'The result is shown on the confirmation page', type: :feature do
 
           context 'the confirmation page' do
             scenario 'shows the correct outcomes' do
-              expect(page).to have_content 'Savings✓ Passed'
+              expect(page).to have_content 'Savings and investments✓ Passed'
               expect(page).to have_content 'Income✓ Passed'
             end
 

--- a/spec/features/applications/show_result_on_confirmation_spec.rb
+++ b/spec/features/applications/show_result_on_confirmation_spec.rb
@@ -79,7 +79,7 @@ RSpec.feature 'The result is shown on the confirmation page', type: :feature do
             end
 
             scenario 'shows the status banner' do
-              expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "full")]/h3[@class="bold"]', text: '✓ Eligible for help with fees')
+              expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "full")]/h3[@class="bold"]', text: 'Eligible for help with fees')
             end
           end
         end
@@ -114,7 +114,7 @@ RSpec.feature 'The result is shown on the confirmation page', type: :feature do
             end
 
             scenario 'shows the status banner' do
-              expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "full")]/h3[@class="bold"]', text: '✓ Eligible for help with fees')
+              expect(page).to have_xpath('//div[contains(@class,"callout")][contains(@class, "full")]/h3[@class="bold"]', text: 'Eligible for help with fees')
             end
           end
         end

--- a/spec/features/applications/stray_error_on_confirmation_page_spec.rb
+++ b/spec/features/applications/stray_error_on_confirmation_page_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Stray error on the confirmation page', type: :feature do
 
     context 'when on application processed page' do
       scenario "'Back to start' link redirects to home page" do
-        expect(page).to have_xpath('//h2', text: 'Processing complete')
+        expect(page).to have_xpath('//div[contains(@class,"callout")]/h3[@class="bold"]')
         click_link 'Back to start'
         expect(page).to have_content 'Start now'
       end

--- a/spec/features/benefit_override/no_ni_number_and_undetermined_result_spec.rb
+++ b/spec/features/benefit_override/no_ni_number_and_undetermined_result_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature 'No NI number provided', type: :feature do
 
       it do
         expect(page).to have_content no_remission
-        expect(page).to have_content 'Processing complete'
+        expect(page).to have_xpath('//div[contains(@class,"callout")]/h3[@class="bold"]')
         expect(page).to have_content no_remission
       end
     end

--- a/spec/features/evidence-checks/evidence_check_page_displays_letter_to_be_sent_spec.rb
+++ b/spec/features/evidence-checks/evidence_check_page_displays_letter_to_be_sent_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Evidence check page displays letter to be sent', type: :feature d
   scenario 'User navigates to the evidence check page, which has all required details' do
     visit evidence_check_path(evidence_check)
 
-    within '.evidence-check-letter' do
+    within '.confirmation-letter' do
       expect(page).to have_content(application.reference)
       expect(page).to have_content(application.full_name)
       expect(page).to have_content(user.name)

--- a/spec/features/evidence/evidence_check_flow_spec.rb
+++ b/spec/features/evidence/evidence_check_flow_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
       let(:outcome) { 'part' }
       let(:amount) { 45 }
 
-      it { expect(page).to have_xpath('//div[contains(@class,"callout-part")]/h3[@class="bold"]', text: 'Must pay £45 towards the fee') }
+      it { expect(page).to have_xpath('//div[contains(@class,"callout-part")]/h3[@class="bold"]', text: 'The applicant must pay £45 towards the fee') }
 
       it 'clicking the Next button redirects to the summary page' do
         click_link_or_button 'Next'
@@ -115,7 +115,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
     context 'when the evidence check returns full' do
       let(:outcome) { 'full' }
 
-      it { expect(page).to have_xpath('//div[contains(@class,"callout-full")]/h3[@class="bold"]', text: '✓ Eligible for help with fees') }
+      it { expect(page).to have_xpath('//div[contains(@class,"callout-full")]/h3[@class="bold"]', text: 'Eligible for help with fees') }
 
       it 'clicking the Complete processing button redirects to the summary page' do
         click_link_or_button 'Next'
@@ -156,7 +156,7 @@ RSpec.feature 'Evidence check flow', type: :feature do
       end
 
       it 'renders correct outcome' do
-        page_expectation("Must pay £#{evidence.amount_to_pay} towards the fee", expected_fields)
+        page_expectation("The applicant must pay £#{evidence.amount_to_pay} towards the fee", expected_fields)
       end
 
       context 'clicking the Complete processing button' do

--- a/spec/models/views/confirmation/result_spec.rb
+++ b/spec/models/views/confirmation/result_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Views::Confirmation::Result do
   let(:application) { build_stubbed(:application) }
   let(:string_passed) { '✓ Passed' }
   let(:string_failed) { '✗ Failed' }
+  let(:string_waiting_evidence) { 'Waiting for evidence' }
+  let(:string_part_payment) { 'Waiting for part-payment' }
   let(:scope) { 'convert_pass_fail' }
   subject(:view) { described_class.new(application) }
 
@@ -71,23 +73,26 @@ RSpec.describe Views::Confirmation::Result do
   end
 
   describe '#income_passed?' do
-    let(:application) { build_stubbed(:application, :income_type, outcome: outcome) }
+    let(:application) { build_stubbed(:application, :income_type, state: state, outcome: outcome) }
 
     subject { view.income_passed? }
 
     context 'when the application is a full remission' do
+      let(:state) { 3 }
       let(:outcome) { 'full' }
 
       it { is_expected.to eq string_passed }
     end
 
     context 'when the application is a part remission' do
+      let(:state) { 2 }
       let(:outcome) { 'part' }
 
-      it { is_expected.to eq string_passed }
+      it { is_expected.to eq string_part_payment }
     end
 
     context 'when the application is a non remission' do
+      let(:state) { 3 }
       let(:outcome) { 'none' }
 
       it { is_expected.to eq string_failed }


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/114297385)

Screenshots of progress thus far:

PASSED
===
Before
---
![screen shot 2016-02-25 at 13 18 59](https://cloud.githubusercontent.com/assets/988436/13320664/86642f9c-dbc2-11e5-9a8e-df85c2b14f7f.png)
After
---
![screen shot 2016-02-25 at 13 17 21](https://cloud.githubusercontent.com/assets/988436/13320669/8d8ee12c-dbc2-11e5-9b32-c89382df6cea.png)
After with reference number
---
![screen shot 2016-02-25 at 13 21 32](https://cloud.githubusercontent.com/assets/988436/13320704/beb5ead4-dbc2-11e5-9a43-9a090a20caac.png)

PART PAYMENT
===
Before
---
![screen shot 2016-02-25 at 13 19 06](https://cloud.githubusercontent.com/assets/988436/13320741/ea07f448-dbc2-11e5-81b6-43d43f85dd00.png)
After
---
![screen shot 2016-02-25 at 13 18 13](https://cloud.githubusercontent.com/assets/988436/13320746/ee386d86-dbc2-11e5-8345-cc0a222e8332.png)
After backend updates
---
**Note:** start of letter
<img width="902" alt="screen shot 2016-02-26 at 13 19 50" src="https://cloud.githubusercontent.com/assets/6757677/13353360/b458ef40-dc8b-11e5-8745-439d9bef551c.png">

EVIDENCE CHECK
===
Before
---
![screen shot 2016-02-25 at 13 19 23](https://cloud.githubusercontent.com/assets/988436/13320754/f95cc360-dbc2-11e5-8050-9cbc871d40bd.png)
After
---
![screen shot 2016-02-25 at 13 17 45](https://cloud.githubusercontent.com/assets/988436/13320761/fdf8c996-dbc2-11e5-8333-f72d4060f851.png)
After backend updates
---
<img width="982" alt="screen shot 2016-02-26 at 13 23 18" src="https://cloud.githubusercontent.com/assets/6757677/13353419/296af45e-dc8c-11e5-9772-85175412ea55.png">

NOT ELIGIBLE
===
Before
---
![screen shot 2016-02-25 at 13 18 50](https://cloud.githubusercontent.com/assets/988436/13320771/08fdfe60-dbc3-11e5-80bb-a9010867d5b4.png)
After
---
![screen shot 2016-02-25 at 13 17 12](https://cloud.githubusercontent.com/assets/988436/13320777/0d9548f2-dbc3-11e5-84a7-6ed13d4317e4.png)