### PR TITLE
Flag evidence checks

### DIFF
--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -50,6 +50,7 @@ class EvidenceController < ApplicationController
 
   def summary_save
     ResolverService.new(evidence, current_user).complete
+    process_evidence_check_flag
     redirect_to evidence_confirmation_path
   end
 
@@ -62,7 +63,15 @@ class EvidenceController < ApplicationController
   end
 
   def return_application
-    redirect_to root_path if ResolverService.new(evidence, current_user).return
+    if ResolverService.new(evidence, current_user).return
+      process_evidence_check_flag
+      redirect_to root_path
+    end
+  end
+
+  def process_evidence_check_flag
+    evidence_check = EvidenceCheckFlaggingService.new(evidence)
+    evidence_check.process_flag if evidence_check.can_be_flagged?
   end
 
   private

--- a/app/models/evidence_check_flag.rb
+++ b/app/models/evidence_check_flag.rb
@@ -1,0 +1,4 @@
+class EvidenceCheckFlag < ActiveRecord::Base
+  validates :ni_number, presence: true
+  validates :ni_number, uniqueness: { scope: :active }, if: :active?
+end

--- a/app/services/evidence_check_flagging_service.rb
+++ b/app/services/evidence_check_flagging_service.rb
@@ -1,0 +1,38 @@
+class EvidenceCheckFlaggingService
+  def initialize(calling_object)
+    if calling_object.is_a?(Application)
+      @application = calling_object
+      @evidence = calling_object.evidence_check
+    else
+      @application = calling_object.application
+      @evidence = calling_object
+    end
+  end
+
+  def can_be_flagged?
+    ni_number.present?
+  end
+
+  def process_flag
+    if evidence_check_flag
+      if @evidence.correct
+        evidence_check_flag.active = false
+      else
+        evidence_check_flag.increment(:count)
+      end
+      evidence_check_flag.save!
+    else
+      EvidenceCheckFlag.create(ni_number: ni_number, count: 1) unless @evidence.correct
+    end
+  end
+
+  private
+
+  def evidence_check_flag
+    @evidence_check_flag ||= EvidenceCheckFlag.find_by(ni_number: ni_number, active: true)
+  end
+
+  def ni_number
+    @ni_number ||= @application.applicant.ni_number
+  end
+end

--- a/app/services/evidence_check_selector.rb
+++ b/app/services/evidence_check_selector.rb
@@ -5,10 +5,19 @@ class EvidenceCheckSelector
   end
 
   def decide!
-    @application.create_evidence_check(expires_at: expires_at) if evidence_check? || flagged?
+    type = evidence_check_type
+    @application.create_evidence_check(expires_at: expires_at, check_type: type) if type
   end
 
   private
+
+  def evidence_check_type
+    if evidence_check?
+      'random'
+    elsif flagged?
+      'flag'
+    end
+  end
 
   def evidence_check?
     if Query::EvidenceCheckable.new.find_all.exists?(@application.id)

--- a/app/services/evidence_check_selector.rb
+++ b/app/services/evidence_check_selector.rb
@@ -5,7 +5,7 @@ class EvidenceCheckSelector
   end
 
   def decide!
-    @application.create_evidence_check(expires_at: expires_at) if evidence_check?
+    @application.create_evidence_check(expires_at: expires_at) if evidence_check? || flagged?
   end
 
   private
@@ -14,6 +14,10 @@ class EvidenceCheckSelector
     if Query::EvidenceCheckable.new.find_all.exists?(@application.id)
       @application.detail.refund? ? check_every_other_refund : check_every_tenth_non_refund
     end
+  end
+
+  def flagged?
+    EvidenceCheckFlag.exists?(ni_number: @application.applicant.ni_number, active: true)
   end
 
   def check_every_other_refund

--- a/db/migrate/20160801095935_create_evidence_check_flag.rb
+++ b/db/migrate/20160801095935_create_evidence_check_flag.rb
@@ -1,0 +1,12 @@
+class CreateEvidenceCheckFlag < ActiveRecord::Migration
+  def change
+    create_table :evidence_check_flags do |t|
+      t.string :ni_number
+      t.boolean :active, default: true
+      t.integer :count
+      t.timestamps null: false
+    end
+
+    add_index :evidence_check_flags, [:ni_number, :active], name: 'evidence_check_flags_active_unique', unique: true, where: "active = true"
+  end
+end

