### PR TITLE
Changes for benefit online submission

### DIFF
--- a/app/builders/application_builder.rb
+++ b/app/builders/application_builder.rb
@@ -38,10 +38,17 @@ class ApplicationBuilder
   end
 
   def online_application_attributes(online_application)
-    fields = %i[threshold_exceeded benefits income children reference]
-    {
-      dependents: (online_application.children > 0)
-    }.merge(prepare_attributes(fields, online_application))
+    fields = %i[threshold_exceeded benefits income reference]
+    prepare_attributes(fields, online_application).merge(dependent_attributes(online_application))
+  end
+
+  def dependent_attributes(online_application)
+    {}.tap do |attributes|
+      if online_application.children.present?
+        attributes[:dependents] = online_application.children > 0
+        attributes[:children] = online_application.children
+      end
+    end
   end
 
   def online_applicant_attributes(online_application)

--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -1,7 +1,7 @@
 class OnlineApplication < ActiveRecord::Base
   belongs_to :jurisdiction
 
-  validates :children, :ni_number, :date_of_birth, :first_name, :last_name, :address,
+  validates :ni_number, :date_of_birth, :first_name, :last_name, :address,
     :postcode, presence: true
   validates :married, :threshold_exceeded, :benefits, :refund, :probate, :email_contact,
     :phone_contact, :post_contact, :feedback_opt_in, inclusion: [true, false]

--- a/db/migrate/20160509081902_allow_null_income_columns_for_online_application.rb
+++ b/db/migrate/20160509081902_allow_null_income_columns_for_online_application.rb
@@ -1,0 +1,5 @@
+class AllowNullIncomeColumnsForOnlineApplication < ActiveRecord::Migration
+  def change
+    change_column_null :online_applications, :children, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160414093931) do
+ActiveRecord::Schema.define(version: 20160509081902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,8 +31,8 @@ ActiveRecord::Schema.define(version: 20160414093931) do
   add_index "applicants", ["application_id"], name: "index_applicants_on_application_id", using: :btree
 
   create_table "applications", force: :cascade do |t|
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
     t.integer  "user_id"
     t.integer  "office_id"
     t.decimal  "threshold"
@@ -88,11 +88,11 @@ ActiveRecord::Schema.define(version: 20160414093931) do
   add_index "benefit_checks", ["user_id"], name: "index_benefit_checks_on_user_id", using: :btree
 
   create_table "benefit_overrides", force: :cascade do |t|
-    t.integer  "application_id",  null: false
+    t.integer  "application_id",   null: false
     t.boolean  "correct"
     t.integer  "completed_by_id"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
     t.string   "incorrect_reason"
   end
 
@@ -190,7 +190,7 @@ ActiveRecord::Schema.define(version: 20160414093931) do
     t.boolean  "married",            null: false
     t.boolean  "threshold_exceeded", null: false
     t.boolean  "benefits",           null: false
-    t.integer  "children",           null: false
+    t.integer  "children"
     t.integer  "income"
     t.boolean  "refund",             null: false
     t.date     "date_fee_paid"

--- a/spec/builders/application_builder_spec.rb
+++ b/spec/builders/application_builder_spec.rb
@@ -113,6 +113,18 @@ RSpec.describe ApplicationBuilder do
         end
       end
 
+      context 'when the online application does not specify children' do
+        let(:online_application) { build_stubbed(:online_application_with_all_details, children: nil) }
+
+        it 'has the dependents flag not to be set' do
+          expect(built_application.dependents).to be nil
+        end
+
+        it 'has the children number set as nil' do
+          expect(built_application.children).to be nil
+        end
+      end
+
       it 'has applicant record built' do
         expect(built_application.applicant).to be_a(Applicant)
         expect(built_application.applicant).not_to be_persisted

--- a/spec/models/online_application_spec.rb
+++ b/spec/models/online_application_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe OnlineApplication, type: :model do
 
   it { is_expected.to belong_to(:jurisdiction) }
 
-  it { is_expected.to validate_presence_of(:children) }
   it { is_expected.to validate_presence_of(:ni_number) }
   it { is_expected.to validate_presence_of(:date_of_birth) }
   it { is_expected.to validate_presence_of(:first_name) }


### PR DESCRIPTION
This change allows `children` to be set to `nil` for `OnlineApplication`, which is needed for the branching of benefit/income journeys in the public app.