### PR TITLE
fix staff guide headline icons

### DIFF
--- a/app/views/guide/appeals.html.slim
+++ b/app/views/guide/appeals.html.slim
@@ -1,5 +1,5 @@
 header
-  h2.guide-headline.guide-headline-evidence.heading-xlarge
+  h2.guide-headline.guide-headline-appeals.heading-xlarge
     span.hint.util_mb-0
       | Staff guide
     | Appeals

--- a/app/views/guide/part_payments.html.slim
+++ b/app/views/guide/part_payments.html.slim
@@ -1,5 +1,5 @@
 header
-  h2.guide-headline.guide-headline-evidence.heading-xlarge
+  h2.guide-headline.guide-headline-part-fee.heading-xlarge
     span.hint.util_mb-0
       | Staff guide
     | Part-payments

--- a/app/views/guide/suspected_fraud.html.slim
+++ b/app/views/guide/suspected_fraud.html.slim
@@ -1,5 +1,5 @@
 header
-  h2.guide-headline.guide-headline-evidence.heading-xlarge
+  h2.guide-headline.guide-headline-fraud.heading-xlarge
     span.hint.util_mb-0
       | Staff guide
     | Suspected fraud


### PR DESCRIPTION
[Pivotal](https://www.pivotaltracker.com/story/show/120591891)

The headlines in the guide sections were showing the wrong icons.