### PR TITLE
DWP down update

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,8 +30,3 @@
 //= require cookies
 //= require login
 //= require fee_field
-
-$(function(){
-  // fire init method of moj module loader
-  window.moj.init();
-});

--- a/app/assets/javascripts/equal_height_boxes.js
+++ b/app/assets/javascripts/equal_height_boxes.js
@@ -4,26 +4,43 @@ window.moj.Modules.equalHeightBoxes = {
   init: function() {
     var self = this;
 
-    if($('.equal-heightboxes').length) {
-      self.equaliseBoxes('.equal-heightboxes', '.panel');
+    if($('[data-equalheight="true"]').length) {
+      self.getBoxGroups();
     }
   },
 
-  equaliseBoxes: function(wrapper, panel) {
-    var wrappers = $(wrapper);
+  getBoxGroups: function() {
+    var self = this,
+        groups = [];
 
-    wrappers.each(function(i, wrapper) {
-      var panels = $(wrapper).find(panel),
+    $('[data-equalheight="true"]').each(function(n, el) {
+      var $el = $(el);
+
+      if(groups.indexOf($el.data('heightgroup')) === -1) {
+        groups[groups.length] = $el.data('heightgroup');
+      }
+    });
+
+    if(groups.length) {
+      self.equaliseBoxes(groups);
+    }
+  },
+
+  equaliseBoxes: function(groups) {
+    for(var x in groups) {
+      var group = groups[x],
+          $boxes = $('[data-heightgroup="' + group + '"]'),
           max = 0;
 
-      panels.each(function(i, el) {
-        var height = $(el).height();
+      $boxes.each(function(n, box) {
+        var height = $(box).height();
 
         if(height >= max) {
           max = height;
         }
       });
-      panels.height(max);
-    });
+
+      $boxes.height(max);
+    }
   }
 };

--- a/app/assets/javascripts/equal_height_boxes.js
+++ b/app/assets/javascripts/equal_height_boxes.js
@@ -27,10 +27,9 @@ window.moj.Modules.equalHeightBoxes = {
   },
 
   equaliseBoxes: function(groups) {
-    for(var x in groups) {
-      var group = groups[x],
-          $boxes = $('[data-heightgroup="' + group + '"]'),
-          max = 0;
+    groups.forEach(function(group) {
+      var $boxes = $('[data-heightgroup="' + group + '"]'),
+           max = 0;
 
       $boxes.each(function(n, box) {
         var height = $(box).height();
@@ -41,6 +40,6 @@ window.moj.Modules.equalHeightBoxes = {
       });
 
       $boxes.height(max);
-    }
+    });
   }
 };

--- a/app/assets/stylesheets/local/panels.scss
+++ b/app/assets/stylesheets/local/panels.scss
@@ -98,26 +98,29 @@
   margin-top: 30px;
 }
 
-.grid-row.dwp-down {
-  .panel {
-    background-color: #fef6ea;
-    border-color: #f3a536;
-    margin-bottom: 0;
-    padding: 10px 20px;
+.dwp-down {
+  background-color: #fef6ea;
+  border: 1px solid #f3a536;
+  margin-bottom: 0;
+  padding: 10px 20px;
 
-    * {
-      font-size: 14px;
-    }
-    ul, p {
-      margin-bottom: 0;
-    }
+  * {
+    font-size: 14px;
   }
 
-  & + .grid-row {
-    margin-top: 0;
+  ul, p {
+    margin-bottom: 0;
+  }
 
-    .panel {
-      border-top: none;
-    }
+  & + .panel {
+    border-top: none;
   }
 }
+
+// & + .grid-row {
+//   margin-top: 0;
+
+//   .panel {
+//     border-top: none;
+//   }
+// }

--- a/app/assets/stylesheets/local/panels.scss
+++ b/app/assets/stylesheets/local/panels.scss
@@ -17,7 +17,7 @@
       flex-grow: 1;
 
       > label,
-      > .field_with_errors >label {
+      > .field_with_errors > label {
         margin-top: 0;
       }
     }
@@ -91,5 +91,33 @@
   }
   p {
     margin: 0;
+  }
+}
+
+.grid-row.staff-panels {
+  margin-top: 30px;
+}
+
+.grid-row.dwp-down {
+  .panel {
+    background-color: #fef6ea;
+    border-color: #f3a536;
+    margin-bottom: 0;
+    padding: 10px 20px;
+
+    * {
+      font-size: 14px;
+    }
+    ul, p {
+      margin-bottom: 0;
+    }
+  }
+
+  & + .grid-row {
+    margin-top: 0;
+
+    .panel {
+      border-top: none;
+    }
   }
 }

--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -60,6 +60,7 @@ module Applications
     end
 
     def benefits
+      @state = DwpMonitor.new.state
       if application.savings_investment_valid?
         @form = Forms::Application::Benefit.new(application)
         render :benefits

--- a/app/views/applications/process/benefits.html.slim
+++ b/app/views/applications/process/benefits.html.slim
@@ -3,7 +3,11 @@
   .grid-row
     .column-two-thirds
       header
-          h2.heading-xlarge Benefits
+          h2.heading-xlarge.util_mb-small Benefits
+
+      -if @state=='offline'
+        .util_mt-tiny.util_mb-small
+          .page-error = t('error_messages.benefit_check.dwp_unavailable')
 
       .form-group
         = f.label :benefits, class: 'form-label'

--- a/app/views/benefit_overrides/paper_evidence.html.slim
+++ b/app/views/benefit_overrides/paper_evidence.html.slim
@@ -1,7 +1,7 @@
 .grid-row
   .column-two-thirds
     header
-      h2.heading-xlarge Benefits
+      h2.heading-xlarge.util_mb_small Benefits
 
     - if error_message_partial
      .page-error.util_mb-medium

--- a/app/views/benefit_overrides/paper_evidence.html.slim
+++ b/app/views/benefit_overrides/paper_evidence.html.slim
@@ -1,7 +1,7 @@
 .grid-row
   .column-two-thirds
     header
-      h2.heading-xlarge.util_mb_small Benefits
+      h2.heading-xlarge.util_mb-small Benefits
 
     - if error_message_partial
      .page-error.util_mb-medium

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -45,7 +45,7 @@
             = f.label :reference, @search_form.errors[:reference].join('').html_safe, class: 'error' if @search_form.errors[:reference].present?
             .field-wrapper
               span.prefix HWF
-              = f.text_field :reference, { class: 'form-control small-field', autocomplete: 'off' }
+              = f.text_field :reference, { class: 'form-control small-field', autocomplete: 'off', disabled: @state=='offline' }
           .util_mt-0
             = f.submit 'Look up', class: 'button util_margin-0', disabled: @state=='offline'
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -21,12 +21,6 @@
   - if policy(:application).new?
     .column-one-half
       .util_pt-medium
-        /- if @state == 'offline'
-        .dwp-down
-          p =t('index.process.paper.dwp-down.heading')
-          ul.list.list-bullet
-            -t('index.process.paper.dwp-down.options').each do |option|
-              li =option
         .panel.flexi
           h3.heading-medium.util_mt-0 Process application
           .panel-inner
@@ -42,9 +36,6 @@
               =link_to 'Start now', create_applications_path, method: :post, class: 'button util_mb-0'
   .column-one-half
     .util_pt-medium
-      /- if @state == 'offline'
-      .dwp-down
-        p =t('index.process.digital.dwp-down')
       = form_for(@search_form, as: :search, url: home_search_path) do |f|
         .panel.flexi
           h3.heading-medium.util_mt-0 Process an online application

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -34,7 +34,7 @@
               span.prefix HWF
               = f.text_field :reference, { class: 'form-control small-field', autocomplete: 'off' }
           .util_mt-0
-            = f.submit 'Look up', class: 'button util_margin-0'
+            = f.submit 'Look up', class: 'button util_margin-0', disabled: @state=='offline'
 
 
 

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -7,12 +7,13 @@
 
 - if @state == 'offline'
   .grid-row.equal-heightboxes.util_mt-medium.dwp-down
-    .column-one-half
-      .panel
-        p =t('index.process.paper.dwp-down.heading')
-        ul.list.list-bullet
-          -t('index.process.paper.dwp-down.options').each do |option|
-            li =option
+    - if policy(:application).new?
+      .column-one-half
+        .panel
+          p =t('index.process.paper.dwp-down.heading')
+          ul.list.list-bullet
+            -t('index.process.paper.dwp-down.options').each do |option|
+              li =option
     .column-one-half
       .panel
         p =t('index.process.digital.dwp-down')

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -5,10 +5,28 @@
 - else
   =render("shared/dwp/#{@state}")
 
-.grid-row.equal-heightboxes.util_mt-medium
+- if @state == 'offline'
+  .grid-row.equal-heightboxes.util_mt-medium.dwp-down
+    .column-one-half
+      .panel
+        p =t('index.process.paper.dwp-down.heading')
+        ul.list.list-bullet
+          -t('index.process.paper.dwp-down.options').each do |option|
+            li =option
+    .column-one-half
+      .panel
+        p =t('index.process.digital.dwp-down')
+
+.grid-row.equal-heightboxes.staff-panels
   - if policy(:application).new?
     .column-one-half
       .util_pt-medium
+        /- if @state == 'offline'
+        .dwp-down
+          p =t('index.process.paper.dwp-down.heading')
+          ul.list.list-bullet
+            -t('index.process.paper.dwp-down.options').each do |option|
+              li =option
         .panel.flexi
           h3.heading-medium.util_mt-0 Process application
           .panel-inner
@@ -24,6 +42,9 @@
               =link_to 'Start now', create_applications_path, method: :post, class: 'button util_mb-0'
   .column-one-half
     .util_pt-medium
+      /- if @state == 'offline'
+      .dwp-down
+        p =t('index.process.digital.dwp-down')
       = form_for(@search_form, as: :search, url: home_search_path) do |f|
         .panel.flexi
           h3.heading-medium.util_mt-0 Process an online application

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -5,24 +5,18 @@
 - else
   =render("shared/dwp/#{@state}")
 
-- if @state == 'offline'
-  .grid-row.equal-heightboxes.util_mt-medium.dwp-down
-    - if policy(:application).new?
-      .column-one-half
-        .panel
-          p =t('index.process.paper.dwp-down.heading')
-          ul.list.list-bullet
-            -t('index.process.paper.dwp-down.options').each do |option|
-              li =option
-    .column-one-half
-      .panel
-        p =t('index.process.digital.dwp-down')
 
-.grid-row.equal-heightboxes.staff-panels
+.grid-row.staff-panels
   - if policy(:application).new?
     .column-one-half
       .util_pt-medium
-        .panel.flexi
+        - if @state == 'offline'
+          .dwp-down data-equalheight="true" data-heightgroup="1"
+            p =t('index.process.paper.dwp-down.heading')
+            ul.list.list-bullet
+              -t('index.process.paper.dwp-down.options').each do |option|
+                li =option
+        .panel.flexi data-equalheight="true" data-heightgroup="2"
           h3.heading-medium.util_mt-0 Process application
           .panel-inner
             p.util_mb-0 You'll need:
@@ -35,10 +29,14 @@
           - else
             .util_mt-0
               =link_to 'Start now', create_applications_path, method: :post, class: 'button util_mb-0'
+
   .column-one-half
     .util_pt-medium
       = form_for(@search_form, as: :search, url: home_search_path) do |f|
-        .panel.flexi
+        - if @state == 'offline'
+          .dwp-down data-equalheight="true" data-heightgroup="1"
+            p =t('index.process.digital.dwp-down')
+        .panel.flexi data-equalheight="true" data-heightgroup="2"
           h3.heading-medium.util_mt-0 Process an online application
           .form-group.panel-inner
             = f.label :reference, class: 'form-label'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,8 @@ en-GB:
       copy: How to process an application, deal with spot checks, part payments, appeals, and fraud.
       link: See the guides
   error_messages:
+    benefit_check:
+      dwp_unavailable: "You will only be able to process this application if you have paper evidence that the applicant is receiving benefits"
     dwp_maintenance: "The DWP checker will be unavailable from 9pm on Friday 22 April 2016 until 7am Monday 25 April 2016 for essential maintenance to be completed."
     dwp_unavailable: "The DWP checker is currently unavailable, you won't be able to check if applicants are receiving benefits"
     dwp_warning: "There may be a problem with the service. You may not be able to check if applicants are receiving benefits, this is being investigated."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,16 @@ en-GB:
       none_in_office: 'Ask your manager to assign jurisdictions to your office.'
     part_payment:
       cannot_be_saved: 'This return could not be processed'
+  index:
+    process:
+      paper:
+        dwp-down:
+          heading: "You can only process:"
+          options:
+            - "income-based applications"
+            - "benefits-based applications if the applicant has provided paper evidence"
+      digital:
+        dwp-down: "Please wait until the DWP checker is available to process online applications"
   feedback:
     rating_1: 'No'
     rating_2: 'I used an accessibility tool such as a screen reader'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en-GB:
       missing_details_html: |
         There’s a problem with the applicant’s surname, date of birth or National Insurance number.
         <a href="%{personal_information_url}">Check all details were entered correctly</a>
-      technical_error: Sorry, the Department for Work and Pensions checker is not available
+      technical_error: "You will only be able to process this application if you have paper evidence that the applicant is receiving benefits"
   evidence:
     correct: 'Yes, the evidence is for the correct applicant and dated in the last 3 months'
     incorrect: 'No, there is a problem with the evidence and it needs to be returned'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,7 +96,7 @@ en-GB:
       link: See the guides
   error_messages:
     dwp_maintenance: "The DWP checker will be unavailable from 9pm on Friday 22 April 2016 until 7am Monday 25 April 2016 for essential maintenance to be completed."
-    dwp_unavailable: "There’s a problem with the service. You can't check if applicants are receiving benefits, but you can accept benefits letters. For emergency applications, complete an undertaking. You can process income-based applications as usual."
+    dwp_unavailable: "The DWP checker is currently unavailable, you won't be able to check if applicants are receiving benefits"
     dwp_warning: "There may be a problem with the service. You may not be able to check if applicants are receiving benefits, this is being investigated."
     dwp_restored: "The connection with the DWP is currently working.  Benefits based and income based applications can now be processed."
     create_be_exists: "A business entity record for %{jurisdiction} already exists in %{office}"

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe Applications::ProcessController, type: :controller do
   let(:benefit_form) { double }
   let(:income_form) { double }
   let(:income_calculation_runner) { double(run: nil) }
+  let(:dwp_monitor) { double }
+  let(:dwp_state) { 'online' }
 
   before do
     sign_in user
@@ -22,6 +24,8 @@ RSpec.describe Applications::ProcessController, type: :controller do
     allow(Forms::Application::Benefit).to receive(:new).with(application).and_return(benefit_form)
     allow(Forms::Application::Income).to receive(:new).with(application).and_return(income_form)
     allow(IncomeCalculationRunner).to receive(:new).with(application).and_return(income_calculation_runner)
+    allow(dwp_monitor).to receive(:state).and_return(dwp_state)
+    allow(DwpMonitor).to receive(:new).and_return(dwp_monitor)
   end
 
   describe 'POST create' do
@@ -240,6 +244,20 @@ RSpec.describe Applications::ProcessController, type: :controller do
 
       it 'assigns the benefits form' do
         expect(assigns(:form)).to eql(benefit_form)
+      end
+
+      describe '@status' do
+        subject { assigns(:state) }
+
+        context 'when the dwp is up' do
+          it { is_expected.to eql(dwp_state) }
+        end
+
+        context 'when the dwp is down' do
+          let(:dwp_state) { 'offline' }
+
+          it { is_expected.to eql(dwp_state) }
+        end
       end
     end
   end

--- a/spec/features/applications/benefit_results_are_processed_spec.rb
+++ b/spec/features/applications/benefit_results_are_processed_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Benefit results are processed', type: :feature do
 
         scenario 'the benefits override page is rendered with an error message' do
           expect(page).to have_xpath('//h2', text: 'Benefits')
-          expect(page).to have_content('Sorry, the Department for Work and Pensions checker is not available')
+          expect(page).to have_content('You will only be able to process this application if you have paper evidence that the applicant is receiving benefits')
         end
       end
 
@@ -93,7 +93,7 @@ RSpec.feature 'Benefit results are processed', type: :feature do
 
         scenario 'the benefits override page is rendered with an error message' do
           expect(page).to have_xpath('//h2', text: 'Benefits')
-          expect(page).to have_content('Sorry, the Department for Work and Pensions checker is not available')
+          expect(page).to have_content('You will only be able to process this application if you have paper evidence that the applicant is receiving benefits')
         end
       end
     end

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -171,6 +171,8 @@ RSpec.describe "home/index.html.slim", type: :view do
           it { is_expected.not_to have_content 'Please wait until the DWP checker is available to process online applications' }
 
           it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
+
+          it { is_expected.to have_xpath('//input[@id="search_reference"][not(@disabled)]') }
         end
 
         context 'when the service is failing or restoring' do
@@ -183,6 +185,8 @@ RSpec.describe "home/index.html.slim", type: :view do
           it { is_expected.not_to have_content 'Please wait until the DWP checker is available to process online applications' }
 
           it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
+
+          it { is_expected.to have_xpath('//input[@id="search_reference"][not(@disabled)]') }
         end
 
         context 'when the service is offline' do
@@ -195,6 +199,8 @@ RSpec.describe "home/index.html.slim", type: :view do
           it { is_expected.to have_content 'Please wait until the DWP checker is available to process online applications' }
 
           it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit" and @disabled]') }
+
+          it { is_expected.to have_xpath('//input[@id="search_reference" and @disabled]') }
         end
       end
     end

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -160,26 +160,42 @@ RSpec.describe "home/index.html.slim", type: :view do
 
   describe 'DWP banner' do
     context 'when the dwp maintenance is off' do
-      context 'when the service is online' do
-        it { is_expected.to have_content I18n.t('error_messages.dwp_restored') }
+      context 'and user can process paper application' do
+        let(:application_new?) { true }
 
-        it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
-      end
+        context 'when the service is online' do
+          it { is_expected.to have_content I18n.t('error_messages.dwp_restored') }
 
-      context 'when the service is failing or restoring' do
-        let(:dwp_state) { 'warning' }
+          it { is_expected.not_to have_content 'You can only process:' }
 
-        it { is_expected.to have_content I18n.t('error_messages.dwp_warning') }
+          it { is_expected.not_to have_content 'Please wait until the DWP checker is available to process online applications' }
 
-        it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
-      end
+          it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
+        end
 
-      context 'when the service is offline' do
-        let(:dwp_state) { 'offline' }
+        context 'when the service is failing or restoring' do
+          let(:dwp_state) { 'warning' }
 
-        it { is_expected.to have_content I18n.t('error_messages.dwp_unavailable') }
+          it { is_expected.to have_content I18n.t('error_messages.dwp_warning') }
 
-        it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit" and @disabled]') }
+          it { is_expected.not_to have_content 'You can only process:' }
+
+          it { is_expected.not_to have_content 'Please wait until the DWP checker is available to process online applications' }
+
+          it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
+        end
+
+        context 'when the service is offline' do
+          let(:dwp_state) { 'offline' }
+
+          it { is_expected.to have_content I18n.t('error_messages.dwp_unavailable') }
+
+          it { is_expected.to have_content 'You can only process:' }
+
+          it { is_expected.to have_content 'Please wait until the DWP checker is available to process online applications' }
+
+          it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit" and @disabled]') }
+        end
       end
     end
 

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -162,18 +162,24 @@ RSpec.describe "home/index.html.slim", type: :view do
     context 'when the dwp maintenance is off' do
       context 'when the service is online' do
         it { is_expected.to have_content I18n.t('error_messages.dwp_restored') }
+
+        it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
       end
 
       context 'when the service is failing or restoring' do
         let(:dwp_state) { 'warning' }
 
         it { is_expected.to have_content I18n.t('error_messages.dwp_warning') }
+
+        it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"][not(@disabled)]') }
       end
 
       context 'when the service is offline' do
         let(:dwp_state) { 'offline' }
 
         it { is_expected.to have_content I18n.t('error_messages.dwp_unavailable') }
+
+        it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit" and @disabled]') }
       end
     end
 


### PR DESCRIPTION
This will update the staff dashboard to highlight the degraded state of the DWP checker by:
### Done
- [x] updating the red box message for clarity
- [x] adding alerts above the functions that will be affected
- [x] styling the alert messages
- [x] disabling the online-application look up button

### To do
- [x] Align dwp-down boxes above staff panels responsively

### The dashboard should look like
![image](https://cloud.githubusercontent.com/assets/6757677/15543066/3f2772dc-228b-11e6-90d9-bccb821d5c72.png)

### currently it looks like
![screen shot 2016-05-27 at 11 55 26](https://cloud.githubusercontent.com/assets/6757677/15606615/334eabee-2405-11e6-8ca6-3467d08075d5.png)
#### and in phone mode
![image](https://cloud.githubusercontent.com/assets/6757677/15670769/0a59bbb2-271f-11e6-9055-8e6ed7597cf3.png)

