### PR TITLE
Report fix for none rows

### DIFF
--- a/app/builders/finance_report_builder.rb
+++ b/app/builders/finance_report_builder.rb
@@ -7,12 +7,17 @@ class FinanceReportBuilder
     'full remission quantity', 'full remission amount',
     'part remission quantity', 'part remission amount',
     'benefit basis quantity', 'benefit basis amount',
-    'income basis quantity', 'income basis amount'
+    'income basis quantity', 'income basis amount',
+    'granted basis quantity', 'granted basis amount'
   ].freeze
 
-  ATTRIBUTES = %w[office jurisdiction be_code total_count total_sum
-                  full_count full_sum part_count part_sum
-                  benefit_count benefit_sum income_count income_sum].freeze
+  ATTRIBUTES = %w[office jurisdiction be_code
+                  total_count total_sum
+                  full_count full_sum
+                  part_count part_sum
+                  benefit_count benefit_sum
+                  income_count income_sum
+                  none_count none_sum].freeze
 
   def initialize(start_date, end_date)
     @date_from = DateTime.parse(start_date.to_s).utc

--- a/app/builders/finance_report_builder.rb
+++ b/app/builders/finance_report_builder.rb
@@ -1,23 +1,23 @@
 class FinanceReportBuilder
   require 'csv'
 
-  HEADERS = [
-    'office', 'jurisdiction', 'BEC',
-    'Total successful quantity', 'Total successful amount',
-    'full remission quantity', 'full remission amount',
-    'part remission quantity', 'part remission amount',
-    'benefit basis quantity', 'benefit basis amount',
-    'income basis quantity', 'income basis amount',
-    'granted basis quantity', 'granted basis amount'
-  ].freeze
-
-  ATTRIBUTES = %w[office jurisdiction be_code
-                  total_count total_sum
-                  full_count full_sum
-                  part_count part_sum
-                  benefit_count benefit_sum
-                  income_count income_sum
-                  none_count none_sum].freeze
+  FIELDS = {
+    office: 'office',
+    jurisdiction: 'jurisdiction',
+    be_code: 'BEC',
+    total_count: 'Total successful quantity',
+    total_sum: 'Total successful amount',
+    full_count: 'full remission quantity',
+    full_sum: 'full remission amount',
+    part_count: 'part remission quantity',
+    part_sum: 'part remission amount',
+    benefit_count: 'benefit basis quantity',
+    benefit_sum: 'benefit basis amount',
+    income_count: 'income basis quantity',
+    income_sum: 'income basis amount',
+    none_count: 'granted basis quantity',
+    none_sum: 'granted basis amount'
+  }.freeze
 
   def initialize(start_date, end_date)
     @date_from = DateTime.parse(start_date.to_s).utc
@@ -31,10 +31,10 @@ class FinanceReportBuilder
       end
 
       csv << ['']
-      csv << HEADERS
+      csv << FIELDS.values
 
       generate.each do |row|
-        csv << ATTRIBUTES.map { |attr| row.send(attr) }
+        csv << FIELDS.keys.map { |attr| row.send(attr) }
       end
     end
   end

--- a/app/models/views/reports/finance_report_data_row.rb
+++ b/app/models/views/reports/finance_report_data_row.rb
@@ -15,6 +15,8 @@ module Views
       attr_accessor :benefit_sum
       attr_accessor :income_count
       attr_accessor :income_sum
+      attr_accessor :none_count
+      attr_accessor :none_sum
 
       def initialize(business_entity, date_from, date_to)
         @business_entity = business_entity

--- a/spec/models/views/reports/finance_report_data_row_spec.rb
+++ b/spec/models/views/reports/finance_report_data_row_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe Views::Reports::FinanceReportDataRow do
     it { is_expected.to respond_to :benefit_sum }
     it { is_expected.to respond_to :income_count }
     it { is_expected.to respond_to :income_sum }
+    it { is_expected.to respond_to :none_count }
+    it { is_expected.to respond_to :none_sum }
   end
 
   describe 'when initialised with valid data' do
@@ -63,7 +65,9 @@ RSpec.describe Views::Reports::FinanceReportDataRow do
       :benefit_count,
       :benefit_sum,
       :income_count,
-      :income_sum
+      :income_sum,
+      :none_count,
+      :none_sum
     ].each do |attr|
       describe "sets the #{attr}" do
         subject { data.send(attr) }
@@ -75,10 +79,13 @@ RSpec.describe Views::Reports::FinanceReportDataRow do
 
   describe 'data returned should only include proccesed applications' do
     let(:wrong_business_entity) { create :business_entity }
+    let(:failed_application) { create :application_no_remission, :processed_state, decision: 'full', decision_type: 'override', application_type: 'none', business_entity: business_entity, office: business_entity.office, decision_date: Time.zone.now }
     before do
       # include these
-      create_list :application_full_remission, 8, :processed_state, business_entity: business_entity, office: business_entity.office, decision_date: Time.zone.now
+      create_list :application_full_remission, 7, :processed_state, business_entity: business_entity, office: business_entity.office, decision_date: Time.zone.now
       create :application_part_remission, :processed_state, business_entity: business_entity, office: business_entity.office, decision_date: Time.zone.now
+      create :decision_override, application: failed_application
+
       # and exclude the following
       create :application_no_remission, :processed_state, business_entity: business_entity, office: business_entity.office, decision_date: Time.zone.now
       create :application_full_remission, :processed_state, business_entity: business_entity, office: business_entity.office, decision_date: Time.zone.now - 2.months


### PR DESCRIPTION
The monthly finance report was failing because a new, unexpected, data type was being returned.

This now shows applications that failed benefit and income as `granted`