### PR TITLE
Fix and update reference keys

### DIFF
--- a/db/migrate/20160329203001_fix_and_improve_foreign_keys.rb
+++ b/db/migrate/20160329203001_fix_and_improve_foreign_keys.rb
@@ -1,0 +1,47 @@
+class FixAndImproveForeignKeys < ActiveRecord::Migration
+  def change
+    add_foreign_key :applicants, :applications, on_update: :cascade
+
+    change_foreign_key :applications, :business_entities
+    change_foreign_key :applications, :offices
+    change_foreign_key :applications, :users
+
+    change_foreign_key :benefit_checks, :applications
+    change_foreign_key :benefit_checks, :users
+
+    change_foreign_key :benefit_overrides, :applications
+
+    add_foreign_key :business_entities, :jurisdictions, on_update: :cascade
+    add_foreign_key :business_entities, :offices, on_update: :cascade
+
+    add_foreign_key :details, :applications, on_update: :cascade
+    add_foreign_key :details, :jurisdictions, on_update: :cascade
+
+    add_foreign_key :evidence_checks, :applications, on_update: :cascade
+
+    change_foreign_key :feedbacks, :offices
+    change_foreign_key :feedbacks, :users
+
+    change_foreign_key :office_jurisdictions, :jurisdictions
+    change_foreign_key :office_jurisdictions, :offices
+
+    add_foreign_key :part_payments, :applications, on_update: :cascade
+
+    change_foreign_key :users, :jurisdictions
+    change_foreign_key :users, :offices
+  end
+
+  def change_foreign_key(from_table, to_table)
+    reversible do |dir|
+      dir.up do
+        remove_foreign_key from_table, to_table
+        add_foreign_key from_table, to_table, on_update: :cascade
+      end
+
+      dir.down do
+        remove_foreign_key from_table, to_table
+        add_foreign_key from_table, to_table
+      end
+    end
+  end
+end

--- a/db/migrate/20160329203002_add_foreign_keys_to_user_references.rb
+++ b/db/migrate/20160329203002_add_foreign_keys_to_user_references.rb
@@ -9,7 +9,8 @@ class AddForeignKeysToUserReferences < ActiveRecord::Migration
 
     add_user_foreign_key(:part_payments, :completed_by_id)
 
-    add_user_foreign_key(:users, :invited_by_id)
+    # This foreign key can't be setup now as it prevents the primary key to be incremented
+    # add_user_foreign_key(:users, :invited_by_id)
   end
 
   def add_user_foreign_key(from_table, column)

