### PR TITLE
General Refactor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   # Exclude anything that isn't really part of our code.
   # rails_helper is excluded because it's full of solecisms, but it's mostly
   # generated code and copy-and-pasted snipets from READMEs.
@@ -93,6 +93,9 @@ Style/EmptyLinesAroundBlockBody:
 
 # We have a mixture at the moment, so don't enforce anything.
 Style/FormatString:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
   Enabled: false
 
 # It's not really clearer to replace every if with a return if.

--- a/app/builders/application_builder.rb
+++ b/app/builders/application_builder.rb
@@ -52,7 +52,7 @@ class ApplicationBuilder
   def dependent_attributes(online_application)
     {}.tap do |attributes|
       if online_application.children.present?
-        attributes[:dependents] = online_application.children > 0
+        attributes[:dependents] = online_application.children.positive?
         attributes[:children] = online_application.children
       end
     end

--- a/app/builders/finance_report_builder.rb
+++ b/app/builders/finance_report_builder.rb
@@ -58,7 +58,7 @@ class FinanceReportBuilder
   def distinct_offices_jurisdictions
     BusinessEntity.
       exclude_hq_teams.
-      joins('LEFT OUTER JOIN applications ON business_entity_id = business_entities.id').
+      joins('LEFT JOIN applications ON business_entity_id = business_entities.id').
       where('decision_date BETWEEN :d1 AND :d2', d1: @date_from, d2: @date_to).
       where('applications.state = 3').uniq { |s| s.values_at(:office, :jurisdiction) }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   include Pundit
   before_action :authenticate_user!
   after_action :verify_authorized
-  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorised
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def after_invite_path_for(*)
     users_path
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def user_not_authorised
+  def user_not_authorized
     flash[:alert] = t('unauthorized.flash')
     redirect_to(request.referrer || root_path)
   end

--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -1,7 +1,7 @@
 module Applications
   # rubocop:disable ClassLength
   class ProcessController < ApplicationController
-    before_action :authorise_application_update, except: :create
+    before_action :authorize_application_update, except: :create
     before_action :check_completed_redirect, except: [:create, :confirmation, :override]
     before_action :set_cache_headers, only: [:confirmation]
 
@@ -143,7 +143,7 @@ module Applications
       form_params(:decision_override).merge(created_by_id: current_user.id)
     end
 
-    def authorise_application_update
+    def authorize_application_update
       authorize application, :update?
     end
 

--- a/app/controllers/benefit_overrides_controller.rb
+++ b/app/controllers/benefit_overrides_controller.rb
@@ -1,5 +1,5 @@
 class BenefitOverridesController < ApplicationController
-  before_action :authorise_benefit_override_create
+  before_action :authorize_benefit_override_create
 
   def paper_evidence
     @form = Forms::BenefitsEvidence.new(benefit_override)
@@ -18,7 +18,7 @@ class BenefitOverridesController < ApplicationController
 
   private
 
-  def authorise_benefit_override_create
+  def authorize_benefit_override_create
     authorize benefit_override, :create?
   end
 

--- a/app/controllers/evidence_controller.rb
+++ b/app/controllers/evidence_controller.rb
@@ -1,5 +1,5 @@
 class EvidenceController < ApplicationController
-  before_action :authorise_evidence_check_update, except: :show
+  before_action :authorize_evidence_check_update, except: :show
 
   include SectionViewsHelper
 
@@ -78,7 +78,7 @@ class EvidenceController < ApplicationController
 
   private
 
-  def authorise_evidence_check_update
+  def authorize_evidence_check_update
     authorize evidence, :update?
   end
 

--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -1,5 +1,5 @@
 class OnlineApplicationsController < ApplicationController
-  before_action :authorise_online_application, except: :create
+  before_action :authorize_online_application, except: :create
   before_action :check_completed_redirect
   rescue_from ActiveRecord::RecordNotFound, with: :redirect_to_homepage
 
@@ -42,7 +42,7 @@ class OnlineApplicationsController < ApplicationController
     ResolverService.new(application, current_user).complete
   end
 
-  def authorise_online_application
+  def authorize_online_application
     authorize online_application
   end
 

--- a/app/controllers/part_payments_controller.rb
+++ b/app/controllers/part_payments_controller.rb
@@ -1,5 +1,5 @@
 class PartPaymentsController < ApplicationController
-  before_action :authorise_part_payment_update, except: :show
+  before_action :authorize_part_payment_update, except: :show
 
   include SectionViewsHelper
 
