### PR TITLE
Update public_submission_data

### DIFF
--- a/app/models/views/reports/public_submission_data.rb
+++ b/app/models/views/reports/public_submission_data.rb
@@ -3,7 +3,8 @@ module Views
     class PublicSubmissionData
 
       def initialize
-        @applications = Application.joins(:office).where.not(online_application_id: nil)
+        @applications = Application.joins(:office).
+                        where.not(online_application_id: nil, completed_at: nil)
       end
 
       def submission_all_time_total

--- a/spec/models/views/reports/public_submission_data_spec.rb
+++ b/spec/models/views/reports/public_submission_data_spec.rb
@@ -2,10 +2,12 @@
 require 'rails_helper'
 
 RSpec.describe Views::Reports::PublicSubmissionData do
+  let!(:online_application) { Timecop.freeze(8.days.ago) { create :online_application, :completed, :with_reference } }
 
   before do
     Timecop.freeze(8.days.ago) do
       create_list :online_application, 8, :completed, :with_reference, convert_to_application: true
+      create :application, :uncompleted, :with_office, state: :created, online_application: online_application, reference: online_application.reference
     end
     Timecop.freeze(2.days.ago) do
       create_list :online_application, 2, :completed, :with_reference, convert_to_application: true
@@ -15,7 +17,7 @@ RSpec.describe Views::Reports::PublicSubmissionData do
   subject(:data) { described_class.new }
 
   it 'returns the expected data' do
-    # #submission_all_time_total returns the expected count of processed online submissions'
+    # #submission_all_time_total returns the expected count of processed online submissions, ignoring uncompleted conversions'
     expect(data.submission_all_time_total).to eq 10
 
     # #submission_all_time returns a collection of courts and a total count of the applications processed


### PR DESCRIPTION
Ensure data loaded has been completed, not just started.
This was causing issues on the live app when a court had started processing an online_application, but had not completed it.