### PR TITLE
Fixes and extension of Update Savings

### DIFF
--- a/app/builders/application_builder.rb
+++ b/app/builders/application_builder.rb
@@ -70,7 +70,10 @@ class ApplicationBuilder
 
   def online_saving_attributes(online_application)
     fields = %i[min_threshold_exceeded max_threshold_exceeded over_61 amount]
-    prepare_attributes(fields, online_application)
+    {
+      min_threshold: Settings.savings_threshold.minimum,
+      max_threshold: Settings.savings_threshold.maximum
+    }.merge(prepare_attributes(fields, online_application))
   end
 
   def prepare_attributes(fields, online_application)

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -51,15 +51,6 @@ class Application < ActiveRecord::Base
     self[:children] = dependents? ? val : 0
   end
 
-  def savings_investment_valid?
-    result = false
-    if threshold_exceeded == false ||
-       (threshold_exceeded && (partner_over_61 && high_threshold_exceeded == false))
-      result = true
-    end
-    result
-  end
-
   def applicant_over_61?
     applicant.age >= 61
   end

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -65,7 +65,7 @@ module Views
     end
 
     def savings
-      format_locale(@application.savings_investment_valid?.to_s)
+      format_locale(@application.saving.passed?.to_s)
     end
 
     def type

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -17,7 +17,7 @@ module Views
     end
 
     def savings
-      format_locale(@application.savings_investment_valid?.to_s)
+      format_locale(@application.saving.passed?.to_s)
     end
 
     def income

--- a/app/models/views/confirmation/result.rb
+++ b/app/models/views/confirmation/result.rb
@@ -54,7 +54,7 @@ module Views
       private
 
       def convert_to_pass_fail(input)
-        I18n.t(input, scope: 'convert_pass_fail')
+        I18n.t(input.to_s, scope: 'convert_pass_fail')
       end
 
       def applicant_is_on_benefits

--- a/app/models/views/overview/savings_and_investments.rb
+++ b/app/models/views/overview/savings_and_investments.rb
@@ -15,7 +15,9 @@ module Views
       end
 
       def max_threshold_exceeded
-        convert_to_boolean(@saving.max_threshold_exceeded?)
+        unless @saving.max_threshold_exceeded.nil?
+          convert_to_boolean(@saving.max_threshold_exceeded?)
+        end
       end
 
       def amount

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en-GB:
       views/overview/savings_and_investments:
         min_threshold_exceeded: "Less than £3,000"
         max_threshold_exceeded: "More than £16,000"
-        amount: 'Amount of income'
+        amount: 'Savings amount'
       views/overview/benefits:
         on_benefits?: Applicant receiving benefits
         override?: Applicant provided paper evidence

--- a/lib/savings_transformation.rb
+++ b/lib/savings_transformation.rb
@@ -41,14 +41,10 @@ class SavingsTransformation
   end
 
   def savings_investment_valid?(application)
-    result = false
-    if application.threshold_exceeded == false ||
-       (
-         application.threshold_exceeded &&
-         (application.partner_over_61 && application.high_threshold_exceeded == false)
-       )
-      result = true
-    end
-    result
+    application.threshold_exceeded == false ||
+      (
+        application.threshold_exceeded &&
+        (application.partner_over_61? && application.high_threshold_exceeded == false)
+      )
   end
 end

--- a/lib/savings_transformation.rb
+++ b/lib/savings_transformation.rb
@@ -16,7 +16,7 @@ class SavingsTransformation
       min_threshold_exceeded: threshold_exceeded?(application.threshold_exceeded),
       max_threshold_exceeded: threshold_exceeded?(application.high_threshold_exceeded),
       amount: nil,
-      passed: application.savings_investment_valid?,
+      passed: savings_investment_valid?(application),
       fee_threshold: generate_fee_threshold(application),
       over_61: someone_over_61?(application)
     )
@@ -38,5 +38,17 @@ class SavingsTransformation
 
   def applicant_age_or_zero(application)
     application.applicant.date_of_birth.present? ? application.applicant.age : 0
+  end
+
+  def savings_investment_valid?(application)
+    result = false
+    if application.threshold_exceeded == false ||
+       (
+         application.threshold_exceeded &&
+         (application.partner_over_61 && application.high_threshold_exceeded == false)
+       )
+      result = true
+    end
+    result
   end
 end

--- a/spec/builders/application_builder_spec.rb
+++ b/spec/builders/application_builder_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe ApplicationBuilder do
         expect(built_application.reference).to eql(online_application.reference)
       end
 
+      it 'sets the current min_thresholds' do
+        expect(built_application.saving.min_threshold).to eql(Settings.savings_threshold.minimum)
+      end
+
+      it 'sets the current max_thresholds' do
+        expect(built_application.saving.max_threshold).to eql(Settings.savings_threshold.maximum)
+      end
+
       %i[benefits income].each do |column|
         it "has #{column} assigned" do
           expect(built_application.public_send(column)).to eql(online_application.public_send(column))

--- a/spec/features/applications/application_form_stories_spec.rb
+++ b/spec/features/applications/application_form_stories_spec.rb
@@ -60,6 +60,9 @@ RSpec.feature 'Completing the application details', type: :feature do
               scenario 'the summary page is shown with correct display' do
                 expect(page).to have_xpath('//h2', text: 'Check details')
                 expect(page).to have_xpath('//h4', text: 'Savings and investments')