@@ -64,7 +64,7 @@ class PartPaymentsController < ApplicationController
     part_payment.application
   end
 
-  def authorise_part_payment_update
+  def authorize_part_payment_update
     authorize part_payment, :update?
   end
 

--- a/app/controllers/processed_applications_controller.rb
+++ b/app/controllers/processed_applications_controller.rb
@@ -17,7 +17,7 @@ class ProcessedApplicationsController < ApplicationController
   end
 
   def update
-    # TODO: The authorisation should be done after the attributes have been updated
+    # TODO: The authorization should be done after the attributes have been updated
     authorize application
 
     @form = Forms::Application::Delete.new(application)

--- a/app/controllers/processed_applications_controller.rb
+++ b/app/controllers/processed_applications_controller.rb
@@ -17,11 +17,9 @@ class ProcessedApplicationsController < ApplicationController
   end
 
   def update
-    # TODO: The authorization should be done after the attributes have been updated
-    authorize application
-
     @form = Forms::Application::Delete.new(application)
     @form.update_attributes(delete_params)
+    authorize application
     save_and_respond_on_update
   end
 

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -14,7 +14,7 @@ module Users
     end
 
     def create
-      authorize user_for_authorisation
+      authorize user_for_authorization
       if @user.deleted?
         flash[:alert] = t('devise.invitations.user_exists', email: Settings.mail.tech_support)
         render :new
@@ -38,7 +38,7 @@ module Users
       params.require(:user).permit(:email, :role, :name, :office_id)
     end
 
-    def user_for_authorisation
+    def user_for_authorization
       @user ||= deleted_user_exists? || User.new(invite_params)
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,7 +24,7 @@ class UsersController < ApplicationController
   end
 
   def update
-    authorise_and_assign_update
+    authorize_and_assign_update
 
     update_successful = user.save
     if update_successful && manager_setup.in_progress?
@@ -103,8 +103,8 @@ class UsersController < ApplicationController
     @manager_setup ||= ManagerSetup.new(current_user, session)
   end
 
-  def authorise_and_assign_update
-    # this double authorisation is unusual, but I didn't find a better solution for making sure
+  def authorize_and_assign_update
+    # this double authorization is unusual, but I didn't find a better solution for making sure
     # that managers can't edit users from other offices, because they can transfer users to
     # other offices by this update
     authorize user, :edit?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -96,7 +96,7 @@ class UsersController < ApplicationController
   end
 
   def redirect_after_restore
-    User.only_deleted.count > 0 ? deleted_users_path : users_path
+    User.only_deleted.count.positive? ? deleted_users_path : users_path
   end
 
   def manager_setup

--- a/app/lib/income_calculation.rb
+++ b/app/lib/income_calculation.rb
@@ -89,7 +89,8 @@ class IncomeCalculation
   end
 
   def applicants_contribution_is_partial
-    applicants_maximum_contribution > 0 && applicants_maximum_contribution < @application.detail.fee
+    applicants_maximum_contribution.positive? &&
+      applicants_maximum_contribution < @application.detail.fee
   end
 
   def minimum_payable_to_applicant

--- a/app/models/benefit_check.rb
+++ b/app/models/benefit_check.rb
@@ -9,7 +9,7 @@ class BenefitCheck < ActiveRecord::Base
   }
 
   scope :non_digital, lambda {
-    joins(:application).joins('LEFT OUTER JOIN offices ON applications.office_id = offices.id').
+    joins(:application).joins('LEFT JOIN offices ON applications.office_id = offices.id').
       where('offices.name != ?', 'Digital')
   }
 

--- a/app/models/forms/application/applicant.rb
+++ b/app/models/forms/application/applicant.rb
@@ -39,9 +39,9 @@ module Forms
       private
 
       def strip_whitespace!
-        title.strip! if title
-        first_name.strip! if first_name
-        last_name.strip! if last_name
+        title&.strip!
+        first_name&.strip!
+        last_name&.strip!
       end
 
       def dob_age_valid?

--- a/app/models/forms/application/decision_override.rb
+++ b/app/models/forms/application/decision_override.rb
@@ -48,7 +48,7 @@ module Forms
       end
 
       def can_load_text_from_locale?
-        self[:value].present? && self[:value].to_i > 0
+        self[:value].present? && self[:value].to_i.positive?
       end
     end
   end

--- a/app/models/forms/application/income.rb
+++ b/app/models/forms/application/income.rb
@@ -27,7 +27,7 @@ module Forms
       end
 
       def children_declared_but_dependents_arent?
