### PR TITLE
Create online application

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -130,6 +130,9 @@ IfUnlessModifier:
 Lint/AssignmentInCondition:
   AllowSafeAssignment: false
 
+Lint/Loop:
+  Enabled: false
+
 # Just a preference to use %w[] over %w()
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:

--- a/app/builders/online_application_builder.rb
+++ b/app/builders/online_application_builder.rb
@@ -1,0 +1,12 @@
+class OnlineApplicationBuilder
+
+  def initialize(object)
+    @source = object
+  end
+
+  def build
+    generator = HwfReferenceGenerator.new
+    @source.merge(generator.attributes)
+    OnlineApplication.new(@source)
+  end
+end

--- a/app/builders/online_application_builder.rb
+++ b/app/builders/online_application_builder.rb
@@ -6,7 +6,7 @@ class OnlineApplicationBuilder
 
   def build
     generator = HwfReferenceGenerator.new
-    @source.merge(generator.attributes)
+    @source.merge!(generator.attributes)
     OnlineApplication.new(@source)
   end
 end

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -10,9 +10,9 @@ module Api
     def create
       online_submission = OnlineApplicationBuilder.new(public_app_params).build
       if online_submission.save
-        render(json: { result: true, message: online_submission.reference }.to_json)
+        render(json: { result: true, message: online_submission.reference })
       else
-        render(json: { result: false, message: 'Could not save online_submission' }.to_json)
+        render(json: { result: false, message: 'Could not save online_submission' })
       end
     end
 
@@ -20,7 +20,7 @@ module Api
 
     # rubocop:disable MethodLength
     def public_app_params
