### PR TITLE
Expire online application pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,4 +26,10 @@ class ApplicationController < ActionController::Base
     flash[:alert] = t('unauthorized.flash')
     redirect_to(request.referrer || root_path)
   end
+
+  def set_cache_headers
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 3.hours.ago.to_formatted_s(:rfc822)
+  end
 end

--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -3,6 +3,7 @@ module Applications
   class ProcessController < ApplicationController
     before_action :authorise_application_update, except: :create
     before_action :check_completed_redirect, except: [:create, :confirmation, :override]
+    before_action :set_cache_headers, only: [:confirmation]
 
     def create
       application = ApplicationBuilder.new(current_user).build

--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -156,12 +156,6 @@ module Applications
       end
     end
 
-    def set_cache_headers
-      response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-      response.headers['Pragma'] = 'no-cache'
-      response.headers['Expires'] = 3.hours.ago.to_formatted_s(:rfc822)
-    end
-
     def form_params(type)
       class_name = "Forms::Application::#{type.to_s.classify}".constantize
       params.require(:application).permit(*class_name.permitted_attributes.keys)

--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -1,17 +1,16 @@
 class OnlineApplicationsController < ApplicationController
+  before_action :authorise_online_application, except: :create
   rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_homepage
 
   include SectionViewsHelper
 
   def edit
-    authorize online_application
     @form = Forms::OnlineApplication.new(online_application)
     @form.enable_default_jurisdiction(current_user)
     assign_jurisdictions
   end
 
   def update
-    authorize online_application
     @form = Forms::OnlineApplication.new(online_application)
     @form.update_attributes(update_params)
 
@@ -24,13 +23,10 @@ class OnlineApplicationsController < ApplicationController
   end
 
   def show
-    authorize online_application
     build_sections
   end
 
   def complete
-    authorize online_application
-
     application = ApplicationBuilder.new(current_user).build_from(online_application)
     process_application(application)
 
@@ -43,6 +39,10 @@ class OnlineApplicationsController < ApplicationController
     SavingsPassFailService.new(application.saving).calculate!
     ApplicationCalculation.new(application).run
     ResolverService.new(application, current_user).complete
+  end
+
+  def authorise_online_application
+    authorize online_application
   end
 
   def online_application

--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -1,5 +1,6 @@
 class OnlineApplicationsController < ApplicationController
   before_action :authorise_online_application, except: :create
+  before_action :check_completed_redirect
   rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_homepage
 
   include SectionViewsHelper
@@ -43,6 +44,20 @@ class OnlineApplicationsController < ApplicationController
 
   def authorise_online_application
     authorize online_application
+  end
+
+  def check_completed_redirect
+    set_cache_headers
+    if online_application.processed?
+      flash[:alert] = I18n.t('application_redirect.processed')
+      redirect_to application_confirmation_path(online_application.linked_application)
+    end
+  end
+
+  def set_cache_headers
+    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = 3.hours.ago.to_formatted_s(:rfc822)
   end
 
   def online_application

--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -54,12 +54,6 @@ class OnlineApplicationsController < ApplicationController
     end
   end
 
-  def set_cache_headers
-    response.headers['Cache-Control'] = 'no-cache, no-store, max-age=0, must-revalidate'
-    response.headers['Pragma'] = 'no-cache'
-    response.headers['Expires'] = 3.hours.ago.to_formatted_s(:rfc822)
-  end
-
   def online_application
     @online_application ||= OnlineApplication.find(params[:id])
   end

--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -20,4 +20,12 @@ class OnlineApplication < ActiveRecord::Base
   def detail
     self
   end
+
+  def processed?
+    linked_application.present?
+  end
+
+  def linked_application
+    Application.find_by(online_application: self)
+  end
 end

--- a/spec/controllers/online_applications_controller_spec.rb
+++ b/spec/controllers/online_applications_controller_spec.rb
@@ -196,4 +196,22 @@ RSpec.describe OnlineApplicationsController, type: :controller do
       end
     end
   end
+
+  context 'after an application is completed' do
+    let(:online_application) { create :online_application, :completed, :with_reference, convert_to_application: true }
+
+    describe 'when accessing the personal_details view' do
+      before { get :edit, id: online_application.id }
+
+      subject { response }
+
+      it { is_expected.to have_http_status(:redirect) }
+
+      it { is_expected.to redirect_to(application_confirmation_path(online_application.linked_application)) }
+
+      it 'is expected to set the flash message' do
+        expect(flash[:alert]).to eql 'This application has been processed. You can’t edit any details.'
+      end
+    end
+  end
 end

--- a/spec/models/online_application_spec.rb
+++ b/spec/models/online_application_spec.rb
@@ -44,4 +44,38 @@ RSpec.describe OnlineApplication, type: :model do
       end
     end
   end
+
+  describe '#processed?' do
+
+    subject { online_application.processed? }
+
+    context 'when an application exists that is linked to this online_application' do
+      let(:online_application) { create :online_application, :completed, :with_reference, convert_to_application: true }
+
+      it { is_expected.to eql true }
+    end
+
+    context 'when no application exists that is linked to this online_application' do
+      let(:online_application) { create :online_application, :completed, :with_reference }
+
+      it { is_expected.to eql false }
+    end
+  end
+
+  describe '#linked_application' do
+
+    subject { online_application.linked_application }
+
+    context 'when an application exists that is linked to this online_application' do
+      let(:online_application) { create :online_application, :completed, :with_reference, convert_to_application: true }
+
+      it { is_expected.to eql Application.find_by(reference: online_application.reference) }
+    end
+
+    context 'when no application exists that is linked to this online_application' do
+      let(:online_application) { create :online_application, :completed, :with_reference }
+
+      it { is_expected.to eql nil }
+    end
+  end
 end


### PR DESCRIPTION
After users have clicked through the standard flow, they (regularly) use the browser back button to return to an earlier page and then click continue... as we have cleared the session values at this point it causes 500 errors.

This PR replicates the work done on the paper application flow, to expire the headers (enforcing a page reload) and redirect if the application is complete. 