-        !dependents && children.to_i > 0
+        !dependents && children.to_i.positive?
       end
 
       def persist!

--- a/app/models/views/office_business_entity_state.rb
+++ b/app/models/views/office_business_entity_state.rb
@@ -16,15 +16,15 @@ module Views
     end
 
     def business_entity_id
-      @business_entity.id if @business_entity
+      @business_entity&.id
     end
 
     def business_entity_code
-      @business_entity.code if @business_entity
+      @business_entity&.code
     end
 
     def business_entity_name
-      @business_entity.name if @business_entity
+      @business_entity&.name
     end
 
     def status

--- a/app/models/views/overview/applicant.rb
+++ b/app/models/views/overview/applicant.rb
@@ -13,7 +13,7 @@ module Views
       end
 
       def ni_number
-        applicant.ni_number.gsub(/(.{2})/, '\1 ') unless applicant.ni_number.nil?
+        applicant.ni_number&.gsub(/(.{2})/, '\1 ')
       end
 
       def status
@@ -32,7 +32,7 @@ module Views
       end
 
       def format_date(date)
-        date.to_s(:gov_uk_long) if date
+        date&.to_s(:gov_uk_long)
       end
     end
   end

--- a/app/models/views/processed_data.rb
+++ b/app/models/views/processed_data.rb
@@ -79,11 +79,11 @@ module Views
     end
 
     def prepare_name(user)
-      user.name if user
+      user&.name
     end
 
     def prepare_date(date)
-      date.strftime(Date::DATE_FORMATS[:gov_uk_long]) if date
+      date&.strftime(Date::DATE_FORMATS[:gov_uk_long])
     end
 
     def prepare_override_reason(object)

--- a/app/models/views/reports/raw_data_export.rb
+++ b/app/models/views/reports/raw_data_export.rb
@@ -78,9 +78,9 @@ module Views
 
       def joins
         <<-JOINS
-          LEFT OUTER JOIN offices ON offices.id = applications.office_id
-          LEFT OUTER JOIN decision_overrides de ON de.application_id = applications.id
-          LEFT OUTER JOIN evidence_checks ec ON ec.application_id = applications.id
+          LEFT JOIN offices ON offices.id = applications.office_id
+          LEFT JOIN decision_overrides de ON de.application_id = applications.id
+          LEFT JOIN evidence_checks ec ON ec.application_id = applications.id
         JOINS
       end
     end

--- a/app/models/views/reports/raw_data_export.rb
+++ b/app/models/views/reports/raw_data_export.rb
@@ -65,7 +65,7 @@ module Views
       end
 
       def named_columns
-        <<-COLUMNS
+        <<~COLUMNS
           offices.name AS name,
           details.emergency_reason IS NOT NULL AS emergency,
           jurisdictions.name AS jurisdiction,
@@ -77,7 +77,7 @@ module Views
       end
 
       def joins
-        <<-JOINS
+        <<~JOINS
           LEFT JOIN offices ON offices.id = applications.office_id
           LEFT JOIN decision_overrides de ON de.application_id = applications.id
           LEFT JOIN evidence_checks ec ON ec.application_id = applications.id

--- a/lib/tasks/jurisdictions.rake
+++ b/lib/tasks/jurisdictions.rake
@@ -27,7 +27,7 @@ namespace :jurisdictions do
     end
 
     jurisdiction = Jurisdiction.where(name: 'Court of Protection').first
-    jurisdiction.destroy unless jurisdiction.nil?
+    jurisdiction&.destroy
   end
 
   desc 'revert back the old jurisdiction names'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ApplicationController, type: :controller do
     sign_in user
   end
 
-  describe 'when action is not authorised' do
+  describe 'when action is not authorized' do
     controller do
       def index
         raise Pundit::NotAuthorizedError

--- a/spec/controllers/offices_controller_spec.rb
+++ b/spec/controllers/offices_controller_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe OfficesController, type: :controller do
     sign_in(user)
   end
 
-  def mock_authorise(record, authorised)
+  def mock_authorize(record, authorized)
     expectation = receive(:authorize).with(record)
-    expectation.and_raise(Pundit::NotAuthorizedError) unless authorised
+    expectation.and_raise(Pundit::NotAuthorizedError) unless authorized
 
     expect(controller).to expectation
-    expect(controller).to receive(:verify_authorized) if authorised
+    expect(controller).to receive(:verify_authorized) if authorized
   end
 
