### PR TITLE
nasty css hacky border rubbish for fee box

### DIFF
--- a/app/assets/stylesheets/local/errors.scss
+++ b/app/assets/stylesheets/local/errors.scss
@@ -26,10 +26,27 @@ div.form-group div.field_with_errors + .field-wrapper {
   padding-left: 10px;
 }
 
+div.form-group div.field_with_errors + .field-wrapper {
+  border-right: 0;
+  border-top: 0;
+  border-bottom: 0;
+
+  .currency {
+    border: 1px solid $grey-2;
+    border-right: none;
+    padding-bottom: 4px;
+  }
+}
+
 .field-wrapper {
   .field_with_errors {
     display: inline-block;
-    width: 90%;
+    width: 85%;
+
+    input {
+      border: 1px solid $grey-2;
+      border-left: none;
+    }
   }
 }
 


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/118280569)

The border on the fee box is faked using a wrapping `div` so that it encompasses the currency symbol. This broke badly when the error handling styles were invoked. This works around that with further fakey bordery nonsense.

Before
---
![screen shot 2016-05-17 at 14 50 01](https://cloud.githubusercontent.com/assets/988436/15324542/c819f43c-1c3e-11e6-95b0-12d02c40546d.png)

After
---
![screen shot 2016-05-17 at 14 49 49](https://cloud.githubusercontent.com/assets/988436/15324546/cbadfe40-1c3e-11e6-8947-25000e8c62eb.png)

 