### PR TITLE
Add feedback_opt_in to online_applications

### DIFF
--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -44,7 +44,8 @@ module Api
         :email_address,
         :phone_contact,
         :phone,
-        :post_contact
+        :post_contact,
+        :feedback_opt_in
       )
     end
 

--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -4,7 +4,7 @@ class OnlineApplication < ActiveRecord::Base
   validates :children, :ni_number, :date_of_birth, :first_name, :last_name, :address,
     :postcode, presence: true
   validates :married, :threshold_exceeded, :benefits, :refund, :probate, :email_contact,
-    :phone_contact, :post_contact, inclusion: [true, false]
+    :phone_contact, :post_contact, :feedback_opt_in, inclusion: [true, false]
   validates :reference, uniqueness: true
 
   def full_name

--- a/db/migrate/20160322151510_add_feedback_opt_in_to_online_application.rb
+++ b/db/migrate/20160322151510_add_feedback_opt_in_to_online_application.rb
@@ -1,0 +1,5 @@
+class AddFeedbackOptInToOnlineApplication < ActiveRecord::Migration
+  def change
+    add_column :online_applications, :feedback_opt_in, :boolean, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160312100207) do
+ActiveRecord::Schema.define(version: 20160322151510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -215,6 +215,7 @@ ActiveRecord::Schema.define(version: 20160312100207) do
     t.decimal  "fee"
     t.integer  "jurisdiction_id"
     t.text     "emergency_reason"
+    t.boolean  "feedback_opt_in",    null: false
   end
 
   add_index "online_applications", ["jurisdiction_id"], name: "index_online_applications_on_jurisdiction_id", using: :btree

--- a/spec/factories/online_applications.rb
+++ b/spec/factories/online_applications.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     email_contact false
     phone_contact false
     post_contact false
+    feedback_opt_in true
 
     trait :with_reference do
       sequence(:reference) { |n| "HWF-#{n}" }

--- a/spec/models/online_application_spec.rb
+++ b/spec/models/online_application_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe OnlineApplication, type: :model do
   it { is_expected.not_to allow_value(nil).for(:email_contact) }
   it { is_expected.not_to allow_value(nil).for(:phone_contact) }
   it { is_expected.not_to allow_value(nil).for(:post_contact) }
+  it { is_expected.not_to allow_value(nil).for(:feedback_opt_in) }
 
   it { is_expected.to validate_uniqueness_of(:reference) }
 


### PR DESCRIPTION
This aligns the staff app with the public app and ensures that the new feedback_opt_in field is recorded