### PR TITLE
Set decision_cost when granting application

### DIFF
--- a/app/services/override_decision_service.rb
+++ b/app/services/override_decision_service.rb
@@ -16,7 +16,8 @@ class OverrideDecisionService
   def update_application
     @application.update_attributes(
       decision: 'full',
-      decision_type: 'override'
+      decision_type: 'override',
+      decision_cost: @application.detail.fee
     )
   end
 end

--- a/db/migrate/20161207104343_complete_decision_cost.rb
+++ b/db/migrate/20161207104343_complete_decision_cost.rb
@@ -1,0 +1,5 @@
+class CompleteDecisionCost < ActiveRecord::Migration
+  def up
+    DecisionCostMigration.run!
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160819130824) do
+ActiveRecord::Schema.define(version: 20161207104343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/decision_cost_migration.rb
+++ b/lib/decision_cost_migration.rb
@@ -1,0 +1,11 @@
+class DecisionCostMigration
+  def self.affected_records
+    Application.where(decision_type: 'override', decision_cost: 0)
+  end
+
+  def self.run!
+    affected_records.each do |application|
+      application.update(decision_cost: application.detail.fee)
+    end
+  end
+end

--- a/spec/lib/decision_cost_migration_spec.rb
+++ b/spec/lib/decision_cost_migration_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe DecisionCostMigration do
+  subject(:migration) { described_class }
+
+  let!(:failed_application) { create :application_no_remission, :processed_state, decision: 'full', decision_cost: 0, decision_type: 'override', application_type: 'none', decision_date: Time.zone.now }
+
+  before do
+    create :decision_override, application: failed_application
+    create_list :application_full_remission, 7, :processed_state, decision_date: Time.zone.now
+  end
+
+  it 'setup creates many records' do
+    expect(Application.count).to eq 8
+  end
+
+  describe '#run!' do
+    before do
+      migration.run!
+      failed_application.reload
+    end
+
+    it 'updates the correct decision_cost' do
+      expect(failed_application.decision_cost).to eq failed_application.detail.fee
+    end
+
+    it 'leaves no records to be updated' do
+      expect(migration.affected_records.count).to eql 0
+    end
+  end
+
+  describe '.affected_records' do
+    subject { migration.affected_records.count }
+
+    it { is_expected.to eql 1 }
+  end
+end

--- a/spec/services/override_decision_service_spec.rb
+++ b/spec/services/override_decision_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe OverrideDecisionService, type: :service do
 
       it { expect(subject.decision).to eql 'full' }
       it { expect(subject.decision_type).to eql('override') }
+      it { expect(subject.decision_cost).to eql(application.detail.fee) }
 
       it 'adds a decision_override to the application' do
         expect(application.decision_override.present?).to be true


### PR DESCRIPTION
When a user manually overrides a no decision, the value was not being set
This PR ensures that the decision_cost is set on manual override and backdates the change to pre-existing granted applications