### PR TITLE
Display DWP maintenance banner for date range

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -22,6 +22,10 @@ class HomeController < ApplicationController
     end
   end
 
+  helper_method def dwp_maintenance?
+    Time.zone.now < Time.zone.parse('24/04/2016 20:00:00')
+  end
+
   private
 
   def manager_setup_progress

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,6 +1,9 @@
 =content_for(:head_scripts) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
 
-=render("shared/dwp/#{@state}")
+- if dwp_maintenance?
+  =render("shared/dwp/maintenance")
+- else
+  =render("shared/dwp/#{@state}")
 
 .grid-row.equal-heightboxes.util_mt-medium
   - if policy(:application).new?

--- a/app/views/shared/dwp/_maintenance.html.slim
+++ b/app/views/shared/dwp/_maintenance.html.slim
@@ -1,0 +1,2 @@
+.util_mt-large
+  .page-error = t('error_messages.dwp_maintenance')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en-GB:
       copy: How to process an application, deal with spot checks, part payments, appeals, and fraud.
       link: See the guides
   error_messages:
+    dwp_maintenance: "The DWP checker will be unavailable from 9pm on Friday 22 April 2016 until 7am Monday 25 April 2016 for essential maintenance to be completed."
     dwp_unavailable: "There’s a problem with the service. You can't check if applicants are receiving benefits, but you can accept benefits letters. For emergency applications, complete an undertaking. You can process income-based applications as usual."
     dwp_warning: "There may be a problem with the service. You may not be able to check if applicants are receiving benefits, this is being investigated."
     dwp_restored: "The connection with the DWP is currently working.  Benefits based and income based applications can now be processed."

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -180,4 +180,24 @@ RSpec.describe HomeController, type: :controller do
       end
     end
   end
+
+  describe '#dwp_maintenance?' do
+    subject do
+      Timecop.freeze(current_time) do
+        controller.dwp_maintenance?
+      end
+    end
+
+    context 'when the current time is before 7am 25th April 2016' do
+      let(:current_time) { Time.zone.parse('23/04/2016 13:00:00') }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when the current time is at or after 8pm 24th April 2016' do
+      let(:current_time) { Time.zone.parse('24/04/2016 20:00:00') }
+
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
A temporary banner timed to be displayed on the homepage.

The view spec is a bit hacky, but the view has to be extended to include the `dwp_maintenance?` method, which then can be stubbed.