+                expect(page).to have_content('Less than £3,000No')
+                expect(page).to have_content('Savings amount£3500')
+                expect(page).to have_no_content('More than £16,000')
                 expect(page).to have_no_xpath('//h4', text: 'Benefits')
                 expect(page).to have_no_xpath('//h4', text: 'Income')
               end

--- a/spec/lib/savings_transformation_spec.rb
+++ b/spec/lib/savings_transformation_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
+def savings_investment_valid?(application)
+  result = false
+  if application.threshold_exceeded == false ||
+     (
+        application.threshold_exceeded &&
+        (application.partner_over_61 && application.high_threshold_exceeded == false)
+     )
+    result = true
+  end
+  result
+end
+
 RSpec.describe SavingsTransformation do
 
   subject(:transform) { described_class.new }
@@ -51,7 +63,8 @@ RSpec.describe SavingsTransformation do
 
     it 'sets passed to equal savings_and_investments_valid? on the application' do
       Saving.all.each do |saving|
-        expect(saving.passed).to eql(saving.application.savings_investment_valid?)
+
+        expect(saving.passed).to eql(savings_investment_valid?(saving.application))
       end
     end
   end

--- a/spec/lib/savings_transformation_spec.rb
+++ b/spec/lib/savings_transformation_spec.rb
@@ -1,17 +1,5 @@
 require 'rails_helper'
 
-def savings_investment_valid?(application)
-  result = false
-  if application.threshold_exceeded == false ||
-     (
-        application.threshold_exceeded &&
-        (application.partner_over_61 && application.high_threshold_exceeded == false)
-     )
-    result = true
-  end
-  result
-end
-
 RSpec.describe SavingsTransformation do
 
   subject(:transform) { described_class.new }
@@ -30,6 +18,11 @@ RSpec.describe SavingsTransformation do
   describe '#up!' do
     before do
       transform.up!
+      application1.reload
+      application2.reload
+      application3.reload
+      application4.reload
+      application5.reload
     end
 
     it 'creates a saving for each application' do
@@ -37,35 +30,31 @@ RSpec.describe SavingsTransformation do
     end
 
     it 'creates the saving model' do
-      application1.reload
       expect(application1.saving.present?).to eql(true)
     end
 
     it 'sets `passed` to false when maximum threshold exceeded' do
-      application2.reload
       expect(application2.saving.passed).to eql(false)
     end
 
     it 'sets `over_61` to true when the applicant is over_61' do
-      application3.reload
       expect(application3.saving.over_61).to eql(true)
     end
 
     it 'sets `over_61` to match partner_over_61' do
-      application4.reload
       expect(application4.saving.over_61).to eql(true)
     end
 
     it 'sets the fee_threshold to minimum when the fee is nil' do
-      application5.reload
       expect(application5.saving.fee_threshold).to eql(3000)
     end
 
     it 'sets passed to equal savings_and_investments_valid? on the application' do
-      Saving.all.each do |saving|
-
-        expect(saving.passed).to eql(savings_investment_valid?(saving.application))
-      end
+      expect(application1.saving.passed).to be true
+      expect(application2.saving.passed).to be false
+      expect(application3.saving.passed).to be false
+      expect(application4.saving.passed).to be true
+      expect(application5.saving.passed).to be true
     end
   end
 end

--- a/spec/models/views/application_overview_spec.rb
+++ b/spec/models/views/application_overview_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Views::ApplicationOverview do
   end
 
   describe '#savings' do
-    before { allow(application).to receive(:savings_investment_valid?).and_return(result) }
+    before { allow(application.saving).to receive(:passed?).and_return(result) }
 
     subject { view.savings }
 

--- a/spec/models/views/application_result_spec.rb
+++ b/spec/models/views/application_result_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Views::ApplicationResult do
     subject { view.savings }
 
     before do
-      allow(application).to receive(:savings_investment_valid?).and_return(savings_valid)
+      allow(application.saving).to receive(:passed?).and_return(savings_valid)
     end
 
     context 'when savings and investment is valid' do

--- a/spec/models/views/confirmation/result_spec.rb
+++ b/spec/models/views/confirmation/result_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Views::Confirmation::Result do
           allow(saving).to receive(:passed?).and_return(!value)
         end
 
-        it { is_expected.to eq I18n.t(!value, scope: scope) }
+        it { is_expected.to eq I18n.t((!value).to_s, scope: scope) }
       end
     end
   end


### PR DESCRIPTION
This PR is designed to allow us to add to the `update-savings` branch while allowing a quicker review process...

Fixes to be implemented
===
- [x] On the application summary view - ensure the max_threshold_exceeded label is only shown when explicitly set
- [x] Ensure the Savings pass/fail is shown on the confirmation page (add .to_s to convert_to_boolean)

Features to be implemented
===
- [x] Remove the savings_investment_valid? from application model and make good (2 view models and duplicate for the migration
- [x] The online application builder is not setting the min_ and max_threshold

Nice to have
===
- [ ] ~~Add the Settings.min/max threshold to the labels on savings view and summary~~