### PR TITLE
Accept income range

### DIFF
--- a/app/builders/application_builder.rb
+++ b/app/builders/application_builder.rb
@@ -44,7 +44,8 @@ class ApplicationBuilder
   end
 
   def online_application_attributes(online_application)
-    fields = %i[benefits income reference]
+    fields = %i[benefits reference
+                income income_min_threshold_exceeded income_max_threshold_exceeded]
     prepare_attributes(fields, online_application).merge(dependent_attributes(online_application))
   end
 

--- a/app/controllers/api/submissions_controller.rb
+++ b/app/controllers/api/submissions_controller.rb
@@ -29,6 +29,8 @@ module Api
         :amount,
         :benefits,
         :children,
+        :income_min_threshold_exceeded,
+        :income_max_threshold_exceeded,
         :income,
         :refund,
         :date_fee_paid,

--- a/db/migrate/20160716101626_add_income_thresholds_to_application.rb
+++ b/db/migrate/20160716101626_add_income_thresholds_to_application.rb
@@ -1,0 +1,8 @@
+class AddIncomeThresholdsToApplication < ActiveRecord::Migration
+  def change
+    change_table :applications do |t|
+      t.boolean :income_min_threshold_exceeded, null: true
+      t.boolean :income_max_threshold_exceeded, null: true
+    end
+  end
+end

