### PR TITLE
Part payment should say paid once it has been processed

### DIFF
--- a/app/assets/stylesheets/local/panels.scss
+++ b/app/assets/stylesheets/local/panels.scss
@@ -76,7 +76,7 @@
   &.not-received, &.no, &.callout-none, &.callout-error, &.callout-return {
     background-color: $error-colour;
   }
-  &.received, &.yes, &.callout-full, &.callout-granted {
+  &.received, &.yes, &.callout-full, &.callout-granted, &.callout-paid {
     background-color: $turquoise;
   }
   &.callout-part, &.callout-evidence-check {

--- a/app/models/views/application_result.rb
+++ b/app/models/views/application_result.rb
@@ -7,12 +7,12 @@ module Views
     end
 
     def result
-      %w[granted full part none return].include?(outcome) ? outcome : 'error'
+      %w[granted full part paid none return].include?(outcome) ? outcome : 'error'
     end
 
     def amount_to_pay
-      if evidence_or_application.amount_to_pay.present?
-        "£#{evidence_or_application.amount_to_pay.round}"
+      if outcome_from.amount_to_pay.present?
+        "£#{outcome_from.amount_to_pay.round}"
       end
     end
 
@@ -34,19 +34,29 @@ module Views
     private
 
     def outcome
-      case evidence_or_application
+      case outcome_from
       when EvidenceCheck
-        evidence_or_application.outcome
+        outcome_from.outcome
       when Application
-        if evidence_or_application.decision_override.present?
-          'granted'
-        else
-          evidence_or_application.outcome
-        end
+        outcome_from_application
       end
     end
 
-    def evidence_or_application
+    def outcome_from_application
+      if @application.decision_override.present?
+        'granted'
+      elsif part_payment_successful
+        'paid'
+      else
+        @application.outcome
+      end
+    end
+
+    def part_payment_successful
+      @application.part_payment && @application.part_payment.correct?
+    end
+
+    def outcome_from
       @application.evidence_check || @application
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -187,6 +187,7 @@ en-GB:
   remissions:
     full: '✓ Eligible for help with fees'
     part: The applicant must pay %{amount_to_pay} towards the fee
+    paid: The applicant has paid %{amount_to_pay} towards the fee
     none: '✗ &nbsp; Not eligible for help with fees'
     callout: Evidence of income needs to be checked
     return: '✗ &nbsp; Not eligible because %{return_type} not provided'

--- a/spec/features/processed_applications/list_processed_applications_spec.rb
+++ b/spec/features/processed_applications/list_processed_applications_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'List processed applications', type: :feature do
   let!(:application3) { create :application_part_remission }
   let!(:application4) { create :application_full_remission, :processed_state, office: user.office, decision_date: Time.zone.parse('2016-01-07') }
   let!(:application5) { create :application_part_remission, :processed_state, office: user.office, decision_date: Time.zone.parse('2016-01-06') }
+  let!(:part_payment) { create :part_payment, outcome: 'part', correct: true, application: application5 }
 
   scenario 'User lists all processed applications with pagination and in correct order' do
     visit '/'
@@ -56,5 +57,14 @@ RSpec.feature 'List processed applications', type: :feature do
 
     expect(page).to have_content('Processed application')
     expect(page).to have_content("Full name#{application1.applicant.full_name}")
+  end
+
+  scenario 'User displays detail of one processed part-payment application' do
+    visit '/processed_applications'
+    click_link 'Next page'
+    click_link application5.reference
+
+    expect(page).to have_content('Processed application')
+    expect(page).to have_content('The applicant has paid £100 towards the fee')
   end
 end

--- a/spec/models/views/application_result_spec.rb
+++ b/spec/models/views/application_result_spec.rb
@@ -83,6 +83,13 @@ RSpec.describe Views::ApplicationResult do
 
       include_examples 'result examples', 'application'
     end
+
+    context 'when the application has a completed part-payment' do
+      let(:part_payment) { build_stubbed :part_payment, outcome: 'part', correct: true }
+      let(:application) { build_stubbed :application, part_payment: part_payment, outcome: 'part' }
+
+      it { is_expected.to eq 'paid' }
+    end
   end
 
   describe '#savings' do


### PR DESCRIPTION
[Trello Ticket](https://trello.com/c/1AnbDZWm/12-part-payment-should-say-paid-once-it-is-processed)

When a part payment goes into the list of processed applications it should say "the applicant has paid..."
As a member of staff
I want to see that a part payment has been paid (currently it looks like it is still outstanding)