### PR TITLE
Variable pagination

### DIFF
--- a/app/assets/stylesheets/local/lists.scss
+++ b/app/assets/stylesheets/local/lists.scss
@@ -22,3 +22,20 @@
     margin-bottom: 10px;
   }
 }
+
+.inline-list {
+  li {
+    display: inline-block;
+    @include core-16;
+    margin-right: 5px;
+  }
+}
+
+.pagination {
+  li:nth-child(n+3) {
+    &::before {
+      content: '|';
+      margin-right: 5px;
+    }
+  }
+}

--- a/app/helpers/processed_views_helper.rb
+++ b/app/helpers/processed_views_helper.rb
@@ -7,8 +7,11 @@ module ProcessedViewsHelper
   end
 
   def paginate(query)
-    per_page_count = per_page_is_all? ? 1000000000 : per_page
-    query.paginate(page: page, per_page: per_page_count)
+    if per_page_is_all?
+      query
+    else
+      query.paginate(page: page, per_page: per_page)
+    end
   end
 
   def previous_page

--- a/app/helpers/processed_views_helper.rb
+++ b/app/helpers/processed_views_helper.rb
@@ -7,7 +7,8 @@ module ProcessedViewsHelper
   end
 
   def paginate(query)
-    query.paginate(page: page, per_page: Settings.processed_deleted.per_page)
+    per_page_count = per_page_is_all? ? 1000000000 : per_page
+    query.paginate(page: page, per_page: per_page_count)
   end
 
   def previous_page
@@ -23,6 +24,16 @@ module ProcessedViewsHelper
   end
 
   def total_pages
-    @paginate.total_pages
+    per_page_is_all? ? 1 : @paginate.total_pages
+  end
+
+  def per_page
+    params[:per_page].try(:to_i) || Settings.processed_deleted.per_page
+  end
+
+  private
+
+  def per_page_is_all?
+    params[:per_page].eql?('All')
   end
 end

--- a/app/views/shared/processed_and_deleted/_index.html.slim
+++ b/app/views/shared/processed_and_deleted/_index.html.slim
@@ -2,6 +2,7 @@ header
   h2.heading-xlarge =t("#{state}_applications.index.title")
 
 - unless @applications.empty?
+  =render('shared/processed_and_deleted/per_page_display')
   table *{class: "#{state}-applications"}
     caption.visuallyhidden =t("#{state}_applications.index.title")
     thead
@@ -25,6 +26,7 @@ header
           td= application.form_name
           td= application.fee
           td= application.emergency
+  = render('shared/processed_and_deleted/per_page_display')
 
 - else
   p =t("#{state}_applications.index.no_applications")
@@ -33,7 +35,7 @@ header
 .pagination
   .paginate.previous
     - if previous_page
-      =link_to('Previous page', "/#{controller.controller_name}?page=#{previous_page}")
+      =link_to('Previous page', "/#{controller.controller_name}?page=#{previous_page}&per_page=#{per_page}")
 
 
   .pages
@@ -41,4 +43,4 @@ header
 
   .paginate.next
     - if next_page
-      =link_to('Next page', "/#{controller.controller_name}?page=#{next_page}")
+      =link_to('Next page', "/#{controller.controller_name}?page=#{next_page}&per_page=#{per_page}")

--- a/app/views/shared/processed_and_deleted/_per_page_display.html.slim
+++ b/app/views/shared/processed_and_deleted/_per_page_display.html.slim
@@ -1,9 +1,8 @@
-div.util_mt-small
-  ul
-    li Display
-    - %w[50 100 500 All].each do |new_per_page|
-      li
-        -if params[:per_page].eql?(new_per_page)
-          =new_per_page
-        -else
-          =link_to(new_per_page, "/#{controller.controller_name}?per_page=#{new_per_page}")
+ul.pagination.inline-list.util_mt-medium.util_mb-small
+  li Display:
+  - %w[50 100 500 All].each do |new_per_page|
+    li.per-page
+      -if params[:per_page].eql?(new_per_page)
+        strong= new_per_page
+      -else
+        =link_to(new_per_page, "/#{controller.controller_name}?per_page=#{new_per_page}")

--- a/app/views/shared/processed_and_deleted/_per_page_display.html.slim
+++ b/app/views/shared/processed_and_deleted/_per_page_display.html.slim
@@ -1,0 +1,9 @@
+div.util_mt-small
+  ul
+    li Display
+    - %w[50 100 500 All].each do |new_per_page|
+      li
+        -if params[:per_page].eql?(new_per_page)
+          =new_per_page
+        -else
+          =link_to(new_per_page, "/#{controller.controller_name}?per_page=#{new_per_page}")

