### PR TITLE
Unicorn killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'redcarpet'
 
 # Use Unicorn as the app server
 gem 'unicorn'
+gem 'unicorn-worker-killer'
 gem 'logstasher', git: 'https://github.com/shadabahmed/logstasher.git',
                   ref: '0b80e972753ba7ef36854b48d2c371e32963bc8d'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
     formatador (0.2.5)
+    get_process_mem (0.2.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     groupdate (2.5.2)
@@ -392,6 +393,9 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    unicorn-worker-killer (0.4.4)
+      get_process_mem (~> 0)
+      unicorn (>= 4, < 6)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -472,6 +476,7 @@ DEPENDENCIES
   timecop
   uglifier (>= 2.7.2)
   unicorn
+  unicorn-worker-killer
   virtus
   web-console (~> 2.1)
   webmock

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,24 @@
 # This file is used by Rack-based servers to start the application.
 
+# --- Start of unicorn worker killer code ---
+
+if ENV['RAILS_ENV'] == 'production'
+  require 'unicorn/worker_killer'
+
+  max_request_min =  2048
+  max_request_max =  3072
+
+  # Max requests per worker
+  use Unicorn::WorkerKiller::MaxRequests, max_request_min, max_request_max
+
+  oom_min = 192 * (1024**2)
+  oom_max = 256 * (1024**2)
+
+  # Max memory size (RSS) per worker
+  use Unicorn::WorkerKiller::Oom, oom_min, oom_max
+end
+
+# --- End of unicorn worker killer code ---
+
 require ::File.expand_path('../config/environment', __FILE__)
 run Rails.application


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6757677/17142570/82091ab8-5348-11e6-80e1-cbba05082993.png)

## Issue - Memory usage has been increasing over time
Memory usage on the production instances has been increasing over time, it was suggested to try refreshing the unicorn workers to free up memory.

## Solution - Implement a solution to reduce memory usage on prod
Kill unicorn workers when memory and/or processes exceed the thresholds

I found two examples for setting the thresholds [here](http://www.rubydoc.info/gems/unicorn-worker-killer/0.4.4) and [here](https://www.digitalocean.com/community/tutorials/how-to-optimize-unicorn-workers-in-a-ruby-on-rails-app) but either seemed very high or low.  I've split the difference and we can monitor the results and adjust as required.

## Possible followup
Another potential culprit is beaver.  If this does not demonstrably reduce the memory usage over time, we should look at something similar for beaver on the sever.