### PR TITLE
Redirection between environments

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+REDIRECTION_DOMAINS=trial.domain:production.domain

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'dotenv-rails', groups: [:development] # this has to be here because of load order
+gem 'dotenv-rails', groups: [:development, :test] # this has to be here because of load order
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~>4.2.6'

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'sentry-raven'
 # Use postgresql as the database for Active Record
 gem 'pg'
 gem 'rails-i18n', '~> 4.0.0'
+gem 'rack-host-redirect'
 
 # configuration
 gem 'config'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,8 @@ GEM
     pundit (1.0.1)
       activesupport (>= 3.0.0)
     rack (1.6.4)
+    rack-host-redirect (1.2.1)
+      rack
     rack-livereload (0.3.16)
       rack
     rack-test (0.6.3)
@@ -424,6 +426,7 @@ DEPENDENCIES
   pg
   pry-rails
   pundit (~> 1.0)
+  rack-host-redirect
   rack-livereload
   rails (~> 4.2.6)
   rails-i18n (~> 4.0.0)

--- a/config/initializers/rack_redirect.rb
+++ b/config/initializers/rack_redirect.rb
@@ -1,0 +1,5 @@
+if Settings.redirection.domains.present?
+  setup = Hash[*Settings.redirection.domains.split(':')]
+
+  Rails.application.config.middleware.use Rack::HostRedirect, setup
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,3 +13,5 @@ part_payment:
   expires_in_days: 14
 submission:
   token: <%= ENV['SUBMISSION_TOKEN'] %>
+redirection:
+  domains: <%= ENV['REDIRECTION_DOMAINS'] || '' %>

--- a/spec/features/domain_redirection_spec.rb
+++ b/spec/features/domain_redirection_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'Domain redirection', type: :feature do
+
+  let(:domain_to_redirect) { 'trial.domain' }
+  let(:domain) { 'production.domain' }
+
+  scenario 'User accesses the system on the domain to redirect and is redirected' do
+    visit "http://#{domain_to_redirect}"
+
+    expect(page.current_host).to eql("http://#{domain}")
+  end
+
+  scenario 'User accesses the system on the final domain and is not redirected' do
+    visit "http://#{domain}"
+
+    expect(page.current_host).to eql("http://#{domain}")
+  end
+end


### PR DESCRIPTION
This allows us to redirect requests coming to a domain to another domain. Useful for the `trial -> prod` migration.