### PR TITLE
Add override to income

### DIFF
--- a/app/models/forms/application/decision_override.rb
+++ b/app/models/forms/application/decision_override.rb
@@ -16,14 +16,13 @@ module Forms
       validates :reason, presence: true, length: { maximum: 500 }, if: :reason_required?
 
       def application_overridable?(application)
-        failed_benefit_application?(application)
+        failed_application?(application)
       end
 
       private
 
-      def failed_benefit_application?(application)
-        application.application_type.eql?('benefit') &&
-          application.outcome.eql?('none') &&
+      def failed_application?(application)
+        application.outcome.eql?('none') &&
           (application.decision_override.nil? || !application.decision_override.persisted?)
       end
 

--- a/spec/features/applications/confirmation_is_rendered_spec.rb
+++ b/spec/features/applications/confirmation_is_rendered_spec.rb
@@ -83,8 +83,8 @@ RSpec.feature 'Confirmation page', type: :feature do
         expect(page).to have_content '✗ Not eligible for help with fees'
       end
 
-      scenario 'the grant help with fees form is not rendered' do
-        expect(page).to have_no_content 'Grant help with fees'
+      scenario 'the grant help with fees form is rendered' do
+        expect(page).to have_content 'Grant help with fees'
       end
     end
 

--- a/spec/models/forms/application/decision_override_spec.rb
+++ b/spec/models/forms/application/decision_override_spec.rb
@@ -82,7 +82,15 @@ RSpec.describe Forms::Application::DecisionOverride do
       context 'that was income based' do
         let(:type) { 'income' }
 
-        it { is_expected.to be false }
+        context 'with no remission granted' do
+          it { is_expected.to be true }
+        end
+
+        context 'with full remission granted' do
+          let(:outcome) { 'full' }
+
+          it { is_expected.to be false }
+        end
       end
 
       context 'that was benefits based' do


### PR DESCRIPTION
[Trello ticket](https://trello.com/c/L1NWBlRK/10-include-manager-override-question-for-income-applications)

Allow users to override, and grant, applications when they fail income applications too.
Currently override is only allowed on benefit applications.