--- a/db/migrate/20160720072635_add_income_thresholds_to_online_application.rb
+++ b/db/migrate/20160720072635_add_income_thresholds_to_online_application.rb
@@ -1,0 +1,8 @@
+class AddIncomeThresholdsToOnlineApplication < ActiveRecord::Migration
+  def change
+    change_table :online_applications do |t|
+      t.boolean :income_min_threshold_exceeded, null: true
+      t.boolean :income_max_threshold_exceeded, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160627135552) do
+ActiveRecord::Schema.define(version: 20160716101626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,8 @@ ActiveRecord::Schema.define(version: 20160627135552) do
     t.datetime "decision_date"
     t.decimal  "decision_cost"
     t.integer  "online_application_id"
+    t.boolean  "income_min_threshold_exceeded"
+    t.boolean  "income_max_threshold_exceeded"
   end
 
   add_index "applications", ["business_entity_id"], name: "index_applications_on_business_entity_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160716101626) do
+ActiveRecord::Schema.define(version: 20160720072635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -216,41 +216,43 @@ ActiveRecord::Schema.define(version: 20160716101626) do
   end
 
   create_table "online_applications", force: :cascade do |t|
-    t.boolean  "married",                null: false
-    t.boolean  "min_threshold_exceeded", null: false
-    t.boolean  "benefits",               null: false
+    t.boolean  "married",                       null: false
+    t.boolean  "min_threshold_exceeded",        null: false
+    t.boolean  "benefits",                      null: false
     t.integer  "children"
     t.integer  "income"
-    t.boolean  "refund",                 null: false
+    t.boolean  "refund",                        null: false
     t.date     "date_fee_paid"
-    t.boolean  "probate",                null: false
+    t.boolean  "probate",                       null: false
     t.string   "deceased_name"
     t.date     "date_of_death"
     t.string   "case_number"
     t.string   "form_name"
-    t.string   "ni_number",              null: false
-    t.date     "date_of_birth",          null: false
+    t.string   "ni_number",                     null: false
+    t.date     "date_of_birth",                 null: false
     t.string   "title"
-    t.string   "first_name",             null: false
-    t.string   "last_name",              null: false
-    t.text     "address",                null: false
-    t.string   "postcode",               null: false
-    t.boolean  "email_contact",          null: false
+    t.string   "first_name",                    null: false
+    t.string   "last_name",                     null: false
+    t.text     "address",                       null: false
+    t.string   "postcode",                      null: false
+    t.boolean  "email_contact",                 null: false
     t.string   "email_address"
-    t.boolean  "phone_contact",          null: false
+    t.boolean  "phone_contact",                 null: false
     t.string   "phone"
-    t.boolean  "post_contact",           null: false
+    t.boolean  "post_contact",                  null: false
     t.string   "reference"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
     t.decimal  "fee"
     t.integer  "jurisdiction_id"
     t.text     "emergency_reason"
-    t.boolean  "feedback_opt_in",        null: false
+    t.boolean  "feedback_opt_in",               null: false
     t.date     "date_received"
     t.boolean  "max_threshold_exceeded"
     t.boolean  "over_61"
     t.integer  "amount"
+    t.boolean  "income_min_threshold_exceeded"
+    t.boolean  "income_max_threshold_exceeded"
   end
 
   add_index "online_applications", ["jurisdiction_id"], name: "index_online_applications_on_jurisdiction_id", using: :btree

--- a/spec/builders/application_builder_spec.rb
+++ b/spec/builders/application_builder_spec.rb
@@ -102,6 +102,24 @@ RSpec.describe ApplicationBuilder do
         end
       end
 
+      context 'when the online application has income thresholds instead of income' do
+        context 'when the minimum threshold has not been exceeded' do
+          let(:online_application) { build_stubbed(:online_application_with_all_details, :with_reference, :completed, income: nil, income_min_threshold_exceeded: false) }
+
+          it 'has income_min_threshold_exceeded assigned' do
+            expect(built_application.income_min_threshold_exceeded).to eql(false)
+          end
+        end
+
+        context 'when the maximum threshold has been exceeded' do
+          let(:online_application) { build_stubbed(:online_application_with_all_details, :with_reference, :completed, income: nil, income_max_threshold_exceeded: true) }
+
+          it 'has income_max_threshold_exceeded assigned' do
+            expect(built_application.income_max_threshold_exceeded).to eql(true)
+          end
+        end
+      end
+
       context 'when the online application has children' do
         let(:online_application) { build_stubbed(:online_application_with_all_details, children: 2) }
 

--- a/spec/lib/income_calculation_spec.rb
+++ b/spec/lib/income_calculation_spec.rb
@@ -13,38 +13,58 @@ RSpec.describe IncomeCalculation do
     context 'when income is not provided explicitly' do
       let(:income) { nil }
 
-      it 'uses the income from the application' do
-        subject
-        expect(application).to have_received(:income).at_least(1).times
-      end
+      context 'when the application has income thresholds set but not income' do
+        context 'when the minimum income threshold has not been exceeded' do
+          let(:application) { build :application_part_remission, income: nil, income_min_threshold_exceeded: false }
 
-      context 'when data for calculation is present' do
-        describe 'for known scenarios' do
-          CalculatorTestData.seed_data.each do |src|
-            it "scenario \##{src[:id]} passes" do
-              application.tap do |a|
-                a.detail.fee = src[:fee]
-                a.applicant.married = src[:married_status]
-                a.children = src[:children]
-                a.income = src[:income]
-              end
+          it 'results in full remission' do
+            is_expected.to eql(outcome: 'full', amount: 0)
+          end
+        end
 
-              is_expected.to eql(outcome: src[:type], amount: src[:they_pay].to_i)
-            end
+        context 'when the maximum income threshold has been exceeded' do
+          let(:application) { build :application_part_remission, fee: 333, income: nil, income_max_threshold_exceeded: true }
+
+          it 'results in no remission' do
+            is_expected.to eql(outcome: 'none', amount: 333)
           end
         end
       end
 
-      context 'when children attribute value is nil' do
-        before { application.children = nil }
+      context 'when the application has income set' do
+        it 'uses the income from the application' do
+          subject
+          expect(application).to have_received(:income).at_least(1).times
+        end
 
-        it { is_expected.not_to be nil }
-      end
+        context 'when data for calculation is present' do
+          describe 'for known scenarios' do
+            CalculatorTestData.seed_data.each do |src|
+              it "scenario \##{src[:id]} passes" do
+                application.tap do |a|
+                  a.detail.fee = src[:fee]
+                  a.applicant.married = src[:married_status]
+                  a.children = src[:children]
+                  a.income = src[:income]
+                end
 
-      context 'when data for calculation is missing' do
-        before { application.detail.fee = nil }
+                is_expected.to eql(outcome: src[:type], amount: src[:they_pay].to_i)
+              end
+            end
+          end
+        end
 
-        it { is_expected.to be nil }
+        context 'when children attribute value is nil' do
+          before { application.children = nil }
+
+          it { is_expected.not_to be nil }
+        end
+
+        context 'when data for calculation is missing' do
+          before { application.detail.fee = nil }
+
+          it { is_expected.to be nil }
+        end
       end
     end
 


### PR DESCRIPTION
This PR makes an addition to the income calculation, which supports min/max income thresholds as well. There is no change to the behaviour of the staff app itself, it's a preparation for the integration with `hwf-publicapp`.