### PR TITLE
Fix validation of boolean fields

### DIFF
--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -1,6 +1,7 @@
 class OnlineApplication < ActiveRecord::Base
-  validates :married, :threshold_exceeded, :benefits, :children, :refund, :probate, :ni_number,
-    :date_of_birth, :first_name, :last_name, :address, :postcode, :email_contact,
-    :phone_contact, :post_contact, presence: true
+  validates :children, :ni_number, :date_of_birth, :first_name, :last_name, :address,
+    :postcode, presence: true
+  validates :married, :threshold_exceeded, :benefits, :refund, :probate, :email_contact,
+    :phone_contact, :post_contact, inclusion: [true, false]
   validates :reference, uniqueness: true
 end

--- a/spec/models/online_application_spec.rb
+++ b/spec/models/online_application_spec.rb
@@ -3,21 +3,22 @@ require 'rails_helper'
 RSpec.describe OnlineApplication, type: :model do
   subject(:online_application) { build :online_application }
 
-  it { is_expected.to validate_presence_of(:married) }
-  it { is_expected.to validate_presence_of(:threshold_exceeded) }
-  it { is_expected.to validate_presence_of(:benefits) }
   it { is_expected.to validate_presence_of(:children) }
-  it { is_expected.to validate_presence_of(:refund) }
-  it { is_expected.to validate_presence_of(:probate) }
   it { is_expected.to validate_presence_of(:ni_number) }
   it { is_expected.to validate_presence_of(:date_of_birth) }
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_presence_of(:last_name) }
   it { is_expected.to validate_presence_of(:address) }
   it { is_expected.to validate_presence_of(:postcode) }
-  it { is_expected.to validate_presence_of(:email_contact) }
-  it { is_expected.to validate_presence_of(:phone_contact) }
-  it { is_expected.to validate_presence_of(:post_contact) }
+
+  it { is_expected.not_to allow_value(nil).for(:married) }
+  it { is_expected.not_to allow_value(nil).for(:threshold_exceeded) }
+  it { is_expected.not_to allow_value(nil).for(:benefits) }
+  it { is_expected.not_to allow_value(nil).for(:refund) }
+  it { is_expected.not_to allow_value(nil).for(:probate) }
+  it { is_expected.not_to allow_value(nil).for(:email_contact) }
+  it { is_expected.not_to allow_value(nil).for(:phone_contact) }
+  it { is_expected.not_to allow_value(nil).for(:post_contact) }
 
   it { is_expected.to validate_uniqueness_of(:reference) }
 end


### PR DESCRIPTION
It's an important for on the OnlineApplication model, which is currently
not being able to save records.

The problem is that boolean fields can't be validated using presence
validator, but only using an inclusion validator. Subsequently the spec
then can't use the given shoulda matcher, but only can test for
inability to assign nil value to those fields.