### PR TITLE
Processed application display

### DIFF
--- a/app/assets/stylesheets/local/panels.scss
+++ b/app/assets/stylesheets/local/panels.scss
@@ -68,7 +68,7 @@
     text-align: left;
   }
 
-  &.not-received, &.no, &.callout-none, &.callout-error {
+  &.not-received, &.no, &.callout-none, &.callout-error, &.callout-return {
     background-color: $error-colour;
   }
   &.received, &.yes, &.callout-full {

--- a/app/helpers/processed_views_helper.rb
+++ b/app/helpers/processed_views_helper.rb
@@ -1,7 +1,6 @@
 module ProcessedViewsHelper
   def assign_views
     @application = application
-    @processed = Views::ProcessingDetails.new(application)
     @overview = Views::ApplicationOverview.new(application)
     @result = Views::ApplicationResult.new(application)
     @summary = Views::ProcessedData.new(application)

--- a/app/helpers/processed_views_helper.rb
+++ b/app/helpers/processed_views_helper.rb
@@ -4,5 +4,6 @@ module ProcessedViewsHelper
     @processed = Views::ProcessingDetails.new(application)
     @overview = Views::ApplicationOverview.new(application)
     @result = Views::ApplicationResult.new(application)
+    @summary = Views::ProcessedData.new(application)
   end
 end

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -94,7 +94,7 @@ module Views
       @application.reference if evidence_check_or_part_payment?
     end
 
-    def decision_type
+    def return_type
       {
         'evidence_check' => 'evidence',
         'part_payment' => 'payment'

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -94,6 +94,10 @@ module Views
       @application.reference if evidence_check_or_part_payment?
     end
 
+    def decision_type
+      @application.decision_type.humanize.downcase if @application.decision_type
+    end
+
     private
 
     def evidence_check_or_part_payment?

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -95,7 +95,10 @@ module Views
     end
 
     def decision_type
-      @application.decision_type.humanize.downcase if @application.decision_type
+      {
+        'evidence_check' => 'evidence',
+        'part_payment' => 'payment'
+      }[@application.decision_type] || nil
     end
 
     private

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -25,7 +25,10 @@ module Views
     end
 
     def decision_type
-      @application.decision_type.humanize.downcase if @application.decision_type
+      {
+        'evidence_check' => 'evidence',
+        'part_payment' => 'payment'
+      }[@application.decision_type] || nil
     end
 
     private

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -7,7 +7,7 @@ module Views
     end
 
     def result
-      %w[full part none].include?(outcome) ? outcome : 'error'
+      %w[full part none return].include?(outcome) ? outcome : 'error'
     end
 
     def amount_to_pay
@@ -22,6 +22,10 @@ module Views
 
     def income
       format_locale(%w[full part].include?(result).to_s)
+    end
+
+    def decision_type
+      @application.decision_type.humanize.downcase if @application.decision_type
     end
 
     private

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -24,7 +24,7 @@ module Views
       format_locale(%w[full part].include?(result).to_s)
     end
 
-    def decision_type
+    def return_type
       {
         'evidence_check' => 'evidence',
         'part_payment' => 'payment'

--- a/app/models/views/processed_data.rb
+++ b/app/models/views/processed_data.rb
@@ -12,11 +12,7 @@ module Views
 
     def application_deleted
       if application_deleted?
-        {
-          on: prepare_date(@application.deleted_at),
-          by: @application.deleted_by.name,
-          text: "Reason for deletion: \"#{@application.deleted_reason}\""
-        }
+        build_delete_hash
       end
     end
 
@@ -55,6 +51,14 @@ module Views
         on: prepare_date(object.completed_at),
         by: prepare_name(object.completed_by),
         text: prepare_reason(object)
+      }
+    end
+
+    def build_delete_hash
+      {
+        on: prepare_date(@application.deleted_at),
+        by: prepare_name(@application.deleted_by),
+        text: "Reason for deletion: \"#{@application.deleted_reason}\""
       }
     end
 

--- a/app/models/views/processed_data.rb
+++ b/app/models/views/processed_data.rb
@@ -1,0 +1,80 @@
+# coding: utf-8
+module Views
+  class ProcessedData
+
+    def initialize(application)
+      @application = application
+    end
+
+    def application_processed
+      build_return_hash @application
+    end
+
+    def application_deleted
+      if application_deleted?
+        {
+          on: prepare_date(@application.deleted_at),
+          by: @application.deleted_by.name,
+          text: "Reason for deletion: \"#{@application.deleted_reason}\""
+        }
+      end
+    end
+
+    def evidence_check_processed
+      build_return_hash(evidence_check) if evidence_check_valid?
+    end
+
+    def part_payment_processed
+      build_return_hash(part_payment) if part_payment_valid?
+    end
+
+    private
+
+    def application_deleted?
+      @application.deleted_by.present?
+    end
+
+    def evidence_check_valid?
+      evidence_check && evidence_check.completed_at
+    end
+
+    def evidence_check
+      @application.evidence_check
+    end
+
+    def part_payment_valid?
+      part_payment && part_payment.completed_at
+    end
+
+    def part_payment
+      @application.part_payment
+    end
+
+    def build_return_hash(object)
+      {
+        on: prepare_date(object.completed_at),
+        by: prepare_name(object.completed_by),
+        text: prepare_reason(object)
+      }
+    end
+
+    def prepare_name(user)
+      user.name if user
+    end
+
+    def prepare_date(date)
+      date.strftime(Date::DATE_FORMATS[:gov_uk_long]) if date
+    end
+
+    def prepare_reason(object)
+      if object.is_a?(Application)
+        text = object.emergency_reason
+        prefix = 'Reason for emergency'
+      else
+        text = object.incorrect_reason
+        prefix = 'Reason not processed'
+      end
+      "#{prefix}: \"#{text}\"" if text
+    end
+  end
+end

--- a/app/views/shared/_remission_type.html.slim
+++ b/app/views/shared/_remission_type.html.slim
@@ -1,2 +1,2 @@
 #result.callout class="callout-#{source.result}"
-  h3.heading-large =t("remissions.#{source.result}", amount_to_pay: source.amount_to_pay, decision_type: source.decision_type).html_safe
+  h3.heading-large =t("remissions.#{source.result}", amount_to_pay: source.amount_to_pay, return_type: source.return_type).html_safe

--- a/app/views/shared/_remission_type.html.slim
+++ b/app/views/shared/_remission_type.html.slim
@@ -1,2 +1,2 @@
 #result.callout class="callout-#{source.result}"
-  h3.heading-large =t("remissions.#{source.result}", amount_to_pay: source.amount_to_pay).html_safe
+  h3.heading-large =t("remissions.#{source.result}", amount_to_pay: source.amount_to_pay, decision_type: source.decision_type).html_safe

--- a/app/views/shared/processed_and_deleted/_show.html.slim
+++ b/app/views/shared/processed_and_deleted/_show.html.slim
@@ -3,7 +3,6 @@ header
 
 =build_section 'Personal details', @overview, %w[full_name date_of_birth ni_number status number_of_children total_monthly_income]
 =build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name case_number deceased_name date_of_death date_fee_paid emergency_reason reference]
-=build_section 'Processing details', @processed, %w[processed_on processed_by deleted_on deleted_by deleted_reason]
 =build_section 'Result', @overview, @overview.savings_investment_params
 
 =render(partial: 'shared/remission_type', locals: { source: @result })

--- a/app/views/shared/processed_and_deleted/_show.html.slim
+++ b/app/views/shared/processed_and_deleted/_show.html.slim
@@ -5,7 +5,7 @@ header
 =build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name case_number deceased_name date_of_death date_fee_paid emergency_reason reference]
 =build_section 'Result', @overview, @overview.savings_investment_params
 
-=render(partial: 'shared/remission_type', locals: { source: @result, decision_type: @application.decision_type.humanize.downcase })
+=render(partial: 'shared/remission_type', locals: { source: @result })
 
 h4.heading-medium.util_mt-0 Processing summary
 table.processed_summary.util_mb-large

--- a/app/views/shared/processed_and_deleted/_show.html.slim
+++ b/app/views/shared/processed_and_deleted/_show.html.slim
@@ -5,7 +5,7 @@ header
 =build_section 'Application details', @overview, %w[fee jurisdiction date_received form_name case_number deceased_name date_of_death date_fee_paid emergency_reason reference]
 =build_section 'Result', @overview, @overview.savings_investment_params
 
-=render(partial: 'shared/remission_type', locals: { source: @result })
+=render(partial: 'shared/remission_type', locals: { source: @result, decision_type: @application.decision_type.humanize.downcase })
 
 h4.heading-medium.util_mt-0 Processing summary
 table.processed_summary.util_mb-large

--- a/app/views/shared/processed_and_deleted/_show.html.slim
+++ b/app/views/shared/processed_and_deleted/_show.html.slim
@@ -7,3 +7,30 @@ header
 =build_section 'Result', @overview, @overview.savings_investment_params
 
 =render(partial: 'shared/remission_type', locals: { source: @result })
+
+h4.heading-medium.util_mt-0 Processing summary
+table.processed_summary.util_mb-large
+  tbody
+    tr
+      th Application processed
+      td =@summary.application_processed[:on]
+      td =@summary.application_processed[:by]
+      td =@summary.application_processed[:text]
+    -if @summary.application_deleted
+      tr
+        th Application deleted
+        td =@summary.application_deleted[:on]
+        td =@summary.application_deleted[:by]
+        td =@summary.application_deleted[:text]
+    -if @summary.evidence_check_processed
+      tr
+        th Evidence processed
+        td =@summary.evidence_check_processed[:on]
+        td =@summary.evidence_check_processed[:by]
+        td =@summary.evidence_check_processed[:text]
+    -if @summary.part_payment_processed
+      tr
+        th Part-payment processed
+        td =@summary.part_payment_processed[:on]
+        td =@summary.part_payment_processed[:by]
+        td =@summary.part_payment_processed[:text]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,7 +183,7 @@ en-GB:
     part: The applicant must pay %{amount_to_pay} towards the fee
     none: '✗ &nbsp; Not eligible for help with fees'
     callout: Evidence of income needs to be checked
-    return: '✗ &nbsp; Not eligible because %{decision_type} returned'
+    return: '✗ &nbsp; Not eligible because %{decision_type} not provided'
   evidence_check:
     callout: Evidence of income needs to be checked
     page_title: Application waiting for evidence

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,7 +183,7 @@ en-GB:
     part: The applicant must pay %{amount_to_pay} towards the fee
     none: '✗ &nbsp; Not eligible for help with fees'
     callout: Evidence of income needs to be checked
-    return: '✗ &nbsp; Not eligible because %{decision_type} not provided'
+    return: '✗ &nbsp; Not eligible because %{return_type} not provided'
   evidence_check:
     callout: Evidence of income needs to be checked
     page_title: Application waiting for evidence

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,6 +183,7 @@ en-GB:
     part: The applicant must pay %{amount_to_pay} towards the fee
     none: '✗ &nbsp; Not eligible for help with fees'
     callout: Evidence of income needs to be checked
+    return: '✗ &nbsp; Not eligible because %{decision_type} returned'
   evidence_check:
     callout: Evidence of income needs to be checked
     page_title: Application waiting for evidence

--- a/spec/controllers/deleted_applications_controller_spec.rb
+++ b/spec/controllers/deleted_applications_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe DeletedApplicationsController, type: :controller do
 
   let(:overview) { double }
   let(:result) { double }
+  let(:summary) { double }
 
   before do
     sign_in user
@@ -18,6 +19,7 @@ RSpec.describe DeletedApplicationsController, type: :controller do
     allow(Application).to receive(:find).with(application1.id.to_s).and_return(application1)
     allow(Views::ApplicationOverview).to receive(:new).with(application1).and_return(overview)
     allow(Views::ApplicationResult).to receive(:new).with(application1).and_return(result)
+    allow(Views::ProcessedData).to receive(:new).with(application1).and_return(summary)
   end
 
   describe 'GET #index' do
@@ -71,6 +73,10 @@ RSpec.describe DeletedApplicationsController, type: :controller do
 
     it 'assigns the ApplicationResult view model' do
       expect(assigns(:result)).to eql(result)
+    end
+
+    it 'assigns the ProcessedData view model' do
+      expect(assigns(:summary)).to eql(summary)
     end
   end
 end

--- a/spec/controllers/processed_applications_controller_spec.rb
+++ b/spec/controllers/processed_applications_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
   let(:overview) { double }
   let(:result) { double }
   let(:delete_form) { double }
+  let(:summary) { double }
 
   before do
     sign_in user
@@ -19,6 +20,7 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
     allow(Views::ApplicationOverview).to receive(:new).with(application1).and_return(overview)
     allow(Views::ApplicationResult).to receive(:new).with(application1).and_return(result)
     allow(Forms::Application::Delete).to receive(:new).with(application1).and_return(delete_form)
+    allow(Views::ProcessedData).to receive(:new).with(application1).and_return(summary)
   end
 
   describe 'GET #index' do
@@ -68,6 +70,10 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
 
     it 'assigns the ApplicationResult view model' do
       expect(assigns(:result)).to eql(result)
+    end
+
+    it 'assigns the ProcessedData view model' do
+      expect(assigns(:summary)).to eql(summary)
     end
 
     it 'assigns the Delete form' do

--- a/spec/factories/part_payments.rb
+++ b/spec/factories/part_payments.rb
@@ -11,6 +11,12 @@ FactoryGirl.define do
       outcome 'none'
     end
 
+    factory :part_payment_incorrect do
+      correct false
+      incorrect_reason 'SOME REASON'
+      outcome 'none'
+    end
+
     trait :completed do
       completed_at Time.zone.yesterday
       association :completed_by, factory: :user

--- a/spec/features/processed_applications/list_deleted_applications_spec.rb
+++ b/spec/features/processed_applications/list_deleted_applications_spec.rb
@@ -45,8 +45,6 @@ RSpec.feature 'List deleted applications', type: :feature do
 
     expect(page).to have_content('Deleted application')
     expect(page).to have_content("Full name#{application1.applicant.full_name}")
-    expect(page).to have_content('Date deleted1 October 2015')
-    expect(page).to have_content('Deleted byBob')
-    expect(page).to have_content("Deleted reason#{application1.deleted_reason}")
+    expect(page).to have_content("Application deleted1 October 2015BobReason for deletion: \"#{application1.deleted_reason}\"")
   end
 end

--- a/spec/models/views/application_overview_spec.rb
+++ b/spec/models/views/application_overview_spec.rb
@@ -213,19 +213,19 @@ RSpec.describe Views::ApplicationOverview do
     context 'when the application was decided by application' do
       let(:decision_type) { 'application' }
 
-      it { is_expected.to eql('application') }
+      it { is_expected.to be_nil }
     end
 
     context 'when the application was decided by evidence check' do
       let(:decision_type) { 'evidence_check' }
 
-      it { is_expected.to eql('evidence check') }
+      it { is_expected.to eql('evidence') }
     end
 
     context 'when the application was decided by part_payment' do
       let(:decision_type) { 'part_payment' }
 
-      it { is_expected.to eql('part payment') }
+      it { is_expected.to eql('payment') }
     end
   end
 end

--- a/spec/models/views/application_overview_spec.rb
+++ b/spec/models/views/application_overview_spec.rb
@@ -198,4 +198,34 @@ RSpec.describe Views::ApplicationOverview do
       end
     end
   end
+
+  describe '#decision_type' do
+    let(:application) { build_stubbed :application, decision_type: decision_type, outcome: 'none' }
+
+    subject { view.decision_type }
+
+    context 'when the application has no decision_type' do
+      let(:decision_type) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the application was decided by application' do
+      let(:decision_type) { 'application' }
+
+      it { is_expected.to eql('application') }
+    end
+
+    context 'when the application was decided by evidence check' do
+      let(:decision_type) { 'evidence_check' }
+
+      it { is_expected.to eql('evidence check') }
+    end
+
+    context 'when the application was decided by part_payment' do
+      let(:decision_type) { 'part_payment' }
+
+      it { is_expected.to eql('part payment') }
+    end
+  end
 end

--- a/spec/models/views/application_overview_spec.rb
+++ b/spec/models/views/application_overview_spec.rb
@@ -199,10 +199,10 @@ RSpec.describe Views::ApplicationOverview do
     end
   end
 
-  describe '#decision_type' do
+  describe '#return_type' do
     let(:application) { build_stubbed :application, decision_type: decision_type, outcome: 'none' }
 
-    subject { view.decision_type }
+    subject { view.return_type }
 
     context 'when the application has no decision_type' do
       let(:decision_type) { nil }

--- a/spec/models/views/application_result_spec.rb
+++ b/spec/models/views/application_result_spec.rb
@@ -138,10 +138,10 @@ RSpec.describe Views::ApplicationResult do
     end
   end
 
-  describe '#decision_type' do
+  describe '#return_type' do
     let(:application) { build_stubbed :application, decision_type: decision_type, outcome: 'none' }
 
-    subject { view.decision_type }
+    subject { view.return_type }
 
     context 'when the application has no decision_type' do
       let(:decision_type) { nil }

--- a/spec/models/views/application_result_spec.rb
+++ b/spec/models/views/application_result_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Views::ApplicationResult do
     subject { view.result }
 
     shared_examples 'result examples' do |type|
-      %w[full part none].each do |result|
+      %w[full part none return].each do |result|
         context "when the #{type} is a #{result} remission" do
           let(:outcome) { result }
 
@@ -135,6 +135,36 @@ RSpec.describe Views::ApplicationResult do
       let(:application) { build_stubbed :application, outcome: outcome }
 
       include_examples 'result examples', 'application'
+    end
+  end
+
+  describe '#decision_type' do
+    let(:application) { build_stubbed :application, decision_type: decision_type, outcome: 'none' }
+
+    subject { view.decision_type }
+
+    context 'when the application has no decision_type' do
+      let(:decision_type) { nil }
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the application was decided by application' do
+      let(:decision_type) { 'application' }
+
+      it { is_expected.to eql('application') }
+    end
+
+    context 'when the application was decided by evidence check' do
+      let(:decision_type) { 'evidence_check' }
+
+      it { is_expected.to eql('evidence check') }
+    end
+
+    context 'when the application was decided by part_payment' do
+      let(:decision_type) { 'part_payment' }
+
+      it { is_expected.to eql('part payment') }
     end
   end
 end

--- a/spec/models/views/application_result_spec.rb
+++ b/spec/models/views/application_result_spec.rb
@@ -152,19 +152,19 @@ RSpec.describe Views::ApplicationResult do
     context 'when the application was decided by application' do
       let(:decision_type) { 'application' }
 
-      it { is_expected.to eql('application') }
+      it { is_expected.to be_nil }
     end
 
     context 'when the application was decided by evidence check' do
       let(:decision_type) { 'evidence_check' }
 
-      it { is_expected.to eql('evidence check') }
+      it { is_expected.to eql('evidence') }
     end
 
     context 'when the application was decided by part_payment' do
       let(:decision_type) { 'part_payment' }
 
-      it { is_expected.to eql('part payment') }
+      it { is_expected.to eql('payment') }
     end
   end
 end

--- a/spec/models/views/processed_data_spec.rb
+++ b/spec/models/views/processed_data_spec.rb
@@ -1,0 +1,107 @@
+# coding: utf-8
+require 'rails_helper'
+
+RSpec.describe Views::ProcessedData do
+  let(:application) { build_stubbed(:application_full_remission, :processed_state) }
+
+  subject(:view) { described_class.new(application) }
+
+  describe '#application_processed' do
+    subject { view.application_processed }
+
+    it 'returns the processed by data' do
+      expect(subject).to eql(on: application.completed_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: application.completed_by.name, text: nil)
+    end
+
+    context 'when an emergency reason was given' do
+      let(:application) { build_stubbed(:application_full_remission, :processed_state, emergency_reason: 'foo bar') }
+
+      it 'is returned' do
+        expect(subject).to eql(on: application.completed_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: application.completed_by.name, text: 'Reason for emergency: "foo bar"')
+      end
+    end
+
+    context 'when data is missing from the application object' do
+      let(:application) { build_stubbed(:application_full_remission, :processed_state, completed_by: nil, completed_at: nil, emergency_reason: 'foo bar') }
+
+      it 'returns nil for the missing fields' do
+        expect(subject).to eql(on: nil, by: nil, text: 'Reason for emergency: "foo bar"')
+      end
+    end
+  end
+
+  describe '#application_deleted' do
+    let(:application) { build_stubbed(:application_full_remission, :processed_state, :deleted_state) }
+
+    subject { view.application_deleted }
+
+    it 'returns the processed by data' do
+      expect(subject).to eql(on: application.deleted_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: application.deleted_by.name, text: 'Reason for deletion: "I did not like it"')
+    end
+
+  end
+
+  describe '#evidence_check_processed' do
+
+    subject { view.evidence_check_processed }
+
+    context 'when the application was completed in a single pass' do
+      it { is_expected.to be_nil }
+    end
+
+    describe 'when the application' do
+
+      let(:application) { build_stubbed :application, :waiting_for_evidence_state, evidence_check: evidence, amount_to_pay: nil }
+
+      context 'has a pending evidence_check' do
+        let(:evidence) { build_stubbed :evidence_check }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'has a completed evidence_check' do
+        let(:evidence) { build_stubbed :evidence_check_part_outcome, :completed }
+
+        it { is_expected.to eql(on: evidence.completed_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: evidence.completed_by.name, text: nil) }
+      end
+
+      context 'has a returned evidence_check' do
+        let(:evidence) { build_stubbed :evidence_check_incorrect, :completed }
+
+        it { is_expected.to eql(on: evidence.completed_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: evidence.completed_by.name, text: 'Reason not processed: "SOME REASON"') }
+      end
+    end
+  end
+
+  describe '#part_payment_processed' do
+
+    subject { view.part_payment_processed }
+
+    context 'when the application was completed in a single pass' do
+      it { is_expected.to be_nil }
+    end
+
+    describe 'when the application' do
+
+      let(:application) { build_stubbed :application, :waiting_for_evidence_state, part_payment: part_payment, amount_to_pay: nil }
+
+      context 'has a pending part_payment' do
+        let(:part_payment) { build_stubbed :part_payment }
+
+        it { is_expected.to be_nil }
+      end
+
+      context 'has a completed part_payment' do
+        let(:part_payment) { build_stubbed :part_payment_part_outcome, :completed }
+
+        it { is_expected.to eql(on: part_payment.completed_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: part_payment.completed_by.name, text: nil) }
+      end
+
+      context 'has a returned part_payment' do
+        let(:part_payment) { build_stubbed :part_payment_incorrect, :completed }
+
+        it { is_expected.to eql(on: part_payment.completed_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: part_payment.completed_by.name, text: 'Reason not processed: "SOME REASON"') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
 [Pivotal ticket](https://www.pivotaltracker.com/story/show/120572955) to update the processed application display to
- [x] Correct the `Error` display - [original pivotal error ticket](https://www.pivotaltracker.com/story/show/119828519)
- [x] Add the processing summary - [design](https://dsdmoj.atlassian.net/wiki/pages/viewpage.action?pageId=52920456)

New display of `return`ed applications, includes processing summary:
![image](https://cloud.githubusercontent.com/assets/6757677/15750623/20825946-28df-11e6-92ef-64a7debcbbca.png)