-  shared_examples 'when not authorised' do
-    context 'when not authorised' do
-      let(:authorised) { false }
+  shared_examples 'when not authorized' do
+    context 'when not authorized' do
+      let(:authorized) { false }
 
       it 'raises Pundit error' do
         expect { subject }.to raise_error(Pundit::NotAuthorizedError)
@@ -32,13 +32,13 @@ RSpec.describe OfficesController, type: :controller do
 
   describe 'GET #index' do
     before do
-      mock_authorise(:office, authorised)
+      mock_authorize(:office, authorized)
     end
 
     subject { get :index }
 
-    context 'when authorised' do
-      let(:authorised) { true }
+    context 'when authorized' do
+      let(:authorized) { true }
 
       before { subject }
 
@@ -51,18 +51,18 @@ RSpec.describe OfficesController, type: :controller do
       end
     end
 
-    include_examples 'when not authorised'
+    include_examples 'when not authorized'
   end
 
   describe 'GET #show' do
     before do
-      mock_authorise(office, authorised)
+      mock_authorize(office, authorized)
     end
 
     subject { get :show, id: office.id }
 
-    context 'when authorised' do
-      let(:authorised) { true }
+    context 'when authorized' do
+      let(:authorized) { true }
 
       before { subject }
 
@@ -75,18 +75,18 @@ RSpec.describe OfficesController, type: :controller do
       end
     end
 
-    include_examples 'when not authorised'
+    include_examples 'when not authorized'
   end
 
   describe 'GET #new' do
     before do
-      mock_authorise(Office, authorised)
+      mock_authorize(Office, authorized)
     end
 
     subject { get :new }
 
-    context 'when authorised' do
-      let(:authorised) { true }
+    context 'when authorized' do
+      let(:authorized) { true }
 
       before { subject }
 
@@ -99,20 +99,20 @@ RSpec.describe OfficesController, type: :controller do
       end
     end
 
-    include_examples 'when not authorised'
+    include_examples 'when not authorized'
   end
 
   describe 'GET #edit' do
     let(:assigned_jurisdiction) { create :jurisdiction }
     before do
       create :business_entity, office: office, jurisdiction: assigned_jurisdiction
-      mock_authorise(office, authorised)
+      mock_authorize(office, authorized)
     end
 
     subject { get :edit, id: office.id }
 
-    context 'when authorised' do
-      let(:authorised) { true }
+    context 'when authorized' do
+      let(:authorized) { true }
 
       before { subject }
 
@@ -129,7 +129,7 @@ RSpec.describe OfficesController, type: :controller do
       end
     end
 
-    include_examples 'when not authorised'
+    include_examples 'when not authorized'
   end
 
   describe 'POST #create' do
@@ -138,13 +138,13 @@ RSpec.describe OfficesController, type: :controller do
 
     before do
       allow(Office).to receive(:new).and_return(new_office)
-      mock_authorise(new_office, authorised)
+      mock_authorize(new_office, authorized)
     end
 
     subject { post :create, office: params }
 
-    context 'when authorised' do
-      let(:authorised) { true }
+    context 'when authorized' do
+      let(:authorized) { true }
 
       before do
         allow(new_office).to receive(:errors).and_return(saved ? [] : [double, double])
@@ -182,7 +182,7 @@ RSpec.describe OfficesController, type: :controller do
       end
     end
 
-    include_examples 'when not authorised'
+    include_examples 'when not authorized'
   end
 
   describe 'PUT #update' do
@@ -191,13 +191,13 @@ RSpec.describe OfficesController, type: :controller do
 
     before do
       allow(Office).to receive(:find).with(existing_office.to_param.to_s).and_return(existing_office)
-      mock_authorise(existing_office, authorised)
+      mock_authorize(existing_office, authorized)
     end
 
     subject { put :update, id: existing_office.id, office: params }
 
-    context 'when authorised' do
-      let(:authorised) { true }
+    context 'when authorized' do
+      let(:authorized) { true }
       let(:manager_setup) { double(setup_profile?: false, in_progress?: false) }
 
       before do
@@ -251,6 +251,6 @@ RSpec.describe OfficesController, type: :controller do
       end
     end
 
-    include_examples 'when not authorised'
+    include_examples 'when not authorized'
   end
 end


### PR DESCRIPTION
* Update rubocop to 2.3 parser
  * we updated to ruby 2.3 _**5**_ months ago!
  * turned off the Style/FrozenStringLiteralComment as it errored on every single page and is due to be implemented in ruby 3
  * made code-climate happy

* Removed OUTER from the LEFT JOINS
* Updated the recent SQL refactor to use the new, indenting, HEREDOC format

