### PR TITLE
Update offices for MI report

### DIFF
--- a/app/builders/finance_report_builder.rb
+++ b/app/builders/finance_report_builder.rb
@@ -57,6 +57,7 @@ class FinanceReportBuilder
 
   def distinct_offices_jurisdictions
     BusinessEntity.
+      exclude_hq_teams.
       joins('LEFT OUTER JOIN applications ON business_entity_id = business_entities.id').
       where('decision_date BETWEEN :d1 AND :d2', d1: @date_from, d2: @date_to).
       where('applications.state = 3').uniq { |s| s.values_at(:office, :jurisdiction) }

--- a/app/models/business_entity.rb
+++ b/app/models/business_entity.rb
@@ -2,6 +2,10 @@ class BusinessEntity < ActiveRecord::Base
   belongs_to :office
   belongs_to :jurisdiction
 
+  scope :exclude_hq_teams, lambda {
+    joins(:office).where.not("offices.name IN ('Digital', 'HMCTS HQ Team ')")
+  }
+
   validates :office, :jurisdiction, :code, :name, :valid_from, presence: true
 
   validates :valid_to, date: {

--- a/spec/builders/finance_report_builder_spec.rb
+++ b/spec/builders/finance_report_builder_spec.rb
@@ -4,8 +4,13 @@ RSpec.describe FinanceReportBuilder do
 
   let(:user) { create :user }
   let(:business_entity) { create :business_entity }
+  let(:excluded_office) { create :office, name: 'Digital' }
+  let(:excluded_business_entity) { create :business_entity, office: excluded_office }
   let!(:application1) do
     create(:application_full_remission, :processed_state, fee: 500, decision: 'full', decision_date: Time.zone.parse('2015-12-01'), business_entity: business_entity)
+  end
+  let!(:application2) do
+    create(:application_full_remission, :processed_state, fee: 500, decision: 'full', decision_date: Time.zone.parse('2015-12-01'), business_entity: excluded_business_entity)
   end
 
   let(:current_time) { Time.zone.parse('2016-02-02 15:50:10') }
@@ -21,6 +26,10 @@ RSpec.describe FinanceReportBuilder do
     end
 
     it { is_expected.to be_a String }
+
+    it 'does not include digital' do
+      is_expected.not_to include('Digital')
+    end
 
     it 'contains static meta data' do
       is_expected.to include('Report Title:,Remissions Granted Report')

--- a/spec/models/business_entity_spec.rb
+++ b/spec/models/business_entity_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe BusinessEntity, type: :model do
     end
   end
 
+  context 'scopes' do
+    let!(:hmcts)   { create(:office, name: 'HMCTS HQ Team ') }
+    let!(:digital) { create(:office, name: 'Digital') }
+    let!(:bristol) { create(:office, name: 'Bristol') }
+
+    describe 'non_digital' do
+      it 'excludes HQ business entities' do
+        # each office gets 2 business_entities by default
+        expect(described_class.count).to eql(6)
+        expect(described_class.exclude_hq_teams.count).to eql(2)
+      end
+    end
+  end
+
   describe '#current_for' do
     let(:business_entity) { create :business_entity }
     subject { described_class.current_for(office, jurisdiction) }

--- a/spec/models/business_entity_spec.rb
+++ b/spec/models/business_entity_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe BusinessEntity, type: :model do
         expect(described_class.count).to eql(6)
         expect(described_class.exclude_hq_teams.count).to eql(2)
       end
+
+      it 'has the two bristol business entities' do
+        all_codes = described_class.exclude_hq_teams.all.map(&:code)
+        expect(all_codes).to eql bristol.business_entities.map(&:code)
+      end
     end
   end
 


### PR DESCRIPTION
[Pivotal ticket](https://www.pivotaltracker.com/story/show/120915287)

The digital and MCTS HQ team needed to be excluded from the Financial MI report

This adds a scope and calls it in the report builder service.