### PR TITLE
Prevent errors when processing online applications

### DIFF
--- a/app/services/application_search.rb
+++ b/app/services/application_search.rb
@@ -9,7 +9,7 @@ class ApplicationSearch
 
   def online
     return if !prepare_reference! || application_exists_and_user_can_access ||
-              application_exists_and_user_cannot_access
+              application_exists_and_user_cannot_access || online_application_income_invalid?
 
     if online_application_exists
       edit_online_application_path(@online_application)
@@ -68,6 +68,28 @@ class ApplicationSearch
 
   def online_application_exists
     @online_application ||= OnlineApplication.find_by(reference: @reference.upcase)
+  end
+
+  def online_application_income_invalid?
+    if online_application_exists && income_required_but_missing
+      @error_message = I18n.t(:income_error, scope: scope)
+    end
+  end
+
+  def income_required_but_missing
+    online_application_income_required? && online_application_income_missing?
+  end
+
+  def online_application_income_required?
+    @online_application.benefits.eql?(false)
+  end
+
+  def online_application_income_missing?
+    [
+      @online_application.income,
+      @online_application.income_min_threshold_exceeded,
+      @online_application.income_max_threshold_exceeded
+    ].all?(&:nil?)
   end
 
   def scope

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,6 +468,7 @@ en-GB:
               not_found: 'Reference number is not recognised'
               processed_html: 'This application has been processed, <a href="%{application_path}">view application</a>'
               processed_by: 'This application has been processed by %{office_name}'
+              income_error: 'This application cannot be processed, please ask the applicant to re-submit a new form'
         forms/online_application:
           attributes:
             fee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,7 +468,7 @@ en-GB:
               not_found: 'Reference number is not recognised'
               processed_html: 'This application has been processed, <a href="%{application_path}">view application</a>'
               processed_by: 'This application has been processed by %{office_name}'
-              income_error: 'This application cannot be processed, please ask the applicant to re-submit a new form'
+              income_error: 'This application is incomplete and can’t be processed. Please ask the applicant to apply again.'
         forms/online_application:
           attributes:
             fee:

--- a/spec/factories/online_applications.rb
+++ b/spec/factories/online_applications.rb
@@ -67,6 +67,13 @@ FactoryGirl.define do
       income 450
     end
 
+    trait :invalid_income do
+      benefits false
+      income nil
+      income_min_threshold_exceeded nil
+      income_max_threshold_exceeded nil
+    end
+
     trait :with_email do
       email_address 'foo@bar.com'
     end

--- a/spec/features/search/staff_cannot_process_applications_with_errors_spec.rb
+++ b/spec/features/search/staff_cannot_process_applications_with_errors_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.feature 'Staff are prevented from processing online applications', type: :feature do
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let(:user) { create :staff }
+  let!(:online_application) { create :online_application, :with_reference, :invalid_income }
+
+  before do
+    login_as user
+  end
+
+  scenario 'when the income data is missing income data' do
+    given_user_is_on_the_homepage
+    when_they_search_for_an_application_with_missing_data
+    they_are_shown_a_warning
+  end
+
+  def given_user_is_on_the_homepage
+    visit '/'
+  end
+
+  def when_they_search_for_an_application_with_missing_data
+    fill_in :online_search_reference, with: online_application.reference
+    click_button 'Look up'
+  end
+
+  def they_are_shown_a_warning
+    expect(page).to have_content(I18n.t('activemodel.errors.models.forms/search.attributes.reference.income_error'))
+  end
+end

--- a/spec/services/application_search_spec.rb
+++ b/spec/services/application_search_spec.rb
@@ -91,6 +91,22 @@ RSpec.describe ApplicationSearch do
         expect(service.error_message).to eq 'Reference number is not recognised'
       end
     end
+
+    context 'when the application has been submitted with invalid data' do
+      let(:reference) { existing_reference }
+      let(:invalid_online_application) { build_stubbed(:online_application, :invalid_income, reference: existing_reference) }
+
+      before do
+        allow(OnlineApplication).to receive(:find_by).with(reference: existing_reference).and_return(invalid_online_application)
+        service.online
+      end
+
+      it { is_expected.to be nil }
+
+      it 'sets the correct error message' do
+        expect(service.error_message).to eq(I18n.t('activemodel.errors.models.forms/search.attributes.reference.income_error'))
+      end
+    end
   end
 
   describe '#completed' do


### PR DESCRIPTION
## Issue
A situation (now rectified) on the public app meant that users could submit applications with incomplete income data.  When a user entered the reference number, edit the application to add fee, date received, etc; but then, when they pushed next, they would get a blank white error screen.

## Fix
This fix means that now, when a user searches for a reference of an affected application, a message is displayed explaining why they cannot proceed.
![image](https://cloud.githubusercontent.com/assets/6757677/17625113/52516c58-609f-11e6-8333-0367e70b39cc.png)

## Incomplete tasks
- [x] Content review of the error message
- [ ] Technical review

