### PR TITLE
js close for alert boxes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,3 +29,4 @@
 //= require cookies
 //= require login
 //= require fee_field
+//= require close_alerts

--- a/app/assets/javascripts/close_alerts.js
+++ b/app/assets/javascripts/close_alerts.js
@@ -1,0 +1,20 @@
+'use strict';
+
+window.moj.Modules.CloseAlerts = {
+  init: function() {
+    this.bindEvents();
+  },
+
+  bindEvents: function() {
+    var self = this;
+
+    $('.alert-box a.close').on('click', function(e) {
+      e.preventDefault();
+      self.closeAlert($(e.target));
+    });
+  },
+
+  closeAlert: function($el) {
+    $el.closest('.alert-box').fadeOut();
+  }
+};


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/117545043)

The staff app features alert boxes, or flash messages, that have a close button marked with an 'x' that doesn't do anything. This lets the user close the messages by clicking the 'x'.

<img width="1003" alt="screen shot 2016-07-20 at 14 35 44" src="https://cloud.githubusercontent.com/assets/988436/16988124/4063bfc0-4e87-11e6-944a-f42b6fbf1c08.png">

