### PR TITLE
Online business entities fix

### DIFF
--- a/app/services/business_entity_generator.rb
+++ b/app/services/business_entity_generator.rb
@@ -1,0 +1,16 @@
+class BusinessEntityGenerator
+  def initialize(application)
+    @application = application
+  end
+
+  def attributes
+    { business_entity: business_entity }
+  end
+
+  private
+
+  def business_entity
+    @business_entity ||=
+      BusinessEntity.current_for(@application.office, @application.detail.jurisdiction)
+  end
+end

--- a/app/services/reference_generator.rb
+++ b/app/services/reference_generator.rb
@@ -4,10 +4,7 @@ class ReferenceGenerator
   end
 
   def attributes
-    {
-      business_entity: business_entity,
-      reference: reference
-    }
+    { reference: reference }
   end
 
   private

--- a/app/services/resolver_service.rb
+++ b/app/services/resolver_service.rb
@@ -41,6 +41,7 @@ class ResolverService
 
   def completed_application_attributes
     completed_attributes.tap do |attrs|
+      attrs.merge! BusinessEntityGenerator.new(@calling_object).attributes
       if @calling_object.reference.blank?
         generator = ReferenceGenerator.new(@calling_object)
         attrs.merge!(generator.attributes)

--- a/db/migrate/20160819130824_add_missing_business_entities.rb
+++ b/db/migrate/20160819130824_add_missing_business_entities.rb
@@ -1,0 +1,5 @@
+class AddMissingBusinessEntities < ActiveRecord::Migration
+  def up
+    UpdateMissingBusinessEntities.up!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818114238) do
+ActiveRecord::Schema.define(version: 20160819130824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/update_missing_business_entities.rb
+++ b/lib/update_missing_business_entities.rb
@@ -1,0 +1,19 @@
+class UpdateMissingBusinessEntities
+
+  def self.affected_records
+    Application.
+      joins(:detail).
+      where(business_entity_id: nil).
+      where.not(
+        reference: nil,
+        office_id: nil,
+        'details.jurisdiction_id': nil
+      )
+  end
+
+  def self.up!
+    affected_records.each do |application|
+      application.update(BusinessEntityGenerator.new(application).attributes)
+    end
+  end
+end

--- a/spec/lib/update_missing_business_entities_spec.rb
+++ b/spec/lib/update_missing_business_entities_spec.rb
@@ -1,0 +1,22 @@
+require 'rspec'
+
+describe UpdateMissingBusinessEntities do
+
+  subject { described_class }
+
+  let(:business_entity) { create :business_entity }
+  let(:shared_params) { { office: business_entity.office, jurisdiction: business_entity.jurisdiction } }
+  let(:shared_params_with_business_entity) { { business_entity: business_entity, office: business_entity.office, jurisdiction: business_entity.jurisdiction } }
+  let!(:application1) { create(:application_full_remission, :processed_state, shared_params) }
+  let!(:application2) { create(:application_full_remission, :processed_state, shared_params_with_business_entity) }
+  let!(:application3) { create(:application_full_remission, :processed_state, shared_params) }
+
+  describe '#up!' do
+    it 'works in sequence' do
+      expect(subject.affected_records.size).to eql(2)
+      subject.up!
+      expect(subject.affected_records.size).to eql(0)
+    end
+  end
+
+end

--- a/spec/services/business_entity_generator_spec.rb
+++ b/spec/services/business_entity_generator_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ReferenceGenerator, type: :service do
+RSpec.describe BusinessEntityGenerator, type: :service do
   let(:current_time) { Time.zone.parse('2016-03-01 10:20:30') }
   let!(:office) { create :office }
   let!(:jurisdiction) { create :jurisdiction }
@@ -18,23 +18,8 @@ RSpec.describe ReferenceGenerator, type: :service do
     end
 
     context 'when there is no existing reference number for the same entity code' do
-      it 'returns hash with the new reference' do
-        expect(subject[:reference]).to eql('AB987-16-1')
-      end
-    end
-
-    context 'when there is an existing reference number for the same entity code' do
-      let(:existing_application1) { create :application, :processed_state, reference: 'AB987-16-18' }
-      let(:existing_application2) { create :application, :processed_state, reference: 'AB987-16-19' }
-
-      before do
-        existing_application2
-        existing_application1
-        application
-      end
-
-      it 'returns hash with the reference next in sequence' do
-        expect(subject[:reference]).to eql('AB987-16-20')
+      it 'returns hash with the relevant business entity' do
+        expect(subject[:business_entity]).to eql(business_entity)
       end
     end
 
@@ -43,7 +28,7 @@ RSpec.describe ReferenceGenerator, type: :service do
       before { business_entity.update_attribute(:valid_to, Time.zone.now) }
 
       it 'uses the active one' do
-        expect(subject[:reference]).to eql('CB975-16-1')
+        expect(subject[:business_entity]).to eql(business_entity2)
       end
     end
   end

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -74,12 +74,16 @@ describe ResolverService do
       end
     end
 
-    shared_examples 'application reference' do
+    shared_examples 'application reference and business_entity' do
       context 'when the application has reference number already' do
         let(:existing_reference) { 'SOME_REFERENCE' }
 
         it 'does not generate a new reference' do
           expect(updated_application.reference).to eql(existing_reference)
+        end
+
+        it 'stores the business entity' do
+          expect(updated_application.business_entity).to eql(business_entity)
         end
       end
 
@@ -87,17 +91,23 @@ describe ResolverService do
         it 'generates and stores the reference' do
           expect(updated_application.reference).to eql(reference)
         end
+
+        it 'stores the business entity' do
+          expect(updated_application.business_entity).to eql(business_entity)
+        end
       end
     end
 
     context 'for Application' do
       let(:reference) { 'ABC' }
       let(:business_entity) { create(:business_entity) }
-      let(:generator) { double(attributes: { reference: reference, business_entity: business_entity }) }
+      let(:be_generator) { double(attributes: { business_entity: business_entity }) }
+      let(:generator) { double(attributes: { reference: reference }) }
 
       let(:object) { application }
 
       before do
+        allow(BusinessEntityGenerator).to receive(:new).and_return(be_generator)
         allow(ReferenceGenerator).to receive(:new).and_return(generator)
         allow(PartPaymentBuilder).to receive(:new).with(application, Fixnum).and_return(part_payment_builder)
       end
@@ -115,7 +125,7 @@ describe ResolverService do
 
         include_examples 'application, evidence check or part payment completed', 'application', 'waiting_for_evidence', false
 
-        include_examples 'application reference'
+        include_examples 'application reference and business_entity'
 
         it 'stores the business entity used to generate the reference' do
           expect(updated_application.business_entity).to eql(business_entity)
@@ -127,7 +137,7 @@ describe ResolverService do
 
         include_examples 'application, evidence check or part payment completed', 'application', 'waiting_for_part_payment', false
 
-        include_examples 'application reference'
+        include_examples 'application reference and business_entity'
 
         it 'stores the business entity used to generate the reference' do
           expect(updated_application.business_entity).to eql(business_entity)
@@ -147,11 +157,7 @@ describe ResolverService do
           include_examples 'application, evidence check or part payment completed', 'application', 'processed', true, 0
         end
 
-        include_examples 'application reference'
-
-        it 'stores the business entity used to generate the reference' do
-          expect(updated_application.business_entity).to eql(business_entity)
-        end
+        include_examples 'application reference and business_entity'
       end
     end
 


### PR DESCRIPTION
## Problem
Business entities are not being created for online_applications when they are processed

## Reason
Originally, when adding a paper form, the system created a business entity and reference at the same time and, so, were encapsulated into a single service class.

Since then, we've added a different type of form (online) and, because they already have a reference generated, this meant that business entities were not being created when processing them.

## Fix
Split the service class into two and call the business entity one always and the reference one as needed.  Update the test scenarios and add a migration script to change the, currently wrong, entries in the DB.