### PR TITLE
Handling DWP checks for out of time refunds

### DIFF
--- a/app/controllers/benefit_overrides_controller.rb
+++ b/app/controllers/benefit_overrides_controller.rb
@@ -35,11 +35,19 @@ class BenefitOverridesController < ApplicationController
   end
 
   helper_method def error_message_partial
-    @error_message_partial ||= case application.last_benefit_check.dwp_result.try(:downcase)
-                               when nil, 'undetermined'
-                                 'missing_details'
-                               when 'server unavailable', 'unspecified error'
-                                 'technical_error'
-                               end
+    @error_message_partial ||= benefit_check_error_message
+  end
+
+  def benefit_check_error_message
+    if !BenefitCheckRunner.new(application).benefit_check_date_valid?
+      'out_of_time'
+    else
+      case application.last_benefit_check.dwp_result.try(:downcase)
+      when nil, 'undetermined'
+        'missing_details'
+      when 'server unavailable', 'unspecified error'
+        'technical_error'
+      end
+    end
   end
 end

--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -24,6 +24,10 @@ class BenefitCheckRunner
     benefit_check.blank? || benefit_check.dwp_result.blank? || overridable_result?
   end
 
+  def benefit_check_date_valid?
+    benefit_check_date > Time.zone.now - 3.months
+  end
+
   private
 
   def applicant
@@ -35,7 +39,7 @@ class BenefitCheckRunner
   end
 
   def should_run?
-    previous_check.nil? || !same_as_before? || was_error?
+    benefit_check_date_valid? && (previous_check.nil? || !same_as_before? || was_error?)
   end
 
   def was_error?

--- a/app/views/benefit_overrides/_out_of_time.html.slim
+++ b/app/views/benefit_overrides/_out_of_time.html.slim
@@ -1,0 +1,1 @@
+=t('benefit_override.errors.out_of_time')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en-GB:
         There’s a problem with the applicant’s surname, date of birth or National Insurance number.
         <a href="%{personal_information_url}">Check all details were entered correctly</a>
       technical_error: "You will only be able to process this application if you have paper evidence that the applicant is receiving benefits"
+      out_of_time: "Because this refund was paid more then three months ago, we cannot check with the DWP, the applicant will need to provide paper evidence for receipt of benefits on the date they paid"
   evidence:
     correct: 'Yes, the evidence is for the correct applicant and dated in the last 3 months'
     incorrect: 'No, there is a problem with the evidence and it needs to be returned'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en-GB:
         There’s a problem with the applicant’s surname, date of birth or National Insurance number.
         <a href="%{personal_information_url}">Check all details were entered correctly</a>
       technical_error: "You will only be able to process this application if you have paper evidence that the applicant is receiving benefits"
-      out_of_time: "Because this refund was paid more then three months ago, we cannot check with the DWP, the applicant will need to provide paper evidence for receipt of benefits on the date they paid"
+      out_of_time: "Fees paid more than 3 months ago can’t be checked with the DWP. The applicant must provide paper evidence to show they were receiving eligible benefits on the date they paid."
   evidence:
     correct: 'Yes, the evidence is for the correct applicant and dated in the last 3 months'
     incorrect: 'No, there is a problem with the evidence and it needs to be returned'

--- a/spec/factories/details.rb
+++ b/spec/factories/details.rb
@@ -19,6 +19,11 @@ FactoryGirl.define do
       date_fee_paid Time.zone.yesterday
     end
 
+    trait :out_of_time_refund do
+      refund true
+      date_fee_paid Time.zone.now - 3.months
+    end
+
     trait :emergency do
       emergency_reason 'It can not wait'
     end

--- a/spec/features/benefit_override/out_of_time_refund_application_handled_correctly_spec.rb
+++ b/spec/features/benefit_override/out_of_time_refund_application_handled_correctly_spec.rb
@@ -1,0 +1,30 @@
+# coding: utf-8
+require 'rails_helper'
+
+RSpec.feature 'Out of time refunds are correctly handled', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let!(:jurisdictions) { create_list :jurisdiction, 3 }
+  let!(:office)        { create(:office, jurisdictions: jurisdictions) }
+  let!(:user)          { create(:user, jurisdiction_id: jurisdictions[1].id, office: office) }
+  let!(:detail)         { create(:complete_detail, :out_of_time_refund) }
+  let!(:application)    { create(:application_full_remission, detail: detail, office: office) }
+
+  before do
+    dwp_api_response 'No'
+    login_as user
+    visit application_benefits_path(application)
+    choose 'application_benefits_true'
+    click_button 'Next'
+  end
+
+  scenario 'they should be on the benefit override page' do
+    expect(page.current_path).to eql(application_benefit_override_paper_evidence_path(application))
+  end
+
+  scenario 'they should be shown the correct warning' do
+    expect(page).to have_content('Because this refund was paid more then three months ago')
+  end
+end

--- a/spec/features/benefit_override/out_of_time_refund_application_handled_correctly_spec.rb
+++ b/spec/features/benefit_override/out_of_time_refund_application_handled_correctly_spec.rb
@@ -25,6 +25,6 @@ RSpec.feature 'Out of time refunds are correctly handled', type: :feature do
   end
 
   scenario 'they should be shown the correct warning' do
-    expect(page).to have_content('Because this refund was paid more then three months ago')
+    expect(page).to have_content('Fees paid more than 3 months ago can’t be checked with the DWP')
   end
 end


### PR DESCRIPTION
[Pivotal ticket](https://www.pivotaltracker.com/story/show/116873277)

We cause errors when we ask the DWP for checks longer than 3 months ago, so when a refund is processed from more than three months ago.  Don't even send a check to the DWP and render a pertinent error message to to the user.

### To do
- [x] Don't send DWP request if date > 3 months old
- [x] Display situationally appropriate error message to the user
- [ ] @joshlow to review error message
