### PR TITLE
Manager override on confirmation page

### DIFF
--- a/app/assets/stylesheets/local/panels.scss
+++ b/app/assets/stylesheets/local/panels.scss
@@ -71,7 +71,7 @@
   &.not-received, &.no, &.callout-none, &.callout-error, &.callout-return {
     background-color: $error-colour;
   }
-  &.received, &.yes, &.callout-full {
+  &.received, &.yes, &.callout-full, &.callout-granted {
     background-color: $turquoise;
   }
   &.callout-part, &.callout-evidence-check {

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -13,6 +13,7 @@ class Application < ActiveRecord::Base
   has_one :evidence_check, required: false
   has_one :part_payment, required: false
   has_one :benefit_override, required: false
+  has_one :decision_override, required: false
 
   enum state: {
     created: 0,

--- a/app/models/decision_override.rb
+++ b/app/models/decision_override.rb
@@ -1,0 +1,6 @@
+class DecisionOverride < ActiveRecord::Base
+  belongs_to :application, required: true
+  belongs_to :user, -> { with_deleted }, required: true
+
+  validates :reason, presence: true
+end

--- a/app/models/forms/application/decision_override.rb
+++ b/app/models/forms/application/decision_override.rb
@@ -15,7 +15,17 @@ module Forms
       validates :value, presence: true
       validates :reason, presence: true, length: { maximum: 500 }, if: :reason_required?
 
+      def application_overridable?(application)
+        failed_benefit_application?(application)
+      end
+
       private
+
+      def failed_benefit_application?(application)
+        application.application_type.eql?('benefit') &&
+          application.outcome.eql?('none') &&
+          (application.decision_override.nil? || !application.decision_override.persisted?)
+      end
 
       def reason_required?
         value == 'other'
@@ -33,7 +43,7 @@ module Forms
         if self[:reason].present?
           self[:reason]
         elsif can_load_text_from_locale?
-          array_value = self[:value] - 1
+          array_value = self[:value].to_i - 1
           I18n.t("options", scope: self[:i18n_scope])[array_value].values.first
         end
       end

--- a/app/models/forms/application/decision_override.rb
+++ b/app/models/forms/application/decision_override.rb
@@ -1,0 +1,46 @@
+module Forms
+  module Application
+    class DecisionOverride < ::FormObject
+      def self.permitted_attributes
+        {
+          value: Integer,
+          reason: String,
+          created_by_id: Integer
+        }
+      end
+
+      define_attributes
+
+      validates :created_by_id, presence: true
+      validates :value, presence: true
+      validates :reason, presence: true, length: { maximum: 500 }, if: :reason_required?
+
+      private
+
+      def reason_required?
+        value == 'other'
+      end
+
+      def persist!
+        @object.update(fields_to_update)
+      end
+
+      def fields_to_update
+        { reason: reason_text, user_id: created_by_id }
+      end
+
+      def reason_text
+        if self[:reason].present?
+          self[:reason]
+        elsif can_load_text_from_locale?
+          array_value = self[:value] - 1
+          I18n.t("options", scope: self[:i18n_scope])[array_value].values.first
+        end
+      end
+
+      def can_load_text_from_locale?
+        self[:value].present? && self[:value].to_i > 0
+      end
+    end
+  end
+end

--- a/app/models/views/application_overview.rb
+++ b/app/models/views/application_overview.rb
@@ -54,6 +54,7 @@ module Views
 
     def benefits
       if type.eql?('benefit')
+        return format_locale('passed_by_override') if @application.decision_override.present?
         return format_locale('passed_with_evidence') if benefit_override?
         format_locale(benefit_result) if @application.last_benefit_check
       end

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -7,7 +7,7 @@ module Views
     end
 
     def result
-      %w[full part none return].include?(outcome) ? outcome : 'error'
+      %w[granted full part none return].include?(outcome) ? outcome : 'error'
     end
 
     def amount_to_pay
@@ -38,7 +38,11 @@ module Views
       when EvidenceCheck
         evidence_or_application.outcome
       when Application
-        evidence_or_application.outcome
+        if evidence_or_application.decision_override.present?
+          'granted'
+        else
+          evidence_or_application.outcome
+        end
       end
     end
 

--- a/app/models/views/processed_data.rb
+++ b/app/models/views/processed_data.rb
@@ -10,6 +10,10 @@ module Views
       build_return_hash @application
     end
 
+    def application_override
+      build_override_hash @application.decision_override if application_overridden?
+    end
+
     def application_deleted
       if application_deleted?
         build_delete_hash
@@ -25,6 +29,10 @@ module Views
     end
 
     private
+
+    def application_overridden?
+      @application.decision_override.present?
+    end
 
     def application_deleted?
       @application.deleted_by.present?
@@ -44,6 +52,14 @@ module Views
 
     def part_payment
       @application.part_payment
+    end
+
+    def build_override_hash(object)
+      {
+        on: prepare_date(object.created_at),
+        by: prepare_name(object.user),
+        text: prepare_override_reason(object)
+      }
     end
 
     def build_return_hash(object)
@@ -70,6 +86,12 @@ module Views
       date.strftime(Date::DATE_FORMATS[:gov_uk_long]) if date
     end
 
+    def prepare_override_reason(object)
+      text = object.reason
+      prefix = 'Reason granted'
+      build_text prefix, text
+    end
+
     def prepare_reason(object)
       if object.is_a?(Application)
         text = object.detail.emergency_reason
@@ -78,6 +100,10 @@ module Views
         text = object.incorrect_reason
         prefix = 'Reason not processed'
       end
+      build_text prefix, text
+    end
+
+    def build_text(prefix, text)
       "#{prefix}: \"#{text}\"" if text
     end
   end

--- a/app/services/override_decision_service.rb
+++ b/app/services/override_decision_service.rb
@@ -1,0 +1,22 @@
+class OverrideDecisionService
+
+  def initialize(application, decision_override)
+    @application = application
+    @decision_override = decision_override
+  end
+
+  def set!
+    @decision_override.save
+    update_application
+    @application.save
+  end
+
+  private
+
+  def update_application
+    @application.update_attributes(
+      decision: 'full',
+      decision_type: 'override'
+    )
+  end
+end

--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -13,6 +13,8 @@ h4.heading-medium.util_mt-medium Reference
 #result.callout class="callout-#{@confirm.result}"
   h3.heading-large = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
 
+=render('shared/decision_override', path: application_override_path(@application, anchor: 'override_panel'))
+
 -if @application.waiting_for_part_payment?
   .confirmation-letter
     = t('letters.part-payment.send_part_payment_html',

--- a/app/views/shared/_decision_override.html.slim
+++ b/app/views/shared/_decision_override.html.slim
@@ -1,4 +1,4 @@
--unless @application.decision_override || ((@application.processed? && @application.application_type == 'benefits' && @application.decision == 'none') == false)
+-if @form.application_overridable?(@application)
   - show_override = @form.errors.empty? ? {} : { open: 'open' }
 
   .panel#override_panel

--- a/app/views/shared/_decision_override.html.slim
+++ b/app/views/shared/_decision_override.html.slim
@@ -1,0 +1,30 @@
+-unless @application.decision_override || ((@application.processed? && @application.application_type == 'benefits' && @application.decision == 'none') == false)
+  - show_override = @form.errors.empty? ? {} : { open: 'open' }
+
+  .panel#override_panel
+    details *show_override
+      summary
+        span.summary.primary Grant help with fees
+      div.util_mt-small
+        = form_for @form, as: :application, url: path, method: :put, html: { autocomplete: 'off', class: 'override-form' } do |f|
+          .form-group
+            = f.label :value, class: 'form-label'
+            = f.label :value, @form.errors[:value].join(', '), class: 'error' if @form.errors[:value].present?
+            = f.hidden_field :value, value: nil
+            .options.radio.cf
+              - t('options', scope: @form.i18n_scope).each do |option|
+                .option
+                  label.block-label for="application_value_#{option.keys.first}"
+                    = f.radio_button :value, option.keys.first, { class: 'show-hide-section' }
+                    =option.values.first
+
+              .option
+                label.block-label for="application_value_other"
+                  = f.radio_button :value, :other, { class: 'show-hide-section', data: { section: 'discretion-reason', show: 'false' } }
+                  = t('option_other', scope: @form.i18n_scope)
+              .form-group.panel-indent.start-hidden#discretion-reason-only
+                = f.label :reason, class: 'form-label'
+                = f.label :reason, @form.errors[:reason].join(', '), class: 'error' if @form.errors[:reason].present?
+                = f.text_area :reason, rows: 3, class: 'form-control'
+
+          = f.submit 'Update application', :class => 'button'

--- a/app/views/shared/processed_and_deleted/_show.html.slim
+++ b/app/views/shared/processed_and_deleted/_show.html.slim
@@ -15,6 +15,12 @@ table.processed_summary.util_mb-large
       td =@summary.application_processed[:on]
       td =@summary.application_processed[:by]
       td =@summary.application_processed[:text]
+    -if @summary.application_override
+      tr
+        th Application granted
+        td =@summary.application_override[:on]
+        td =@summary.application_override[:by]
+        td =@summary.application_override[:text]
     -if @summary.application_deleted
       tr
         th Application deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,15 @@ en-GB:
         correct_false: 'No'
         correct_true: 'Yes, the evidence is correct'
         incorrect_reason: 'Describe the problem with the evidence'
+      forms/application/decision_override:
+        explain: 'You can update details for this application if:'
+        value: 'Select a reason'
+        options:
+          - 1: "You've received paper evidence that the applicant is receiving benefits"
+          - 2: "You want to check if the applicant is receiving benefits using the DWP checker (and it was unavailable when the application was first processed)"
+          - 3: "You are exercising discretion with this application"
+        option_other: 'Other'
+        reason: 'Other reason'
     errors:
       models:
         forms/finance_report:
@@ -418,6 +427,12 @@ en-GB:
           attributes:
             deleted_reason:
               blank: Enter the reason
+        forms/application/decision_override:
+          attributes:
+            value:
+              blank: Please select an authorisation reason
+            reason:
+              blank: Please enter an authorisation reason
         forms/benefits_evidence:
           attributes:
             evidence:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,11 +180,12 @@ en-GB:
     remove_warning_html: "%{managers} at %{office} need to unselect these jurisdictions before you can deactivate them."
     deactivate_warning: "Deactivating this jurisdiction will remove it from the list that %{office} can use. It will still be displayed for any applications processed before %{today_date}."
   remissions:
-    full: 'Eligible for help with fees'
+    full: '✓ Eligible for help with fees'
     part: The applicant must pay %{amount_to_pay} towards the fee
     none: '✗ &nbsp; Not eligible for help with fees'
     callout: Evidence of income needs to be checked
     return: '✗ &nbsp; Not eligible because %{return_type} not provided'
+    granted: '✓ Granted help with fees'
   evidence_check:
     callout: Evidence of income needs to be checked
     page_title: Application waiting for evidence
@@ -326,6 +327,7 @@ en-GB:
         'true': '✓ Passed'
         'false': '✗ Failed'
         passed_with_evidence: '✓ Passed (paper evidence checked)'
+        passed_by_override: "✓ Passed (by manager's decision)"
         savings_investments: Savings and investments
         benefits: Benefits
         income: Income
@@ -341,8 +343,7 @@ en-GB:
         correct_true: 'Yes, the evidence is correct'
         incorrect_reason: 'Describe the problem with the evidence'
       forms/application/decision_override:
-        explain: 'You can update details for this application if:'
-        value: 'Select a reason'
+        value: 'You can update details for this application if:'
         options:
           - 1: "You've received paper evidence that the applicant is receiving benefits"
           - 2: "You want to check if the applicant is receiving benefits using the DWP checker (and it was unavailable when the application was first processed)"
@@ -430,9 +431,9 @@ en-GB:
         forms/application/decision_override:
           attributes:
             value:
-              blank: Please select an authorisation reason
+              blank: Please select a reason for granting help with fees
             reason:
-              blank: Please enter an authorisation reason
+              blank: Please enter a reason for granting help with fees
         forms/benefits_evidence:
           attributes:
             evidence:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
     get 'summary', to: 'applications/process#summary', as: :summary
     put 'summary_save', to: 'applications/process#summary_save', as: :summary_save
     get 'confirmation', to: 'applications/process#confirmation', as: :confirmation
+    put 'override', to: 'applications/process#override', as: :override
   end
 
   resources :online_applications, only: [:edit, :update, :show] do

--- a/db/migrate/20160627135552_create_decision_overrides.rb
+++ b/db/migrate/20160627135552_create_decision_overrides.rb
@@ -1,0 +1,11 @@
+class CreateDecisionOverrides < ActiveRecord::Migration
+  def change
+    create_table :decision_overrides do |t|
+      t.references :user, index: true, foreign_key: true
+      t.references :application, index: true, foreign_key: true
+      t.string :reason
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160620085231) do
+ActiveRecord::Schema.define(version: 20160627135552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,17 @@ ActiveRecord::Schema.define(version: 20160620085231) do
   add_index "business_entities", ["name"], name: "index_business_entities_on_name", using: :btree
   add_index "business_entities", ["office_id", "jurisdiction_id", "valid_to"], name: "unique_active_office_jurisdiction", unique: true, using: :btree
   add_index "business_entities", ["office_id"], name: "index_business_entities_on_office_id", using: :btree
+
+  create_table "decision_overrides", force: :cascade do |t|
+    t.integer  "user_id"
+    t.integer  "application_id"
+    t.string   "reason"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+  end
+
+  add_index "decision_overrides", ["application_id"], name: "index_decision_overrides_on_application_id", using: :btree
+  add_index "decision_overrides", ["user_id"], name: "index_decision_overrides_on_user_id", using: :btree
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer  "priority",   default: 0, null: false
@@ -326,6 +337,8 @@ ActiveRecord::Schema.define(version: 20160620085231) do
   add_foreign_key "benefit_overrides", "users", column: "completed_by_id", on_update: :cascade
   add_foreign_key "business_entities", "jurisdictions", on_update: :cascade
   add_foreign_key "business_entities", "offices", on_update: :cascade
+  add_foreign_key "decision_overrides", "applications"
+  add_foreign_key "decision_overrides", "users"
   add_foreign_key "details", "applications", on_update: :cascade
   add_foreign_key "details", "jurisdictions", on_update: :cascade
   add_foreign_key "evidence_checks", "applications", on_update: :cascade

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -468,6 +468,51 @@ RSpec.describe Applications::ProcessController, type: :controller do
     end
   end
 
+  describe 'PUT #override' do
+    let!(:application) { create(:application, office: user.office) }
+    let(:override_reason) { nil }
+    let(:params) { { value: override_value, reason: override_reason, created_by_id: user.id } }
+
+    before { put :override, application_id: application.id, application: params }
+
+    context 'when the parameters are valid' do
+      context 'by selecting a radio button' do
+        let(:override_value) { 1 }
+
+        it 'redirects to the confirmation page' do
+          expect(response).to redirect_to(application_confirmation_path(application))
+        end
+      end
+
+      context 'by selecting `other` and providing a reason' do
+        let(:override_value) { 'other' }
+        let(:override_reason) { 'foo bar' }
+
+        it 'redirects to the confirmation page' do
+          expect(response).to redirect_to(application_confirmation_path(application))
+        end
+      end
+    end
+
+    context 'when the parameters are invalid' do
+      context 'because they are missing' do
+        let(:override_value) { nil }
+
+        it 're-renders the confirmation page' do
+          expect(response).to render_template(:confirmation)
+        end
+      end
+
+      context 'because a reason is not supplied' do
+        let(:override_value) { 'other' }
+
+        it 're-renders the confirmation page' do
+          expect(response).to render_template(:confirmation)
+        end
+      end
+    end
+  end
+
   context 'GET #confirmation' do
     before { get :confirmation, application_id: application.id }
 

--- a/spec/factories/decision_overrides.rb
+++ b/spec/factories/decision_overrides.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :decision_override do
+    association :user
+    reason "My reasons"
+
+    after(:build) do |override|
+      override.application ||= build(:application, decision_override: override)
+    end
+
+    after(:stub) do |override|
+      around_stub(override) do
+        override.application ||= build_stubbed(:application, decision_override: override)
+      end
+    end
+  end
+end

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -29,6 +29,10 @@ RSpec.feature 'Confirmation page', type: :feature do
       scenario 'the remission register right hand guidance is no longer shown' do
         expect(page).to have_no_content 'remission register'
       end
+
+      scenario 'the grant help with fees form is rendered' do
+        expect(page).to have_content 'Grant help with fees'
+      end
     end
 
     context 'after user continues from summary' do
@@ -63,6 +67,16 @@ RSpec.feature 'Confirmation page', type: :feature do
 
       scenario 'the income label displays correctly' do
         expect(page).to have_xpath('//div[contains(@class,"summary-result") and contains(@class,"part")]', text: 'Waiting for evidence')
+      end
+    end
+
+    context 'when an application has been overridden' do
+      let(:decision_override) { create :decision_override }
+
+      before { visit application_confirmation_path(decision_override.application) }
+
+      scenario 'the grant help with fees form is not rendered' do
+        expect(page).not_to have_content 'Grant help with fees'
       end
     end
   end

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -29,10 +29,6 @@ RSpec.feature 'Confirmation page', type: :feature do
       scenario 'the remission register right hand guidance is no longer shown' do
         expect(page).to have_no_content 'remission register'
       end
-
-      scenario 'the grant help with fees form is rendered' do
-        expect(page).to have_content 'Grant help with fees'
-      end
     end
 
     context 'after user continues from summary' do
@@ -58,6 +54,10 @@ RSpec.feature 'Confirmation page', type: :feature do
       scenario 'the income label displays correctly' do
         expect(page).to have_xpath('//div[contains(@class,"summary-result") and contains(@class,"part")]', text: 'Waiting for part-payment')
       end
+
+      scenario 'the grant help with fees form is not rendered' do
+        expect(page).not_to have_content 'Grant help with fees'
+      end
     end
 
     context 'when application requires evidence' do
@@ -68,15 +68,49 @@ RSpec.feature 'Confirmation page', type: :feature do
       scenario 'the income label displays correctly' do
         expect(page).to have_xpath('//div[contains(@class,"summary-result") and contains(@class,"part")]', text: 'Waiting for evidence')
       end
+
+      scenario 'the grant help with fees form is not rendered' do
+        expect(page).not_to have_content 'Grant help with fees'
+      end
+    end
+
+    context 'when application fails because of income' do
+      let(:application) { create :application_no_remission, :processed_state, office: office }
+
+      before { visit application_confirmation_path(application) }
+
+      scenario 'the income label displays correctly' do
+        expect(page).to have_content '✗ Not eligible for help with fees'
+      end
+
+      scenario 'the grant help with fees form is not rendered' do
+        expect(page).not_to have_content 'Grant help with fees'
+      end
+    end
+
+    context 'when application fails because of benefits' do
+      let(:application) { create :application_no_remission, :processed_state, application_type: 'benefit', office: office }
+
+      before { visit application_confirmation_path(application) }
+
+      scenario 'the income label displays correctly' do
+        expect(page).to have_content '✗ Not eligible for help with fees'
+      end
+
+      scenario 'the grant help with fees form is rendered' do
+        expect(page).to have_content 'Grant help with fees'
+      end
     end
 
     context 'when an application has been overridden' do
-      let(:decision_override) { create :decision_override }
+      let(:application) { create(:application, :confirm, office: office) }
+      let(:decision_override) { create :decision_override, application: application }
 
       before { visit application_confirmation_path(decision_override.application) }
 
       scenario 'the grant help with fees form is not rendered' do
         expect(page).not_to have_content 'Grant help with fees'
+        expect(page).to have_content 'Granted help with fees'
       end
     end
   end

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Confirmation page', type: :feature do
       end
 
       scenario 'the grant help with fees form is not rendered' do
-        expect(page).not_to have_content 'Grant help with fees'
+        expect(page).to have_no_content 'Grant help with fees'
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.feature 'Confirmation page', type: :feature do
       end
 
       scenario 'the grant help with fees form is not rendered' do
-        expect(page).not_to have_content 'Grant help with fees'
+        expect(page).to have_no_content 'Grant help with fees'
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.feature 'Confirmation page', type: :feature do
       end
 
       scenario 'the grant help with fees form is not rendered' do
-        expect(page).not_to have_content 'Grant help with fees'
+        expect(page).to have_no_content 'Grant help with fees'
       end
     end
 
@@ -109,7 +109,7 @@ RSpec.feature 'Confirmation page', type: :feature do
       before { visit application_confirmation_path(decision_override.application) }
 
       scenario 'the grant help with fees form is not rendered' do
-        expect(page).not_to have_content 'Grant help with fees'
+        expect(page).to have_no_content 'Grant help with fees'
         expect(page).to have_content 'Granted help with fees'
       end
     end

--- a/spec/models/decision_override_spec.rb
+++ b/spec/models/decision_override_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe DecisionOverride, type: :model do
+  subject(:override) { build_stubbed :decision_override }
+
+  it { is_expected.to belong_to(:application) }
+  it { is_expected.to belong_to(:user) }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:application) }
+    it { is_expected.to validate_presence_of(:user) }
+
+    describe 'reason' do
+      subject(:override) { build_stubbed :decision_override, reason: reason }
+
+      before { override.valid? }
+
+      context 'when nil' do
+        let(:reason) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when set' do
+        let(:reason) { 'a reason' }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+end

--- a/spec/models/decision_override_spec.rb
+++ b/spec/models/decision_override_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe DecisionOverride, type: :model do
     describe 'reason' do
       subject(:override) { build_stubbed :decision_override, reason: reason }
 
-      before { override.valid? }
-
       context 'when nil' do
         let(:reason) { nil }
 

--- a/spec/models/forms/application/decision_override_spec.rb
+++ b/spec/models/forms/application/decision_override_spec.rb
@@ -70,6 +70,37 @@ RSpec.describe Forms::Application::DecisionOverride do
     end
   end
 
+  describe '#application_overridable?' do
+
+    subject { form.application_overridable?(application) }
+
+    context 'when the form was instantiated with an application' do
+      let(:outcome) { 'none' }
+      let(:application) { create :application_no_remission, :processed_state, application_type: type, outcome: outcome }
+      let(:form) { described_class.new(application) }
+
+      context 'that was income based' do
+        let(:type) { 'income' }
+
+        it { is_expected.to be false }
+      end
+
+      context 'that was benefits based' do
+        let(:type) { 'benefit' }
+
+        context 'with no remission granted' do
+          it { is_expected.to be true }
+        end
+
+        context 'with full remission granted' do
+          let(:outcome) { 'full' }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+
   describe '#save' do
     let(:override) { create :decision_override }
 

--- a/spec/models/forms/application/decision_override_spec.rb
+++ b/spec/models/forms/application/decision_override_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe Forms::Application::DecisionOverride do
+  params_list = %i[value reason created_by_id]
+
+  let(:override) { build_stubbed :decision_override }
+  let(:user) { create :staff }
+
+  subject(:form) { described_class.new(override) }
+
+  describe '.permitted_attributes' do
+    it 'returns a list of attributes' do
+      expect(described_class.permitted_attributes.keys).to match_array(params_list)
+    end
+  end
+
+  context 'validation' do
+    before { form.update_attributes(params) }
+    subject { form.valid? }
+
+    context 'user_id' do
+      let(:user_id) { nil }
+      let(:params) { { value: 1, reason: nil, created_by_id: user_id } }
+
+      context 'not set' do
+        it { is_expected.to be false }
+      end
+
+      context 'set with a checkbox value' do
+        let(:user_id) { user.id }
+
+        it { is_expected.to be true }
+      end
+
+    end
+
+    context 'with attribute "value"' do
+      let(:reason) { nil }
+      let(:option) { nil }
+      let(:params) { { value: option, reason: reason, created_by_id: user.id } }
+
+      context 'not set' do
+        it { is_expected.to be false }
+      end
+
+      context 'set with a checkbox value' do
+        let(:option) { 1 }
+
+        it { is_expected.to be true }
+      end
+
+      context 'set with "other" value' do
+        let(:option) { 'other' }
+
+        it { is_expected.to be false }
+
+        context 'with attribute "reason"' do
+
+          context 'not set' do
+            it { is_expected.to be false }
+          end
+
+          context 'set' do
+            let(:reason) { 'Some reason' }
+
+            it { is_expected.to be true }
+          end
+        end
+      end
+    end
+  end
+
+  describe '#save' do
+    let(:override) { create :decision_override }
+
+    before do
+      form.update_attributes(params)
+    end
+
+    subject { form.save }
+
+    context 'for an invalid form' do
+      let(:params) { { value: nil, reason: nil, created_by_id: user.id } }
+      it { is_expected.to be false }
+    end
+
+    context 'for a valid form when a value is chosen' do
+      let(:params) { { value: 1, reason: nil, created_by_id: user.id } }
+
+      it { is_expected.to be true }
+
+      before { subject && override.reload }
+
+      it 'updates the reason from the option label' do
+        expect(override.reason).to eql "You've received paper evidence that the applicant is receiving benefits"
+      end
+    end
+
+    context 'for a valid form when user inputs a reason' do
+      let(:params) { { value: 'other', reason: 'foo reason bar', created_by_id: user.id } }
+
+      it { is_expected.to be true }
+
+      before { subject && override.reload }
+
+      it 'updates the correct field on evidence check and creates reason record with explanation' do
+        expect(override.reason).to eql 'foo reason bar'
+      end
+    end
+  end
+
+end

--- a/spec/models/views/application_overview_spec.rb
+++ b/spec/models/views/application_overview_spec.rb
@@ -132,6 +132,14 @@ RSpec.describe Views::ApplicationOverview do
 
         it { is_expected.to eq '✗ Failed' }
       end
+
+      context 'when a decision_overide exists' do
+        let(:result) { 'no' }
+        let!(:application) { create(:application, :benefit_type) }
+        let!(:override) { create :decision_override, application: application }
+
+        it { is_expected.to eql "✓ Passed (by manager's decision)" }
+      end
     end
 
     context 'for an income type application' do

--- a/spec/models/views/application_result_spec.rb
+++ b/spec/models/views/application_result_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Views::ApplicationResult do
     subject { view.result }
 
     shared_examples 'result examples' do |type|
-      %w[full part none return].each do |result|
+      %w[granted full part none return].each do |result|
         context "when the #{type} is a #{result} remission" do
           let(:outcome) { result }
 

--- a/spec/models/views/confirmation/result_spec.rb
+++ b/spec/models/views/confirmation/result_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe Views::Confirmation::Result do
         it { is_expected.to eq string_failed }
       end
     end
+
+    context 'when a decision override exists' do
+      let!(:decision_override) { build_stubbed(:decision_override, application: application, reason: 'foo bar') }
+
+      it { is_expected.to eq "✓ Passed (by manager's decision)" }
+    end
   end
 
   describe '#income_passed?' do
@@ -127,5 +133,12 @@ RSpec.describe Views::Confirmation::Result do
 
       it { is_expected.to eql 'none' }
     end
+
+    context 'when a decision override exists' do
+      let!(:decision_override) { build_stubbed(:decision_override, application: application, reason: 'foo bar') }
+
+      it { is_expected.to eql 'granted' }
+    end
+
   end
 end

--- a/spec/models/views/processed_data_spec.rb
+++ b/spec/models/views/processed_data_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Views::ProcessedData do
     end
   end
 
+  describe '#application_override' do
+    let(:application) { create(:application, :confirm, :processed_state) }
+    let!(:decision_override) { create :decision_override, application: application }
+    subject { view.application_override }
+
+    it 'returns the override data' do
+      expect(subject).to eql(on: application.decision_override.created_at.strftime(Date::DATE_FORMATS[:gov_uk_long]), by: application.decision_override.user.name, text: 'Reason granted: "My reasons"')
+    end
+  end
+
   describe '#application_deleted' do
     let(:application) { build_stubbed(:application_full_remission, :processed_state, :deleted_state) }
 

--- a/spec/services/override_decision_service_spec.rb
+++ b/spec/services/override_decision_service_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe OverrideDecisionService, type: :service do
+
+  let(:application) { create :application, :processed_state, outcome: 'full' }
+  let(:decision_override) { DecisionOverride.new(application: application) }
+  let(:form) { Forms::Application::DecisionOverride.new(decision_override) }
+
+  before do
+    form.update_attributes(
+      created_by_id: user.id,
+      value: 'other',
+      reason: 'foo reason bar'
+    )
+  end
+
+  let(:reason) { 'foo reason bar' }
+  let(:user) { create :staff }
+
+  subject(:service) { described_class.new(application, form) }
+
+  it { is_expected.to be_a(described_class) }
+
+  describe '#set!' do
+    before { service.set! }
+
+    context 'updates the application' do
+      subject { application }
+
+      it { expect(subject.decision).to eql 'full' }
+      it { expect(subject.decision_type).to eql('override') }
+
+      it 'adds a decision_override to the application' do
+        expect(application.decision_override.present?).to be true
+      end
+
+      it 'saves the application' do
+        expect(subject.changed?).to be false
+        expect(subject.decision_override.changed?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Pivotal ticket](#120851949)

Allows users to override an application that has failed via the benefit route.

Still to do 
===
- [x] Refactor the logic used on the display, possibly into the decision_override view model
- [x] Update the processed applications page to display the new`✓ Passed (by manager's decision)` message
- [x] Increase the number of reason radio buttons (see content task)
- [x] Review the content