### PR TITLE
Enable default jurisdiction

### DIFF
--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -4,6 +4,7 @@ class OnlineApplicationsController < ApplicationController
   def edit
     authorize online_application
     @form = Forms::OnlineApplication.new(online_application)
+    @form.update_attributes(jurisdiction_id: current_user.jurisdiction_id)
     assign_jurisdictions
   end
 

--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -4,7 +4,7 @@ class OnlineApplicationsController < ApplicationController
   def edit
     authorize online_application
     @form = Forms::OnlineApplication.new(online_application)
-    @form.update_attributes(jurisdiction_id: current_user.jurisdiction_id)
+    @form.enable_default_jurisdiction(current_user)
     assign_jurisdictions
   end
 

--- a/app/models/forms/online_application.rb
+++ b/app/models/forms/online_application.rb
@@ -26,6 +26,10 @@ module Forms
       self.emergency = true if emergency_reason.present?
     end
 
+    def enable_default_jurisdiction(user)
+      self.jurisdiction_id = user.jurisdiction_id
+    end
+
     private
 
     def min_date

--- a/spec/controllers/online_applications_controller_spec.rb
+++ b/spec/controllers/online_applications_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe OnlineApplicationsController, type: :controller do
   describe 'GET #edit' do
     let(:params) { { jurisdiction_id: user.jurisdiction_id } }
     before do
-      allow(form).to receive(:update_attributes).with(params)
+      allow(form).to receive(:enable_default_jurisdiction).with(user)
       allow(form).to receive(:jurisdiction_id).and_return(user.jurisdiction_id)
       get :edit, id: id
     end

--- a/spec/controllers/online_applications_controller_spec.rb
+++ b/spec/controllers/online_applications_controller_spec.rb
@@ -17,7 +17,10 @@ RSpec.describe OnlineApplicationsController, type: :controller do
   end
 
   describe 'GET #edit' do
+    let(:params) { { jurisdiction_id: user.jurisdiction_id } }
     before do
+      allow(form).to receive(:update_attributes).with(params)
+      allow(form).to receive(:jurisdiction_id).and_return(user.jurisdiction_id)
       get :edit, id: id
     end
 
@@ -46,6 +49,18 @@ RSpec.describe OnlineApplicationsController, type: :controller do
 
       it 'assigns the user\'s office jurisdictions' do
         expect(assigns(:jurisdictions)).to eq(user.office.jurisdictions)
+      end
+
+      it 'sets the jurisdiction of the new object' do
+        expect(assigns(:form).jurisdiction_id).to eq user.jurisdiction_id
+      end
+
+      context 'when the user does not have a default jurisdiction' do
+        let(:user) { create :user, jurisdiction_id: nil }
+
+        it 'sets the jurisdiction of the new object' do
+          expect(assigns(:form).jurisdiction_id).to be_nil
+        end
       end
     end
   end

--- a/spec/models/forms/online_application_spec.rb
+++ b/spec/models/forms/online_application_spec.rb
@@ -32,6 +32,26 @@ RSpec.describe Forms::OnlineApplication do
     end
   end
 
+  describe '#enable_default_jurisdiction' do
+    let(:user) { create :staff, jurisdiction: jurisdiction }
+
+    subject { form.jurisdiction_id }
+
+    before { form.enable_default_jurisdiction(user) }
+
+    context 'when the user has no default jurisdiction' do
+      let(:jurisdiction) { nil }
+
+      it { is_expected.to eq nil }
+    end
+
+    context 'when the user has a default jurisdiction' do
+      let(:jurisdiction) { create :jurisdiction }
+
+      it { is_expected.to eq jurisdiction.id }
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:fee) }
     it { is_expected.to validate_numericality_of(:fee) }


### PR DESCRIPTION
When processing online-applications a users' default jurisdiction
was not being set on the new object and being shown on the view

[Pivotal](https://www.pivotaltracker.com/story/show/118470941)

[finishes #118470941]