### PR TITLE
Remove HTML-safe from I18n

### DIFF
--- a/app/views/applications/partials/_full_fee.html.slim
+++ b/app/views/applications/partials/_full_fee.html.slim
@@ -1,2 +1,2 @@
 #result.callout.callout-none
-  h3.heading-large =t('remissions.none').html_safe
+  h3.heading-large =t('remissions.none_html')

--- a/app/views/applications/process/confirmation.html.slim
+++ b/app/views/applications/process/confirmation.html.slim
@@ -11,7 +11,7 @@ h4.heading-medium.util_mt-medium Reference
   = build_section 'Result', @confirm, @confirm.all_fields
 
 #result.callout class="callout-#{@confirm.result}"
-  h3.heading-large = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
+  h3.heading-large = t("remissions.#{@confirm.result}_html", amount_to_pay: "£#{@application.amount_to_pay}")
 
 =render('shared/decision_override', path: application_override_path(@application, anchor: 'override_panel'))
 

--- a/app/views/evidence_checks/show.html.slim
+++ b/app/views/evidence_checks/show.html.slim
@@ -11,7 +11,7 @@ h4.heading-medium.util_mt-medium Reference
   = build_section 'Result', @confirm, @confirm.all_fields
 
 #result.callout class="callout-#{@confirm.result}"
-  h3.heading-large = t("remissions.#{@confirm.result}", amount_to_pay: "£#{@application.amount_to_pay}").html_safe
+  h3.heading-large = t("remissions.#{@confirm.result}_html", amount_to_pay: "£#{@application.amount_to_pay}")
 
 .guidance
   h4.heading-medium =t('evidence_check.next_steps.title')

--- a/app/views/shared/_remission_type.html.slim
+++ b/app/views/shared/_remission_type.html.slim
@@ -1,2 +1,2 @@
 #result.callout class="callout-#{source.result}"
-  h3.heading-large =t("remissions.#{source.result}", amount_to_pay: source.amount_to_pay, return_type: source.return_type).html_safe
+  h3.heading-large =t("remissions.#{source.result}_html", amount_to_pay: source.amount_to_pay, return_type: source.return_type)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -191,13 +191,13 @@ en-GB:
     remove_warning_html: "%{managers} at %{office} need to unselect these jurisdictions before you can deactivate them."
     deactivate_warning: "Deactivating this jurisdiction will remove it from the list that %{office} can use. It will still be displayed for any applications processed before %{today_date}."
   remissions:
-    full: '✓ Eligible for help with fees'
-    part: The applicant must pay %{amount_to_pay} towards the fee
-    paid: The applicant has paid %{amount_to_pay} towards the fee
-    none: '✗ &nbsp; Not eligible for help with fees'
-    callout: Evidence of income needs to be checked
-    return: '✗ &nbsp; Not eligible because %{return_type} not provided'
-    granted: '✓ Granted help with fees'
+    full_html: '✓ Eligible for help with fees'
+    part_html: 'The applicant must pay %{amount_to_pay} towards the fee'
+    paid_html: 'The applicant has paid %{amount_to_pay} towards the fee'
+    none_html: '✗ &nbsp; Not eligible for help with fees'
+    callout_html: 'Evidence of income needs to be checked'
+    return_html: '✗ &nbsp; Not eligible because %{return_type} not provided'
+    granted_html: '✓ Granted help with fees'
   evidence_check:
     callout: Evidence of income needs to be checked
     page_title: Application waiting for evidence


### PR DESCRIPTION
Replace with _html names that are escaped internally

This removes a brakeman XSS warning 