### PR TITLE
Restore dwp banner

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,7 +1,6 @@
 =content_for(:head_scripts) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
 
-/.page-error = t('error_messages.dwp_unavailable')
-.dwp-restored.util_mt-medium =t('error_messages.dwp_restored')
+=render("shared/dwp/#{@state}")
 
 .grid-row.equal-heightboxes.util_mt-medium
   - if policy(:application).new?

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -10,6 +10,49 @@ RSpec.describe HomeController, type: :controller do
 
   describe 'GET #index' do
     context 'when the user is authenticated' do
+      describe 'DWP status banner' do
+
+        before { sign_in staff }
+
+        subject { assigns(:state) }
+
+        context 'when less than 25% of the last dwp_results are "400 Bad Request"' do
+          before do
+            build_with_bad_requests(8, 2)
+            get :index
+          end
+
+          it { is_expected.to eql 'online' }
+        end
+
+        context 'when more than 25% of the last dwp_results are "400 Bad Request"' do
+          before do
+            build_with_bad_requests(6, 4)
+            get :index
+          end
+
+          it { is_expected.to eql 'warning' }
+        end
+
+        context 'checks for "Server broke connection" messages too' do
+          before do
+            build_both_errors
+            get :index
+          end
+
+          it { is_expected.to eql 'warning' }
+        end
+
+        context 'when more than 50% of the last dwp_results are "400 Bad Request"' do
+          before do
+            build_with_bad_requests
+            get :index
+          end
+
+          it { is_expected.to eql 'offline' }
+        end
+      end
+
       context 'as a user' do
 
         before(:each) do

--- a/spec/services/dwp_monitor_spec.rb
+++ b/spec/services/dwp_monitor_spec.rb
@@ -10,38 +10,25 @@ describe DwpMonitor do
       subject { service.state }
 
       context 'when more than 50% of the last dwp_results are "400 Bad Request"' do
-        before do
-          create_list :benefit_check, 5, :yes_result
-          create_list :benefit_check, 5, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
-        end
+        before { build_with_bad_requests }
 
         it { is_expected.to eql 'offline' }
       end
 
       context 'when more than 25% of the last dwp_results are "400 Bad Request"' do
-        before do
-          create_list :benefit_check, 6, :yes_result
-          create_list :benefit_check, 4, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
-        end
+        before { build_with_bad_requests(6, 4) }
 
         it { is_expected.to eql 'warning' }
       end
 
       context 'checks for "Server broke connection" messages too' do
-        before do
-          create_list :benefit_check, 6, :yes_result
-          create_list :benefit_check, 2, dwp_result: 'Unspecified error', error_message: 'Server broke connection'
-          create_list :benefit_check, 2, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
-        end
+        before { build_both_errors }
 
         it { is_expected.to eql 'warning' }
       end
 
       context 'when less than 25% of the last dwp_results are "400 Bad Request"' do
-        before do
-          create_list :benefit_check, 8, :yes_result
-          create_list :benefit_check, 2, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
-        end
+        before { build_with_bad_requests(8, 2) }
 
         it { is_expected.to eql 'online' }
       end

--- a/spec/support/dwp_setup.rb
+++ b/spec/support/dwp_setup.rb
@@ -1,0 +1,25 @@
+module DwpSetup
+
+  def build_with_bad_requests(yes_response = 5, bad_requests = 5)
+    teardown
+    create_list :benefit_check, yes_response, :yes_result
+    create_list :benefit_check, bad_requests, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
+  end
+
+  def build_both_errors
+    teardown
+    create_list :benefit_check, 6, :yes_result
+    create_list :benefit_check, 2, dwp_result: 'Unspecified error', error_message: 'Server broke connection'
+    create_list :benefit_check, 2, dwp_result: 'Unspecified error', error_message: '400 Bad Request'
+  end
+
+  private
+
+  def teardown
+    BenefitCheck.delete_all
+  end
+end
+
+RSpec.configure do |c|
+  c.include DwpSetup
+end

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "home/index.html.slim", type: :view do
   let(:report_graphs?) { false }
   let(:report_index?) { false }
   let(:office_index?) { false }
+  let(:dwp_state) { 'online' }
 
   before do
     allow(view).to receive(:policy).with(:application).and_return(double(new?: application_new?, index?: application_index?))
@@ -19,7 +20,7 @@ RSpec.describe "home/index.html.slim", type: :view do
     allow(view).to receive(:policy).with(:office).and_return(double(index?: office_index?))
 
     sign_in user
-    assign(:state, 'online')
+    assign(:state, dwp_state)
     assign(:search_form, double(errors: {}, reference: nil))
     render
   end
@@ -146,6 +147,24 @@ RSpec.describe "home/index.html.slim", type: :view do
       it 'are not rendered' do
         is_expected.not_to have_xpath('//h2', text: 'Total')
       end
+    end
+  end
+
+  describe 'DWP banner' do
+    context 'when the service is online' do
+      it { is_expected.to have_content I18n.t('error_messages.dwp_restored') }
+    end
+
+    context 'when the service is failing or restoring' do
+      let(:dwp_state) { 'warning' }
+
+      it { is_expected.to have_content I18n.t('error_messages.dwp_warning') }
+    end
+
+    context 'when the service is offline' do
+      let(:dwp_state) { 'offline' }
+
+      it { is_expected.to have_content I18n.t('error_messages.dwp_unavailable') }
     end
   end
 end


### PR DESCRIPTION
This restores the conditional display of the DWP status banner.

It got removed during the foundation removal.

Tests have been added to ensure that the controller generates the correct state and that the view displays the correct text.