### PR TITLE
Update the refund date validation

### DIFF
--- a/app/models/forms/application/detail.rb
+++ b/app/models/forms/application/detail.rb
@@ -43,7 +43,6 @@ module Forms
 
       with_options if: :validate_date_fee_paid? do
         validates :date_fee_paid, date: {
-          after_or_equal_to: :min_refund_date,
           before_or_equal_to: :max_refund_date,
           allow_blank: false
         }
@@ -57,10 +56,6 @@ module Forms
 
       def min_date
         3.months.ago.midnight
-      end
-
-      def min_refund_date
-        date_received - 3.months unless date_received.blank?
       end
 
       def max_refund_date

--- a/spec/models/forms/application/detail_spec.rb
+++ b/spec/models/forms/application/detail_spec.rb
@@ -163,18 +163,6 @@ RSpec.describe Forms::Application::Detail do
               it { is_expected.to be_valid }
             end
 
-            describe 'just outside' do
-              let(:date_fee_paid) { Time.zone.local(2014, 8, 15, 10, 23, 55) }
-
-              describe 'returns an error if exceeded' do
-                before { refund.valid? }
-
-                subject { refund.errors[:date_fee_paid] }
-
-                it { is_expected.to eq ['This date can’t be more than 3 months before the application was received'] }
-              end
-            end
-
             describe 'on the same day' do
               let(:date_fee_paid) { Time.zone.local(2014, 11, 15, 12, 30, 0) }
 


### PR DESCRIPTION
Remove the maximum 3 month limit in accordance with [pivotal](https://www.pivotaltracker.com/story/show/120940853)