### PR TITLE
exclude branch runner builds from active_job

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ submission:
 redirection:
   domains: <%= ENV['REDIRECTION_DOMAINS'] || '' %>
 active_job:
-  enabled: <%= ENV['ACTIVE_JOB_ENABLED'].present? && ['1', 'true'].include?(ENV['ACTIVE_JOB_ENABLED'].downcase) %>
+  ENV['ACTIVE_JOB_ENABLED'].present? && ['1', 'true'].include?(ENV['ACTIVE_JOB_ENABLED'].downcase) && ENV['APP_BUILD_TAG'].present? && !ENV['APP_BUILD_TAG'].downcase.starts_with?('jenkins-fr-staff-branch-builder')
 analytics:
   id: <%= ENV['GA_ID'] || 'UA-37377084-54' %>
   domain: <%= ENV['GA_DOMAIN'] || 'auto' %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ submission:
 redirection:
   domains: <%= ENV['REDIRECTION_DOMAINS'] || '' %>
 active_job:
-  enabled: ENV['ACTIVE_JOB_ENABLED'].present? && ['1', 'true'].include?(ENV['ACTIVE_JOB_ENABLED'].downcase) && ENV['APP_BUILD_TAG'].present? && !ENV['APP_BUILD_TAG'].downcase.starts_with?('jenkins-fr-staff-branch-builder')
+  enabled: <%= ENV['ACTIVE_JOB_ENABLED'].present? && ['1', 'true'].include?(ENV['ACTIVE_JOB_ENABLED'].downcase) && (!ENV['APP_BUILD_TAG'].present? || !ENV['APP_BUILD_TAG'].downcase.starts_with?('jenkins-fr-staff-branch-builder')) %>
 analytics:
   id: <%= ENV['GA_ID'] || 'UA-37377084-54' %>
   domain: <%= ENV['GA_DOMAIN'] || 'auto' %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,7 +16,7 @@ submission:
 redirection:
   domains: <%= ENV['REDIRECTION_DOMAINS'] || '' %>
 active_job:
-  ENV['ACTIVE_JOB_ENABLED'].present? && ['1', 'true'].include?(ENV['ACTIVE_JOB_ENABLED'].downcase) && ENV['APP_BUILD_TAG'].present? && !ENV['APP_BUILD_TAG'].downcase.starts_with?('jenkins-fr-staff-branch-builder')
+  enabled: ENV['ACTIVE_JOB_ENABLED'].present? && ['1', 'true'].include?(ENV['ACTIVE_JOB_ENABLED'].downcase) && ENV['APP_BUILD_TAG'].present? && !ENV['APP_BUILD_TAG'].downcase.starts_with?('jenkins-fr-staff-branch-builder')
 analytics:
   id: <%= ENV['GA_ID'] || 'UA-37377084-54' %>
   domain: <%= ENV['GA_DOMAIN'] || 'auto' %>


### PR DESCRIPTION
Hi @novotnyjakub Can you please check the code to exclude "branch runner" jobs from "active_job".
I was not able to set ACTIVE_JOB_ENABLED to "false" in the branch-runner container