### PR TITLE
Prevent public HWF reference reuse

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,6 @@ class HomeController < ApplicationController
 
   def search
     @search_form = Forms::Search.new(search_params)
-
     online_application = search_and_return
     if online_application
       redirect_to(edit_online_application_path(online_application))
@@ -73,12 +72,18 @@ class HomeController < ApplicationController
 
   def search_and_return
     if @search_form.valid?
-      begin
-        OnlineApplication.find_by!(reference: @search_form.reference.upcase)
-      rescue ActiveRecord::RecordNotFound
-        @search_form.errors.add(:reference, :not_found)
-        nil
+      @search = ApplicationSearch.new(@search_form.reference.upcase, current_user)
+      @matched = @search.for_hwf
+      if @matched.is_a? OnlineApplication
+        return @matched
+      else
+        @search_form.errors.add(:reference, @search.error_message)
       end
+      return nil
     end
+  end
+
+  def can_show(application)
+    application.office == current_user.office
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -72,18 +72,14 @@ class HomeController < ApplicationController
 
   def search_and_return
     if @search_form.valid?
-      @search = ApplicationSearch.new(@search_form.reference.upcase, current_user)
-      @matched = @search.for_hwf
-      if @matched.is_a? OnlineApplication
-        return @matched
+      search = ApplicationSearch.new(@search_form.reference, current_user)
+      matched = search.for_hwf
+      if matched.is_a? OnlineApplication
+        return matched
       else
-        @search_form.errors.add(:reference, @search.error_message)
+        @search_form.errors.add(:reference, search.error_message)
       end
       return nil
     end
-  end
-
-  def can_show(application)
-    application.office == current_user.office
   end
 end

--- a/app/services/application_search.rb
+++ b/app/services/application_search.rb
@@ -41,7 +41,7 @@ class ApplicationSearch
   end
 
   def user_can_access
-    ApplicationPolicy.new(@current_user, @application).show?
+    Pundit.policy(@current_user, @application).show?
   end
 
   def online_application_exists

--- a/app/services/application_search.rb
+++ b/app/services/application_search.rb
@@ -9,6 +9,7 @@ class ApplicationSearch
 
   def for_hwf
     return unless @reference.present?
+    @reference.upcase!
     return false if application_exists_and_user_can_access
     return false if application_exists_and_user_cannot_access
 
@@ -40,7 +41,7 @@ class ApplicationSearch
   end
 
   def user_can_access
-    @application.office == @current_user.office
+    ApplicationPolicy.new(@current_user, @application).show?
   end
 
   def online_application_exists

--- a/app/services/application_search.rb
+++ b/app/services/application_search.rb
@@ -1,0 +1,57 @@
+class ApplicationSearch
+
+  attr_reader :error_message
+
+  def initialize(reference, current_user)
+    @reference = reference
+    @current_user = current_user
+  end
+
+  def for_hwf
+    return unless @reference.present?
+    return false if application_exists_and_user_can_access
+    return false if application_exists_and_user_cannot_access
+
+    if online_application_exists
+      @online_application
+    else
+      @error_message = I18n.t(:not_found, scope: scope)
+      false
+    end
+  end
+
+  private
+
+  def application_exists_and_user_can_access
+    if application_exists && user_can_access
+      redirect_data = CompletedApplicationRedirect.new(@application)
+      @error_message = I18n.t(:processed_html, scope: scope, application_path: redirect_data.path)
+    end
+  end
+
+  def application_exists_and_user_cannot_access
+    if application_exists && !user_can_access
+      @error_message = I18n.t(:processed_by, scope: scope, office_name: application_office)
+    end
+  end
+
+  def application_exists
+    @application ||= Application.find_by(reference: @reference.upcase)
+  end
+
+  def user_can_access
+    @application.office == @current_user.office
+  end
+
+  def online_application_exists
+    @online_application ||= OnlineApplication.find_by(reference: @reference.upcase)
+  end
+
+  def scope
+    'activemodel.errors.models.forms/search.attributes.reference'
+  end
+
+  def application_office
+    @application.office.name
+  end
+end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -29,7 +29,7 @@
           h3.heading-medium.util_mt-0 Process an online application
           .form-group.panel-inner
             = f.label :reference, class: 'form-label'
-            = f.label :reference, @search_form.errors[:reference].join(', '), class: 'error' if @search_form.errors[:reference].present?
+            = f.label :reference, @search_form.errors[:reference].join('').html_safe, class: 'error' if @search_form.errors[:reference].present?
             = f.text_field :reference, { class: 'form-control small-field', autocomplete: 'off' }
           .util_mt-0
             = f.submit 'Look up', class: 'button util_margin-0'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,6 +428,8 @@ en-GB:
             reference:
               blank: 'Must not be blank'
               not_found: 'Application not found'
