### PR TITLE
Removed 'remission register' from guidance

### DIFF
--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -34,10 +34,8 @@ h4.heading-medium.util_mt-medium Reference
     -elsif @application.outcome.eql?('part')
       li Write to the applicant with details of how much they have to pay
       li Store the application form in a secure location until you receive the part-payment
-      li You don't need to complete the remission register until part-payment has been received
       li Write the reference number on the top right corner of the paper form
     -else
-      li Complete the remission register with the application details
       li Write the reference number on the top right corner of the paper form
       li Copy the reference number into the case management system
       li Write to the applicant and send back all the documents

--- a/app/views/evidence/confirmation.html.slim
+++ b/app/views/evidence/confirmation.html.slim
@@ -19,7 +19,6 @@
         -elsif @confirmation.outcome == 'part'
           li Write to the applicant with details of how much they have to pay
           li Store the application form in a secure location until you receive the part-payment
-          li You don't need to complete the remission register until part-payment has been received
           li Write the reference number on the top right corner of the paper form
         -else
           li Write the reference number on the top right corner of the paper form

--- a/app/views/guide/process_application.html.slim
+++ b/app/views/guide/process_application.html.slim
@@ -159,7 +159,7 @@ header
     p We’re trialling a new service for the public to apply for help with court fees online; soon it will be available to everyone in the UK. 
     p The new online service asks the same questions as the existing ‘apply for help with fees’ form (EX160) and you’ll be able to process it in the same way that you’ve been processing paper applications for help with fees. 
     ol.list.list-number 
-      li Everyone who applies for help with fees online will get a reference number, like this: HWF-1612-1345
+      li Everyone who applies for help with fees online will get a reference number, like this: HWF-A73-L8T
       li You’ll find the reference number on the court or tribunal form in the HWF reference number field, or in a letter if the applicant is applying for a refund
       li Enter this reference number in the ‘Process an online application field’. It's important to enter the dashes in the reference number exactly as they appear in the example above 
       li Check the name of the applicant is correct and enter the following details: fee; jurisdiction; and form name or number. You can also select whether it’s an emergency case

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,7 +181,6 @@ en-GB:
         - 'Write the reference number on the top right corner of the paper form'
         - 'Write to the applicant using the letter on this page to ask for evidence'
         - 'Store the application form in a secure location until you receive the evidence'
-        - "You don't need to complete the remission register until evidence has been received"
   activemodel:
     attributes:
       evidence/forms/income:

--- a/spec/features/applications/remission_confirmation_spec.rb
+++ b/spec/features/applications/remission_confirmation_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature 'Confirmation page for remission', type: :feature do
       let(:part_remission_copy) do
         ['Write to the applicant with details of how much they have to pay',
          'Store the application form in a secure location until you receive the part-payment',
-         "You don't need to complete the remission register until part-payment has been received",
          'Write the reference number on the top right corner of the paper form']
       end
 


### PR DESCRIPTION
Also, updated online ref number format example