--- a/spec/controllers/deleted_applications_controller_spec.rb
+++ b/spec/controllers/deleted_applications_controller_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe DeletedApplicationsController, type: :controller do
     let(:relation) { MockRelation.new([application1, application2]) }
     let(:query) { double(find: scope) }
     let(:page) { nil }
+    let(:per_page) { nil }
 
     class MockRelation < Array
       def paginate(_options)
@@ -42,7 +43,7 @@ RSpec.describe DeletedApplicationsController, type: :controller do
       allow(Views::ApplicationList).to receive(:new).with(application1).and_return(view1)
       allow(Views::ApplicationList).to receive(:new).with(application2).and_return(view2)
 
-      get :index, page: page
+      get :index, page: page, per_page: per_page
     end
 
     it 'returns the correct status code' do
@@ -67,6 +68,27 @@ RSpec.describe DeletedApplicationsController, type: :controller do
 
     context 'when page parameter is not set' do
       it 'calls pagination with page as nil and defined number per page (settings)' do
+        expect(relation).to have_received(:paginate).with(page: 1, per_page: 2)
+      end
+    end
+
+    context 'when the per_page parameter is set to all' do
+      let(:per_page) { 'All' }
+
+      it 'calls pagination with the page number and params number per page' do
+        expect(relation).to have_received(:paginate).with(page: 1, per_page: 1000000000)
+      end
+    end
+    context 'when the per_page parameter is set numerically' do
+      let(:per_page) { 3 }
+
+      it 'calls pagination with the page number and params number per page' do
+        expect(relation).to have_received(:paginate).with(page: 1, per_page: 3)
+      end
+    end
+
+    context 'when the per_page parameter is not set' do
+      it 'calls pagination with the page number and defined number per page (settings)' do
         expect(relation).to have_received(:paginate).with(page: 1, per_page: 2)
       end
     end

--- a/spec/controllers/deleted_applications_controller_spec.rb
+++ b/spec/controllers/deleted_applications_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe DeletedApplicationsController, type: :controller do
       let(:per_page) { 'All' }
 
       it 'calls pagination with the page number and params number per page' do
-        expect(relation).to have_received(:paginate).with(page: 1, per_page: 1000000000)
+        expect(relation).not_to have_received(:paginate)
       end
     end
     context 'when the per_page parameter is set numerically' do

--- a/spec/controllers/processed_applications_controller_spec.rb
+++ b/spec/controllers/processed_applications_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
       let(:per_page) { 'All' }
 
       it 'calls pagination with the page number and params number per page' do
-        expect(relation).to have_received(:paginate).with(page: 1, per_page: 1000000000)
+        expect(relation).not_to have_received(:paginate)
       end
     end
     context 'when the per_page parameter is set numerically' do

--- a/spec/controllers/processed_applications_controller_spec.rb
+++ b/spec/controllers/processed_applications_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
     let(:relation) { MockRelation.new([application1, application2]) }
     let(:query) { double(find: scope) }
     let(:page) { nil }
+    let(:per_page) { nil }
 
     class MockRelation < Array
       def paginate(_options)
@@ -43,7 +44,7 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
       allow(Views::ApplicationList).to receive(:new).with(application1).and_return(view1)
       allow(Views::ApplicationList).to receive(:new).with(application2).and_return(view2)
 
-      get :index, page: page
+      get :index, page: page, per_page: per_page
     end
 
     it 'returns the correct status code' do
@@ -68,6 +69,27 @@ RSpec.describe ProcessedApplicationsController, type: :controller do
 
     context 'when page parameter is not set' do
       it 'calls pagination with page as nil and defined number per page (settings)' do
+        expect(relation).to have_received(:paginate).with(page: 1, per_page: 2)
+      end
+    end
+
+    context 'when the per_page parameter is set to all' do
+      let(:per_page) { 'All' }
+
+      it 'calls pagination with the page number and params number per page' do
+        expect(relation).to have_received(:paginate).with(page: 1, per_page: 1000000000)
+      end
+    end
+    context 'when the per_page parameter is set numerically' do
+      let(:per_page) { 3 }
+
+      it 'calls pagination with the page number and params number per page' do
+        expect(relation).to have_received(:paginate).with(page: 1, per_page: 3)
+      end
+    end
+
+    context 'when the per_page parameter is not set' do
+      it 'calls pagination with the page number and defined number per page (settings)' do
         expect(relation).to have_received(:paginate).with(page: 1, per_page: 2)
       end
     end


### PR DESCRIPTION
[Pivotal ticket](https://www.pivotaltracker.com/story/show/126793691)

On first load the page defaults to 50 records per-page for processed/deleted application indexes.

This adds a selector for 50/100/500/All to allow users to select their preference, for a single use of the page