### PR TITLE
Online applications summary

### DIFF
--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -17,6 +17,10 @@ class OnlineApplicationsController < ApplicationController
     render :edit
   end
 
+  def show
+    authorize online_application
+  end
+
   private
 
   def online_application

--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -19,6 +19,7 @@ class OnlineApplicationsController < ApplicationController
 
   def show
     authorize online_application
+    @overview = Views::ApplicationOverview.new(online_application)
   end
 
   private

--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -11,10 +11,13 @@ class OnlineApplicationsController < ApplicationController
     authorize online_application
     @form = Forms::OnlineApplication.new(online_application)
     @form.update_attributes(update_params)
-    flash[:notice] = 'Application has been saved.' if @form.save
 
-    assign_jurisdictions
-    render :edit
+    if @form.save
+      redirect_to(action: :show)
+    else
+      assign_jurisdictions
+      render :edit
+    end
   end
 
   def show

--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -1,4 +1,6 @@
 class OnlineApplication < ActiveRecord::Base
+  belongs_to :jurisdiction
+
   validates :children, :ni_number, :date_of_birth, :first_name, :last_name, :address,
     :postcode, presence: true
   validates :married, :threshold_exceeded, :benefits, :refund, :probate, :email_contact,

--- a/app/policies/online_application_policy.rb
+++ b/app/policies/online_application_policy.rb
@@ -6,4 +6,8 @@ class OnlineApplicationPolicy < BasePolicy
   def update?
     staff_or_manager?
   end
+
+  def show?
+    staff_or_manager?
+  end
 end

--- a/app/views/online_applications/show.html.slim
+++ b/app/views/online_applications/show.html.slim
@@ -1,7 +1,8 @@
 header
   h2 Check details
 
-=build_section 'Personal details', @online_application, %w[last_name date_of_birth ni_number children income]
+=build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status number_of_children total_monthly_income]
 
-/= form_for @application, url: application_summary_save_path(@overview.application.id), method: :put do |f|
-/  = f.submit 'Complete processing', :class => 'button primary large'
+- change_link = ['Change application details', edit_online_application_path(@overview.application.id)]
+=build_section 'Application details', @overview, %w[fee jurisdiction form_name emergency_reason], *change_link
+

--- a/app/views/online_applications/show.html.slim
+++ b/app/views/online_applications/show.html.slim
@@ -1,0 +1,7 @@
+header
+  h2 Check details
+
+=build_section 'Personal details', @online_application, %w[last_name date_of_birth ni_number children income]
+
+/= form_for @application, url: application_summary_save_path(@overview.application.id), method: :put do |f|
+/  = f.submit 'Complete processing', :class => 'button primary large'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
     get 'confirmation', to: 'applications/process#confirmation', as: :confirmation
   end
 
-  resources :online_applications, only: [:edit, :update]
+  resources :online_applications, only: [:edit, :update, :show]
 
   get 'evidence/:id', to: 'evidence#show', as: :evidence_show
   get 'evidence/:id/accuracy', to: 'evidence#accuracy', as: :evidence_accuracy

--- a/spec/controllers/online_applications_controller_spec.rb
+++ b/spec/controllers/online_applications_controller_spec.rb
@@ -104,4 +104,30 @@ RSpec.describe OnlineApplicationsController, type: :controller do
       end
     end
   end
+
+  describe 'GET #show' do
+    before do
+      get :show, id: id
+    end
+
+    context 'when no online application is found with the id' do
+      let(:id) { 'non-existent' }
+
+      it 'redirects to the homepage' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context 'when an online application is found with the id' do
+      let(:id) { online_application.id }
+
+      it 'renders the show template' do
+        expect(response).to render_template(:show)
+      end
+
+      it 'assigns the online application' do
+        expect(assigns(:online_application)).to eql(online_application)
+      end
+    end
+  end
 end

--- a/spec/controllers/online_applications_controller_spec.rb
+++ b/spec/controllers/online_applications_controller_spec.rb
@@ -106,7 +106,11 @@ RSpec.describe OnlineApplicationsController, type: :controller do
   end
 
   describe 'GET #show' do
+    let(:overview) { double }
+
     before do
+      allow(Views::ApplicationOverview).to receive(:new).with(online_application).and_return(overview)
+
       get :show, id: id
     end
 
@@ -125,8 +129,8 @@ RSpec.describe OnlineApplicationsController, type: :controller do
         expect(response).to render_template(:show)
       end
 
-      it 'assigns the online application' do
-        expect(assigns(:online_application)).to eql(online_application)
+      it 'assigns the overview view model' do
+        expect(assigns(:overview)).to eql(overview)
       end
     end
   end

--- a/spec/controllers/online_applications_controller_spec.rb
+++ b/spec/controllers/online_applications_controller_spec.rb
@@ -76,12 +76,8 @@ RSpec.describe OnlineApplicationsController, type: :controller do
       context 'when the form can be saved' do
         let(:form_save) { true }
 
-        it 'temporarily renders the edit template' do
-          expect(response).to render_template(:edit)
-        end
-
-        it 'renders a success flash message' do
-          expect(flash[:notice]).to eql('Application has been saved.')
+        it 'redirects to the summary page' do
+          expect(response).to redirect_to(online_application_path(online_application))
         end
       end
 

--- a/spec/features/online_applications/staff_can_add_details_spec.rb
+++ b/spec/features/online_applications/staff_can_add_details_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Staff can search for online application', type: :feature do
   scenario 'User fills in all required fields and the application is saved' do
     given_user_is_editting_the_application
     when_they_fill_in_all_required_fields
-    then_the_application_is_saved
+    then_the_summary_page_is_displayed
   end
 
   scenario 'User does not fill in all the required fields and the application fails to save' do
@@ -40,8 +40,9 @@ RSpec.feature 'Staff can search for online application', type: :feature do
     click_button 'Next'
   end
 
-  def then_the_application_is_saved
-    expect(page).to have_content 'Application has been saved.'
+  def then_the_summary_page_is_displayed
+    expect(page).to have_content 'Check details'
+    expect(page).to have_content 'Fee£200'
   end
 
   def when_they_do_not_fill_in_all_required_fields

--- a/spec/models/online_application_spec.rb
+++ b/spec/models/online_application_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe OnlineApplication, type: :model do
   subject(:online_application) { build :online_application }
 
+  it { is_expected.to belong_to(:jurisdiction) }
+
   it { is_expected.to validate_presence_of(:children) }
   it { is_expected.to validate_presence_of(:ni_number) }
   it { is_expected.to validate_presence_of(:date_of_birth) }

--- a/spec/policies/online_application_policy_spec.rb
+++ b/spec/policies/online_application_policy_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe OnlineApplicationPolicy, type: :policy do
 
     it { is_expected.to permit_action(:edit) }
     it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:show) }
   end
 
   context 'for manager' do
@@ -17,6 +18,7 @@ RSpec.describe OnlineApplicationPolicy, type: :policy do
 
     it { is_expected.to permit_action(:edit) }
     it { is_expected.to permit_action(:update) }
+    it { is_expected.to permit_action(:show) }
   end
 
   context 'for admin' do
@@ -24,5 +26,6 @@ RSpec.describe OnlineApplicationPolicy, type: :policy do
 
     it { is_expected.not_to permit_action(:edit) }
     it { is_expected.not_to permit_action(:update) }
+    it { is_expected.not_to permit_action(:show) }
   end
 end


### PR DESCRIPTION
The staff can now proceed do the summary page.

The prototype design has slightly different values for some fields (for example `None` instead of `0` for `Number of children`), but it's consistent with the other summary pages. So when we work on making them the same, this will change too.