### PR TITLE
Copy reference from OnlineApplication

### DIFF
--- a/app/builders/application_builder.rb
+++ b/app/builders/application_builder.rb
@@ -38,7 +38,7 @@ class ApplicationBuilder
   end
 
   def online_application_attributes(online_application)
-    fields = %i[threshold_exceeded benefits income children]
+    fields = %i[threshold_exceeded benefits income children reference]
     {
       dependents: (online_application.children > 0)
     }.merge(Hash[fields.map { |field| [field, online_application.send(field)] }])

--- a/spec/builders/application_builder_spec.rb
+++ b/spec/builders/application_builder_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe ApplicationBuilder do
         expect(built_application.online_application).to eql(online_application)
       end
 
+      it 'has reference from the online application' do
+        expect(built_application.reference).to eql(online_application.reference)
+      end
+
       %i[threshold_exceeded benefits income].each do |column|
         it "has #{column} assigned" do
           expect(built_application.public_send(column)).to eql(online_application.public_send(column))


### PR DESCRIPTION
We wanted to preserve the original reference, but it was forgotten to be
copied. So this is a bug fix for that feature.