### PR TITLE
Monitor dwp

### DIFF
--- a/app/assets/stylesheets/errors.scss
+++ b/app/assets/stylesheets/errors.scss
@@ -72,3 +72,9 @@ div.form-group div.row.collapse div.field_with_errors label {
   background-color: $grass-green-25;
   border: 1px solid $grass-green;
 }
+
+.dwp-warning {
+  padding: $gutter $gutter-half;
+  background-color: $orange-25;
+  border: 1px solid $orange;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,6 +6,7 @@ class HomeController < ApplicationController
     load_graphs_for_admin
     load_waiting_applications
     @search_form = Forms::Search.new
+    @state = DwpMonitor.new.state
   end
 
   def search
@@ -16,6 +17,7 @@ class HomeController < ApplicationController
       redirect_to(edit_online_application_path(online_application))
     else
       load_waiting_applications
+      @state = DwpMonitor.new.state
       render :index
     end
   end

--- a/app/services/dwp_monitor.rb
+++ b/app/services/dwp_monitor.rb
@@ -1,0 +1,31 @@
+class DwpMonitor
+
+  def initialize
+    dwp_results
+  end
+
+  def state
+    if percent >= 50.0
+      'offline'
+    elsif percent >= 25.0
+      'warning'
+    else
+      'online'
+    end
+  end
+
+  private
+
+  def dwp_results
+    @checks = BenefitCheck.pluck(:dwp_result, :error_message).last(20)
+  end
+
+  def percent
+    return 0 unless @checks.any?
+    # When DWP is offline it returns 400 Bad Request
+    # maybe extend to search for x00 as first 3 chars to check for 500 errors too
+    total = @checks.count.to_f
+    bad = @checks.flatten.count('400 Bad Request').to_f
+    bad / total * 100.0
+  end
+end

--- a/app/services/health_status.rb
+++ b/app/services/health_status.rb
@@ -39,8 +39,7 @@ class HealthStatus
   end
 
   def self.api
-    response = JSON.parse RestClient.get "#{ENV['DWP_API_PROXY']}/api/healthcheck"
-    response[:ok]
+    DwpMonitor.new.state == 'online'
   rescue StandardError => error
     Rails.logger.error "The DWP API errored with: #{error}"
     false

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,9 +1,6 @@
 =content_for(:javascript) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
 
-.row.pad-top-thirty-px
-  .columns.small-12
-    /.page-error = t('error_messages.dwp_unavailable')
-    .dwp-restored =t('error_messages.dwp_restored')
+=render("shared/dwp/#{@state}")
 
 .row.equal-heightboxes
   - if policy(:application).new?

--- a/app/views/shared/dwp/_offline.html.slim
+++ b/app/views/shared/dwp/_offline.html.slim
@@ -1,0 +1,3 @@
+.row.pad-top-thirty-px
+  .columns.small-12
+    .page-error = t('error_messages.dwp_unavailable')

--- a/app/views/shared/dwp/_online.html.slim
+++ b/app/views/shared/dwp/_online.html.slim
@@ -1,0 +1,3 @@
+.row.pad-top-thirty-px
+  .columns.small-12
+    .dwp-restored = t('error_messages.dwp_restored')

--- a/app/views/shared/dwp/_warning.html.slim
+++ b/app/views/shared/dwp/_warning.html.slim
@@ -1,0 +1,3 @@
+.row.pad-top-thirty-px
+  .columns.small-12
+    .dwp-warning = t('error_messages.dwp_warning')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en-GB:
       link: See the guides
   error_messages:
     dwp_unavailable: "There’s a problem with the service. You can't check if applicants are receiving benefits, but you can accept benefits letters. For emergency applications, complete an undertaking. You can process income-based applications as usual."
+    dwp_warning: "There may be a problem with the service. You may not be able to check if applicants are receiving benefits, this is being investigated."
     dwp_restored: "The connection with the DWP is currently working.  Benefits based and income based applications can now be processed."
     create_be_exists: "A business entity record for %{jurisdiction} already exists in %{office}"
     manager_cant_invite_admin: 'You cannot create an admin account'

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe HomeController, type: :controller do
         it 'assigns the search form' do
           expect(assigns(:search_form)).to be_a(Forms::Search)
         end
+
+        it 'assigns the DwpMonitor state' do
+          expect(assigns(:state)).to be_a String
+        end
       end
 
       context 'as an admin' do
@@ -114,6 +118,10 @@ RSpec.describe HomeController, type: :controller do
         it 'assigns the search form' do
           expect(assigns(:search_form)).to be_a(Forms::Search)
         end
+
+        it 'assigns the DwpMonitor state' do
+          expect(assigns(:state)).to be_a String
+        end
       end
 
       context 'when an online application is found with that reference' do
@@ -121,6 +129,10 @@ RSpec.describe HomeController, type: :controller do
 
         it 'redirects to the edit page for that online application' do
           expect(response).to redirect_to(edit_online_application_path(online_application))
+        end
+
+        it 'does not assign the DwpMonitor state' do
+          expect(assigns(:state)).to be nil
         end
       end
     end

--- a/spec/services/dwp_monitor_spec.rb
+++ b/spec/services/dwp_monitor_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe DwpMonitor do
+  subject(:service) { described_class.new }
+
+  it { is_expected.to be_a described_class }
+
+  describe 'methods' do
+    describe '.state' do
+      subject { service.state }
+
+      context 'when more than 50% of the last dwp_results are "400 Bad Request"' do
+        before do
+          create_list :benefit_check, 5, :yes_result
+          create_list :benefit_check, 5, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
+        end
+
+        it { is_expected.to eql 'offline' }
+      end
+
+      context 'when more than 25% of the last dwp_results are "400 Bad Request"' do
+        before do
+          create_list :benefit_check, 6, :yes_result
+          create_list :benefit_check, 4, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
+        end
+
+        it { is_expected.to eql 'warning' }
+      end
+
+      context 'when less than 25% of the last dwp_results are "400 Bad Request"' do
+        before do
+          create_list :benefit_check, 8, :yes_result
+          create_list :benefit_check, 2, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
+        end
+
+        it { is_expected.to eql 'online' }
+      end
+    end
+  end
+end

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "home/index.html.slim", type: :view do
     allow(view).to receive(:policy).with(:office).and_return(double(index?: office_index?))
 
     sign_in user
-
+    assign(:state, 'online')
     assign(:search_form, double(errors: {}, reference: nil))
     render
   end


### PR DESCRIPTION
Monitor the last 20 requests and return a state based on the number of 400 Bad Requests received

This is then called from the home controller to display the correct banner.

Update the healthcheck page to call the monitor too.

To do
===
- [x] rebase on master
- [x] front end review of new css
- [x] code review