--- a/db/migrate/20160803121730_add_type_to_evidence_check.rb
+++ b/db/migrate/20160803121730_add_type_to_evidence_check.rb
@@ -1,0 +1,6 @@
+class AddTypeToEvidenceCheck < ActiveRecord::Migration
+  def change
+    add_column :evidence_checks, :check_type, :string
+    EvidenceCheck.connection.execute("UPDATE evidence_checks SET check_çtype='random';")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801095935) do
+ActiveRecord::Schema.define(version: 20160803121730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -188,6 +188,7 @@ ActiveRecord::Schema.define(version: 20160801095935) do
     t.datetime "completed_at"
     t.integer  "completed_by_id"
     t.string   "incorrect_reason"
+    t.string   "check_type"
   end
 
   add_index "evidence_checks", ["application_id"], name: "index_evidence_checks_on_application_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160727091449) do
+ActiveRecord::Schema.define(version: 20160801095935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,6 +165,16 @@ ActiveRecord::Schema.define(version: 20160727091449) do
   end
 
   add_index "details", ["application_id"], name: "index_details_on_application_id", using: :btree
+
+  create_table "evidence_check_flags", force: :cascade do |t|
+    t.string   "ni_number"
+    t.boolean  "active",     default: true
+    t.integer  "count"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "evidence_check_flags", ["ni_number", "active"], name: "evidence_check_flags_active_unique", unique: true, where: "(active = true)", using: :btree
 
   create_table "evidence_checks", force: :cascade do |t|
     t.integer  "application_id",   null: false

--- a/spec/factories/evidence_check_flags.rb
+++ b/spec/factories/evidence_check_flags.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :evidence_check_flag do
+    ni_number 'AA123456C'
+    active true
+    count 1
+  end
+end

--- a/spec/models/evidence_check_flag_spec.rb
+++ b/spec/models/evidence_check_flag_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe EvidenceCheckFlag, type: :model do
+
+  subject { build :evidence_check_flag }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:ni_number) }
+
+    context 'when ni_number is already in use' do
+      let!(:original) { create :evidence_check_flag }
+
+      it 'will not allow a duplicate to be created' do
+        expect(subject.valid?).to be false
+      end
+    end
+
+    context 'when evidence check flag has been cleared' do
+      let!(:original) { create :evidence_check_flag, active: false }
+
+      it 'allows a new flag to be created' do
+        expect(subject.valid?).to be true
+      end
+    end
+  end
+end

--- a/spec/services/evidence_check_flagging_service_spec.rb
+++ b/spec/services/evidence_check_flagging_service_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe EvidenceCheckFlaggingService do
+  let(:current_time) { Time.zone.now }
+  let(:expires_in_days) { 2 }
+
+  describe '#can_be_flagged?' do
+    subject { described_class.new(application).can_be_flagged? }
+
+    let(:application) { create :application_full_remission, reference: 'XY55-22-3', applicant: applicant }
+
+    context 'when the applicant has no ni_number' do
+      let(:applicant) { create :applicant_with_all_details, ni_number: nil }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the applicant has an ni_number' do
+      let(:applicant) { create :applicant_with_all_details }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe '#process_flag' do
+    subject { described_class.new(evidence_check).process_flag }
+
+    let(:application) { create :application_full_remission, reference: 'XY55-22-3', applicant: applicant }
+    let(:applicant) { create :applicant_with_all_details }
+
+    context 'when the evidence check passed' do
+      let(:evidence_check) { create :evidence_check_full_outcome, :completed, application: application }
+
+      context 'when a previous flag exists' do
+        let!(:flag) { create :evidence_check_flag, ni_number: applicant.ni_number }
+
+        it 'deactivates the flag' do
+          expect { subject && flag.reload }.to change { flag.active }.to false
+        end
+      end
+
+      context 'when there is no flag' do
+        it 'does not create a flag' do
+          expect { subject }.not_to change { EvidenceCheckFlag.count }
+        end
+      end
+    end
+
+    context 'when the evidence check failed' do
+      let(:evidence_check) { create :evidence_check_incorrect, :completed, application: application }
+
+      context 'when no flag exists' do
+        it 'creates a new flag' do
+          expect { subject }.to change { EvidenceCheckFlag.count }.by(1)
+        end
+      end
+
+      context 'when a previous flag exists' do
+        let!(:flag) { create :evidence_check_flag, ni_number: applicant.ni_number }
+
+        it 'increments the count on the existing flag' do
+          expect { subject && flag.reload }.to change { flag.count }.by(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/evidence_check_selector_spec.rb
+++ b/spec/services/evidence_check_selector_spec.rb
@@ -52,6 +52,8 @@ describe EvidenceCheckSelector do
             is_expected.to be_a(EvidenceCheck)
           end
 
+          it { expect(subject.check_type).to eql 'random' }
+
           it 'sets expiration on the evidence_check' do
             expect(subject.expires_at).to eql(current_time + expires_in_days.days)
           end
@@ -105,6 +107,10 @@ describe EvidenceCheckSelector do
         let!(:flag) { create :evidence_check_flag, ni_number: applicant.ni_number }
 
         it { is_expected.to be_a(EvidenceCheck) }
+
+        it 'sets the type to "flag"' do
+          expect(subject.check_type).to eql 'flag'
+        end
       end
     end
   end

--- a/spec/services/evidence_check_selector_spec.rb
+++ b/spec/services/evidence_check_selector_spec.rb
@@ -98,6 +98,14 @@ describe EvidenceCheckSelector do
           end
         end
       end
+
+      context 'when the application is flagged for failed evidence check' do
+        let(:applicant) { create :applicant_with_all_details }
+        let(:application) { create :application_full_remission, reference: 'XY55-22-3', applicant: applicant }
+        let!(:flag) { create :evidence_check_flag, ni_number: applicant.ni_number }
+
+        it { is_expected.to be_a(EvidenceCheck) }
+      end
     end
   end
 end


### PR DESCRIPTION
[Ticket](https://www.pivotaltracker.com/story/show/126320983)

Flag NI numbers that have had a failed or returned evidence check.  
* Automatically re-check on subsequent applications.  
* Count the number of failed applications for MI purposes.
* Clear a flag on completion of a successful evidence check