### PR TITLE
Performance platform integration

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -46,5 +46,6 @@
 
 - content_for :javascripts
   = javascript_include_tag('application.js')
+  = render('shared/analytics')
 
 = render template: "layouts/local-template"

--- a/app/views/layouts/local-template.html.erb
+++ b/app/views/layouts/local-template.html.erb
@@ -61,7 +61,7 @@
   </head>
 
   <body class="<%= content_for?(:body_classes) ? raw("#{yield(:body_classes)}") : "#{config_item(:phase).to_s.downcase} #{config_item(:product_type).to_s.downcase}" %>">
-    <%= render :partial => 'shared/tag_manager' %>
+    <%= render 'shared/tag_manager' %>
     <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
     <%= yield :body_start %>
@@ -132,7 +132,7 @@
         <% end %>
 
 
-    <%= render :partial => 'shared/footer' %>
+    <%= render 'shared/footer' %>
 
     <!--end footer-->
 

--- a/app/views/layouts/local-template.html.erb
+++ b/app/views/layouts/local-template.html.erb
@@ -61,6 +61,7 @@
   </head>
 
   <body class="<%= content_for?(:body_classes) ? raw("#{yield(:body_classes)}") : "#{config_item(:phase).to_s.downcase} #{config_item(:product_type).to_s.downcase}" %>">
+    <%= render :partial => 'shared/tag_manager' %>
     <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
     <%= yield :body_start %>

--- a/app/views/shared/_analytics.html.slim
+++ b/app/views/shared/_analytics.html.slim
@@ -1,0 +1,11 @@
+javascript:
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('set', 'anonymizeIp', true);
+  ga('create', "#{Settings.analytics.id}", "#{Settings.analytics.domain}", {'allowLinker': true});
+  ga('send', 'pageview');
+
+= yield(:analytic_events)

--- a/app/views/shared/_tag_manager.html.slim
+++ b/app/views/shared/_tag_manager.html.slim
@@ -1,0 +1,10 @@
+javascript:
+  <!-- Google Tag Manager -->
+  <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-K4ZTK6"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-K4ZTK6');</script>
+  <!-- End Google Tag Manager -->

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,3 +17,6 @@ redirection:
   domains: <%= ENV['REDIRECTION_DOMAINS'] || '' %>
 active_job:
   enabled: <%= ENV['ACTIVE_JOB_ENABLED'].present? && ['1', 'true'].include?(ENV['ACTIVE_JOB_ENABLED'].downcase) %>
+analytics:
+  id: <%= ENV['GA_ID'] || 'UA-37377084-54' %>
+  domain: <%= ENV['GA_DOMAIN'] || 'auto' %>


### PR DESCRIPTION
Add Google Analytics and Google Tag Manager to the staff app to enable generation of GDS performance Platform metrics.

Use Tags, Triggers and events to generate completed events upon form submission.

Initially, I have added the google JS code snippets and I will try configuring the recording of events between Google Tags and Google Analytics events. 