+              processed_html: 'Has been processed, <a href="%{application_path}">click to display</a>'
+              processed_by: 'Has been processed by %{office_name}'
         forms/online_application:
           attributes:
             fee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,8 +428,8 @@ en-GB:
             reference:
               blank: 'Must not be blank'
               not_found: 'Application not found'
-              processed_html: 'Has been processed, <a href="%{application_path}">click to display</a>'
-              processed_by: 'Has been processed by %{office_name}'
+              processed_html: 'This application has been processed, <a href="%{application_path}">view application</a>'
+              processed_by: 'This application has been processed by %{office_name}'
         forms/online_application:
           attributes:
             fee:

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -125,10 +125,12 @@ RSpec.describe HomeController, type: :controller do
 
   describe 'POST #search' do
     let(:online_application) { build_stubbed(:online_application, :with_reference) }
+    let(:application) { nil }
 
     before do
-      allow(OnlineApplication).to receive(:find_by!).with(reference: online_application.reference).and_return(online_application)
-      allow(OnlineApplication).to receive(:find_by!).with(reference: 'WRONG').and_raise(ActiveRecord::RecordNotFound)
+      allow(OnlineApplication).to receive(:find_by).with(reference: online_application.reference).and_return(online_application)
+      allow(OnlineApplication).to receive(:find_by).with(reference: 'WRONG').and_return(nil)
+      allow(Application).to receive(:find_by).with(reference: online_application.reference).and_return(application) unless application.nil?
 
       sign_in(user)
       post :search, search: search_params
@@ -176,6 +178,15 @@ RSpec.describe HomeController, type: :controller do
 
         it 'does not assign the DwpMonitor state' do
           expect(assigns(:state)).to be nil
+        end
+      end
+
+      context 'when an application exists with the reference' do
+        let(:reference) { online_application.reference }
+        let(:application) { build_stubbed(:application, reference: online_application.reference, office: user.office) }
+
+        it 'renders the index template' do
+          expect(response).to render_template(:index)
         end
       end
     end

--- a/spec/services/application_search_spec.rb
+++ b/spec/services/application_search_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ApplicationSearch do
       it { is_expected.to eql false }
 
       it 'sets the correct error message' do
-        expect(service.error_message).to include('click to display')
+        expect(service.error_message).to include('view application')
       end
     end
 

--- a/spec/services/application_search_spec.rb
+++ b/spec/services/application_search_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationSearch do
+  let(:reference) { nil }
+  let(:user) { create :staff }
+
+  subject(:service) { described_class.new(reference, user) }
+
+  it { is_expected.to respond_to :error_message }
+
+  describe '#for_hwf' do
+    let(:online_application) { build_stubbed(:online_application, :with_reference) }
+
+    subject { service.for_hwf }
+
+    before do
+      allow(OnlineApplication).to receive(:find_by).with(reference: online_application.reference).and_return(online_application)
+      allow(OnlineApplication).to receive(:find_by).with(reference: online_application.reference.reverse).and_return(nil)
+    end
+
+    context 'when reference is nil' do
+      it { is_expected.to eq nil }
+    end
+
+    context 'when an online_application exists' do
+      let(:reference) { online_application.reference }
+
+      it { is_expected.to eql online_application }
+    end
+
+    context 'when an application has been processed in my office' do
+      let(:reference) { online_application.reference }
+      let(:application) { build_stubbed(:application, reference: online_application.reference, office: user.office) }
+
+      before do
+        allow(Application).to receive(:find_by).with(reference: online_application.reference).and_return(application)
+        service.for_hwf
+      end
+
+      it { is_expected.to eql false }
+
+      it 'sets the correct error message' do
+        expect(service.error_message).to include('click to display')
+      end
+    end
+
+    context 'when an application has been processed by a different office' do
+      let(:office) { create :office }
+      let(:reference) { online_application.reference }
+      let(:application) { build_stubbed(:application, reference: online_application.reference, office: office) }
+
+      before do
+        allow(Application).to receive(:find_by).with(reference: online_application.reference).and_return(application)
+        service.for_hwf
+      end
+
+      it { is_expected.to eql false }
+
+      it 'sets the correct error message' do
+        expect(service.error_message).to include(office.name)
+      end
+    end
+
+    context 'when the reference is not there' do
+      let(:reference) { online_application.reference.reverse }
+
+      before { service.for_hwf }
+
+      it { is_expected.to be false }
+
+      it 'sets the correct error message' do
+        expect(service.error_message).to eq 'Application not found'
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a member of staff searched for a HWF reference that had already been processed, they would be allowed to continue until they hit complete processing, at which point it would crash.

This PR shows an error if the number has previously been processed.

If it was by the users office, it includes a routed link.
If it was by a different office, it includes the name of the office that processed it, but no link.

This is because of the Pundit policy for accessing applications for different offices.

[Pivotal](https://www.pivotaltracker.com/story/show/118470941)