-      params.require(:jwt).permit(
+      params.require(:online_application).permit(
         :married,
         :threshold_exceeded,
         :benefits,

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -8,14 +8,44 @@ module Api
     before_action :authenticate
 
     def create
-      result = { result: true, message: public_app_params['jwt'] }
-      render(json: result.to_json)
+      online_submission = OnlineApplicationBuilder.new(public_app_params).build
+      if online_submission.save
+        render(json: { result: true, message: online_submission.reference }.to_json)
+      else
+        render(json: { result: false, message: 'Could not save online_submission' }.to_json)
+      end
     end
 
     private
 
+    # rubocop:disable MethodLength
     def public_app_params
-      params.permit(:jwt)
+      params.require(:jwt).permit(
+        :married,
+        :threshold_exceeded,
+        :benefits,
+        :children,
+        :income,
+        :refund,
+        :date_fee_paid,
+        :probate,
+        :deceased_name,
+        :date_of_death,
+        :case_number,
+        :form_name,
+        :ni_number,
+        :date_of_birth,
+        :title,
+        :first_name,
+        :last_name,
+        :address,
+        :postcode,
+        :email_contact,
+        :email_address,
+        :phone_contact,
+        :phone,
+        :post_contact
+      )
     end
 
     def authenticate

--- a/app/services/hwf_reference_generator.rb
+++ b/app/services/hwf_reference_generator.rb
@@ -1,0 +1,19 @@
+class HwfReferenceGenerator
+
+  def initialize
+    generate_reference
+  end
+
+  def attributes
+    { reference: @new_reference }
+  end
+
+  private
+
+  def generate_reference
+    loop do
+      @new_reference = "HWF-#{SecureRandom.hex(3).upcase.scan(/.{1,3}/).join('-')}"
+      break if OnlineApplication.find_by(reference: @new_reference).nil?
+    end
+  end
+end

--- a/app/services/hwf_reference_generator.rb
+++ b/app/services/hwf_reference_generator.rb
@@ -1,19 +1,20 @@
 class HwfReferenceGenerator
 
-  def initialize
-    generate_reference
-  end
-
   def attributes
-    { reference: @new_reference }
+    { reference: generate_reference }
   end
 
   private
 
   def generate_reference
-    loop do
-      @new_reference = "HWF-#{SecureRandom.hex(3).upcase.scan(/.{1,3}/).join('-')}"
-      break if OnlineApplication.find_by(reference: @new_reference).nil?
-    end
+    begin
+      reference = reference_string
+    end until OnlineApplication.find_by(reference: reference).nil?
+
+    reference
+  end
+
+  def reference_string
+    "HWF-#{SecureRandom.hex(3).upcase.scan(/.{1,3}/).join('-')}"
   end
 end

--- a/spec/builders/online_application_builder_spec.rb
+++ b/spec/builders/online_application_builder_spec.rb
@@ -13,31 +13,5 @@ describe OnlineApplicationBuilder do
       is_expected.to be_a(OnlineApplication)
       is_expected.not_to be_persisted
     end
-
-    describe 'email contact' do
-      subject(:email) { build_submission.email_address }
-      describe 'when applicant responds `no`' do
-        it { is_expected.to eql nil }
-      end
-
-      describe 'when applicant responds `no`' do
-        let(:submission) { attributes_for :public_app_submission, :email_contact }
-
-        it { is_expected.to eql 'foo@bar.com' }
-      end
-    end
-
-    describe 'children field' do
-      subject(:children) { build_submission.children }
-      describe 'when applicant responds `no`' do
-        it { is_expected.to eql 0 }
-      end
-
-      describe 'when applicant responds `yes`' do
-        let(:submission) { attributes_for :public_app_submission, :with_children }
-
-        it { is_expected.to eql 1 }
-      end
-    end
   end
 end

--- a/spec/builders/online_application_builder_spec.rb
+++ b/spec/builders/online_application_builder_spec.rb
@@ -1,0 +1,43 @@
+# coding: utf-8
+require 'rails_helper'
+
+describe OnlineApplicationBuilder do
+
+  let(:current_time) { Time.zone.now }
+  let(:submission) { attributes_for :public_app_submission }
+
+  describe '#build' do
+    subject(:build_submission) { described_class.new(submission).build }
+
+    it 'returns non persisted OnlineApplication' do
+      is_expected.to be_a(OnlineApplication)
+      is_expected.not_to be_persisted
+    end
+
+    describe 'email contact' do
+      subject(:email) { build_submission.email_address }
+      describe 'when applicant responds `no`' do
+        it { is_expected.to eql nil }
+      end
+
+      describe 'when applicant responds `no`' do
+        let(:submission) { attributes_for :public_app_submission, :email_contact }
+
+        it { is_expected.to eql 'foo@bar.com' }
+      end
+    end
+
+    describe 'children field' do
+      subject(:children) { build_submission.children }
+      describe 'when applicant responds `no`' do
+        it { is_expected.to eql 0 }
+      end
+
+      describe 'when applicant responds `yes`' do
+        let(:submission) { attributes_for :public_app_submission, :with_children }
+
+        it { is_expected.to eql 1 }
+      end
+    end
+  end
+end

--- a/spec/builders/online_application_builder_spec.rb
+++ b/spec/builders/online_application_builder_spec.rb
@@ -13,5 +13,11 @@ describe OnlineApplicationBuilder do
       is_expected.to be_a(OnlineApplication)
       is_expected.not_to be_persisted
     end
+
+    describe 'it adds a reference number' do
+      subject(:reference) { build_submission.reference }
+
+      it { is_expected.not_to be_nil }
+    end
   end
 end

--- a/spec/controllers/api/submissions_controller_spec.rb
+++ b/spec/controllers/api/submissions_controller_spec.rb
@@ -2,10 +2,12 @@ require 'rails_helper'
 
 RSpec.describe Api::SubmissionsController, type: :controller do
   let(:auth_token) { 'my-big-secret' }
+  let(:submitted) { attributes_for :public_app_submission }
+
   before(:each) do
     allow(Settings.submission).to receive(:token).and_return('my-big-secret')
     controller.request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Token.encode_credentials(auth_token)
-    post :create, jwt: 'something'
+    post :create, 'jwt': submitted
   end
 
   describe 'POST #create' do
@@ -19,6 +21,13 @@ RSpec.describe Api::SubmissionsController, type: :controller do
 
         it { is_expected.to include 'message' }
         it { is_expected.to include 'result' }
+      end
+
+      describe 'when sent invalid data from the public' do
+        let(:submitted) { attributes_for :public_app_submission, postcode: nil }
+        subject(:result) { JSON.parse(returned.body)['result'] }
+
+        it { is_expected.to eql false }
       end
     end
 

--- a/spec/controllers/api/submissions_controller_spec.rb
+++ b/spec/controllers/api/submissions_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Api::SubmissionsController, type: :controller do
   before(:each) do
     allow(Settings.submission).to receive(:token).and_return('my-big-secret')
     controller.request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Token.encode_credentials(auth_token)
-    post :create, 'jwt': submitted
+    post :create, online_application: submitted
   end
 
   describe 'POST #create' do

--- a/spec/factories/public_app_submissions.rb
+++ b/spec/factories/public_app_submissions.rb
@@ -1,0 +1,47 @@
+FactoryGirl.define do
+  factory :public_app_submission, class: OpenStruct do
+
+    to_create { |instance| instance.as_json['table'] }
+
+    married true
+    threshold_exceeded true
+    benefits true
+    children 0
+    income 100
+    refund false
+    probate false
+    case_number 'AB16D1234'
+    form_name 'O113'
+    ni_number 'AB123456A'
+    date_of_birth '1990-01-01'
+    title 'Mr'
+    first_name 'Foo'
+    last_name 'Bar'
+    address '1 The Street'
+    postcode 'POS 0DE'
+    email_contact false
+    phone_contact true
+    phone '000 000 0000'
+    post_contact 'true'
+
+    trait :refund do
+      refund true
+      date_fee_paid '2016-01-01'
+    end
+
+    trait :probate_case do
+      probate true
+      deceased_name 'foo'
+      date_of_death '2016-01-01'
+    end
+
+    trait :with_children do
+      children 1
+    end
+
+    trait :email_contact do
+      email_contact true
+      email_address 'foo@bar.com'
+    end
+  end
+end

--- a/spec/services/hwf_reference_generator_spec.rb
+++ b/spec/services/hwf_reference_generator_spec.rb
@@ -15,8 +15,19 @@ RSpec.describe HwfReferenceGenerator, type: :service do
 
       it { is_expected.to start_with 'HWF-' }
 
-      it 'is 10 characters long' do
+      it 'is 11 characters long' do
         expect(subject.length).to eql 11
+      end
+    end
+
+    context 'when the generated reference number already exists', focus: true do
+      before do
+        create(:online_application, reference: 'collision')
+        expect(generator).to receive(:reference_string).and_return('collision', 'no-collision')
+      end
+
+      it 'keeps generating until there is no collision' do
+        expect(attributes[:reference]).to eql('no-collision')
       end
     end
   end

--- a/spec/services/hwf_reference_generator_spec.rb
+++ b/spec/services/hwf_reference_generator_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe HwfReferenceGenerator, type: :service do
+  subject(:generator) { described_class.new }
+
+  describe '#attributes' do
+
+    subject(:attributes) { generator.attributes }
+
+    it { is_expected.to be_a Hash }
+    it { is_expected.to include :reference }
+
+    describe 'reference' do
+      subject(:reference) { attributes[:reference] }
+
+      it { is_expected.to start_with 'HWF-' }
+
+      it 'is 10 characters long' do
+        expect(subject.length).to eql 11
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the MVP for receiving data (currently JSON) from the public app.

It will create an online_application, generate (and add) a (HWF-) reference number and save it to the database.

Things that still need work: 
* confirm format of reference!
* test non-generation of whatever format is decided on
* expand return values when errors occur.