### PR TITLE
Use 0 for children when nil for income calculation

### DIFF
--- a/app/lib/income_calculation.rb
+++ b/app/lib/income_calculation.rb
@@ -12,12 +12,15 @@ class IncomeCalculation
 
   def calculation_inputs_present?
     [
-      @application.children,
+      children,
       @application.detail.fee,
       !@application.applicant.married.nil?,
-      income,
-      !@application.dependents.nil?
+      income
     ].all?
+  end
+
+  def children
+    @application.children || 0
   end
 
   def return_outcome_and_amount
@@ -40,7 +43,7 @@ class IncomeCalculation
   end
 
   def child_uplift
-    @application.children * Settings.calculator.uplift_per_child
+    children * Settings.calculator.uplift_per_child
   end
 
   def married_supplement

--- a/spec/lib/income_calculation_spec.rb
+++ b/spec/lib/income_calculation_spec.rb
@@ -35,6 +35,12 @@ RSpec.describe IncomeCalculation do
         end
       end
 
+      context 'when children attribute value is nil' do
+        before { application.children = nil }
+
+        it { is_expected.not_to be nil }
+      end
+
       context 'when data for calculation is missing' do
         before { application.detail.fee = nil }
 


### PR DESCRIPTION
The proper fix should be that the children field is always 0 or more,
but the public app at the moment sends nil when the user selects 'No'.
So that has to be fixed first.