### PR TITLE
Resolver cost update

### DIFF
--- a/app/services/resolver_cost_calculator.rb
+++ b/app/services/resolver_cost_calculator.rb
@@ -5,7 +5,7 @@ class ResolverCostCalculator
   end
 
   def cost
-    @source.outcome == 'none' ? 0 : incurred_cost
+    %w[return none].include?(@source.outcome) ? 0 : incurred_cost
   end
 
   private

--- a/db/migrate/20160818114238_update_decision_cost.rb
+++ b/db/migrate/20160818114238_update_decision_cost.rb
@@ -1,0 +1,5 @@
+class UpdateDecisionCost < ActiveRecord::Migration
+  def up
+    CorrectReturnedCosts.up!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160803121730) do
+ActiveRecord::Schema.define(version: 20160818114238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/correct_returned_costs.rb
+++ b/lib/correct_returned_costs.rb
@@ -1,0 +1,11 @@
+class CorrectReturnedCosts
+  def self.affected_records
+    Application.where(decision: 'none').where('decision_cost > 0')
+  end
+
+  def self.up!
+    affected_records.each do |application|
+      application.update(decision_cost: 0)
+    end
+  end
+end

--- a/spec/lib/correct_returned_costs_spec.rb
+++ b/spec/lib/correct_returned_costs_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CorrectReturnedCosts do
+  subject { described_class }
+
+  let!(:application1) { create(:application_full_remission, :processed_state, decision_type: 'part', decision_cost: 30, outcome: 'none') }
+  let!(:application2) { create(:application_full_remission, :processed_state, decision_type: 'evidence', decision_cost: 30, outcome: 'none') }
+  let!(:application3) { create(:application_full_remission, :processed_state) }
+
+  describe '#up!' do
+    it 'works in sequence' do
+      expect(subject.affected_records.size).to eql(2)
+      subject.up!
+      expect(subject.affected_records.size).to eql(0)
+    end
+  end
+end

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -288,6 +288,10 @@ describe ResolverService do
       it "sets decision_type to be #{type}" do
         expect(updated_application.decision_type).to eql(type)
       end
+
+      it 'sets the decision_cost to 0' do
+        expect(updated_application.decision_cost).to eql(0)
+      end
     end
 
     context 'for EvidenceCheck' do


### PR DESCRIPTION
## Problem
When an application is finalised the resolver service is supposed to calculate a final cost to the department.  In some cases this was not completing properly.  In reports, we had applications with a decision of None (no remission, applicant pays full amount) and a decision_cost.

## Reason
When a feature was added to return part-payments and evidence checks, a new outcome type of `return` was created, this was not checked for in the resolver cost calculator

## Fix 
Check for `none` and `return` in the calculator and set the return value to 0 for both.  Update the test scenarios and add a migration script to change the, currently wrong, entries in the DB.