--- a/db/migrate/20160329203002_add_foreign_keys_to_user_references.rb
+++ b/db/migrate/20160329203002_add_foreign_keys_to_user_references.rb
@@ -1,0 +1,18 @@
+class AddForeignKeysToUserReferences < ActiveRecord::Migration
+  def change
+    add_user_foreign_key(:applications, :completed_by_id)
+    add_user_foreign_key(:applications, :deleted_by_id)
+
+    add_user_foreign_key(:benefit_overrides, :completed_by_id)
+
+    add_user_foreign_key(:evidence_checks, :completed_by_id)
+
+    add_user_foreign_key(:part_payments, :completed_by_id)
+
+    add_user_foreign_key(:users, :invited_by_id)
+  end
+
+  def add_user_foreign_key(from_table, column)
+    add_foreign_key from_table, :users, column: column, on_update: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160329203001) do
+ActiveRecord::Schema.define(version: 20160329203002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -281,21 +281,27 @@ ActiveRecord::Schema.define(version: 20160329203001) do
   add_foreign_key "applications", "business_entities", on_update: :cascade
   add_foreign_key "applications", "offices", on_update: :cascade
   add_foreign_key "applications", "online_applications", on_update: :cascade
+  add_foreign_key "applications", "users", column: "completed_by_id", on_update: :cascade
+  add_foreign_key "applications", "users", column: "deleted_by_id", on_update: :cascade
   add_foreign_key "applications", "users", on_update: :cascade
   add_foreign_key "benefit_checks", "applications", on_update: :cascade
   add_foreign_key "benefit_checks", "users", on_update: :cascade
   add_foreign_key "benefit_overrides", "applications", on_update: :cascade
+  add_foreign_key "benefit_overrides", "users", column: "completed_by_id", on_update: :cascade
   add_foreign_key "business_entities", "jurisdictions", on_update: :cascade
   add_foreign_key "business_entities", "offices", on_update: :cascade
   add_foreign_key "details", "applications", on_update: :cascade
   add_foreign_key "details", "jurisdictions", on_update: :cascade
   add_foreign_key "evidence_checks", "applications", on_update: :cascade
+  add_foreign_key "evidence_checks", "users", column: "completed_by_id", on_update: :cascade
   add_foreign_key "feedbacks", "offices", on_update: :cascade
   add_foreign_key "feedbacks", "users", on_update: :cascade
   add_foreign_key "office_jurisdictions", "jurisdictions", on_update: :cascade
   add_foreign_key "office_jurisdictions", "offices", on_update: :cascade
   add_foreign_key "online_applications", "jurisdictions", on_update: :cascade
   add_foreign_key "part_payments", "applications", on_update: :cascade
+  add_foreign_key "part_payments", "users", column: "completed_by_id", on_update: :cascade
   add_foreign_key "users", "jurisdictions", on_update: :cascade
   add_foreign_key "users", "offices", on_update: :cascade
+  add_foreign_key "users", "users", column: "invited_by_id", on_update: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -303,5 +303,4 @@ ActiveRecord::Schema.define(version: 20160329203002) do
   add_foreign_key "part_payments", "users", column: "completed_by_id", on_update: :cascade
   add_foreign_key "users", "jurisdictions", on_update: :cascade
   add_foreign_key "users", "offices", on_update: :cascade
-  add_foreign_key "users", "users", column: "invited_by_id", on_update: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160324110832) do
+ActiveRecord::Schema.define(version: 20160329203001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -277,18 +277,25 @@ ActiveRecord::Schema.define(version: 20160324110832) do
   add_index "users", ["invited_by_id"], name: "index_users_on_invited_by_id", using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
-  add_foreign_key "applications", "business_entities"
-  add_foreign_key "applications", "offices"
+  add_foreign_key "applicants", "applications", on_update: :cascade
+  add_foreign_key "applications", "business_entities", on_update: :cascade
+  add_foreign_key "applications", "offices", on_update: :cascade
   add_foreign_key "applications", "online_applications", on_update: :cascade
-  add_foreign_key "applications", "users"
-  add_foreign_key "benefit_checks", "applications"
-  add_foreign_key "benefit_checks", "users"
-  add_foreign_key "benefit_overrides", "applications"
-  add_foreign_key "feedbacks", "offices"
-  add_foreign_key "feedbacks", "users"
-  add_foreign_key "office_jurisdictions", "jurisdictions"
-  add_foreign_key "office_jurisdictions", "offices"
+  add_foreign_key "applications", "users", on_update: :cascade
+  add_foreign_key "benefit_checks", "applications", on_update: :cascade
+  add_foreign_key "benefit_checks", "users", on_update: :cascade
+  add_foreign_key "benefit_overrides", "applications", on_update: :cascade
+  add_foreign_key "business_entities", "jurisdictions", on_update: :cascade
+  add_foreign_key "business_entities", "offices", on_update: :cascade
+  add_foreign_key "details", "applications", on_update: :cascade
+  add_foreign_key "details", "jurisdictions", on_update: :cascade
+  add_foreign_key "evidence_checks", "applications", on_update: :cascade
+  add_foreign_key "feedbacks", "offices", on_update: :cascade
+  add_foreign_key "feedbacks", "users", on_update: :cascade
+  add_foreign_key "office_jurisdictions", "jurisdictions", on_update: :cascade
+  add_foreign_key "office_jurisdictions", "offices", on_update: :cascade
   add_foreign_key "online_applications", "jurisdictions", on_update: :cascade
-  add_foreign_key "users", "jurisdictions"
-  add_foreign_key "users", "offices"
+  add_foreign_key "part_payments", "applications", on_update: :cascade
+  add_foreign_key "users", "jurisdictions", on_update: :cascade
+  add_foreign_key "users", "offices", on_update: :cascade
 end

--- a/lib/tasks/trial_prune.rake
+++ b/lib/tasks/trial_prune.rake
@@ -1,0 +1,44 @@
+namespace :trial_prune do
+  desc 'Delete applications for an office'
+  task :office_applications, [:office_id] => :environment do |_, args|
+    office = Office.find(args[:office_id])
+
+    ActiveRecord::Base.transaction do
+      office.applications.each do |application|
+        application.applicant.delete
+        application.detail.delete
+
+        application.benefit_checks.delete_all unless application.benefit_checks.empty?
+        application.evidence_check.delete if application.evidence_check
+        application.part_payment.delete if application.part_payment
+        application.benefit_override.delete if application.benefit_override
+
+        application.delete
+      end
+    end
+  end
+
+  desc 'Delete applications created by a user'
+  task :user_applications, [:user_id] => :environment do |_, args|
+    user = User.find(args[:user_id])
+
+    ActiveRecord::Base.transaction do
+      Application.where(user: user).each do |application|
+        application.applicant.delete
+        application.detail.delete
+
+        application.benefit_checks.delete_all unless application.benefit_checks.empty?
+        application.evidence_check.delete if application.evidence_check
+        application.part_payment.delete if application.part_payment
+        application.benefit_override.delete if application.benefit_override
+
+        application.delete
+      end
+    end
+  end
+
+  desc 'Delete users with @digital.justice.gov.uk email'
+  task digital_users: :environment do
+    User.with_deleted.where('email LIKE ?', '%@digital.justice.gov.uk').delete_all
+  end
+end

--- a/spec/factories/benefit_overrides.rb
+++ b/spec/factories/benefit_overrides.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :benefit_override do
     correct false
-    completed_by_id 1
+    association :completed_by, factory: :user
   end
 end

--- a/spec/models/forms/application/detail_spec.rb
+++ b/spec/models/forms/application/detail_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe Forms::Application::Detail do
   end
 
   describe '#save' do
-    let(:jurisdiction) { build_stubbed(:jurisdiction) }
+    let(:jurisdiction) { create(:jurisdiction) }
     let(:detail) { create :detail }
     subject(:form) { described_class.new(detail) }
 


### PR DESCRIPTION
This is a preparation for the `trial` -> `production` migration. We need to be able to update all primary keys and cascade those changes to all referenced tables. This PR adds missing foreign key database constraints. And also makes sure that all the foreign keys have `UPDATE ON CASCADE` setup.