### PR TITLE
Add hmcts net emails

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,10 @@ class User < ActiveRecord::Base
 
   scope :by_office, ->(office_id) { where('office_id = ?', office_id) }
 
-  email_regex = /\A([^@\s]+)@((justice|hmcourts-service|hmcts)\.gsi|digital\.justice)\.gov\.uk\z/i
+  # rubocop:disable LineLength
+  email_regex = /\A([^@\s]+)@(((justice|hmcourts-service|hmcts)\.gsi|digital\.justice)\.gov\.uk|hmcts\.net)\z/i
+  # rubocop:enable LineLength
+
   validates :role, :name, presence: true
   validates :email, format: {
     with: email_regex,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,6 +65,11 @@ describe User, type: :model do
           expect(user).to be_valid
         end
 
+        it 'allows hmcts.net' do
+          user.email = 'test.user@hmcts.net'
+          expect(user).to be_valid
+        end
+
         context 'non white listed emails' do
           let(:invalid_email) { 'email.that.rocks@gmail.com' }
           before(:each) { user.email = invalid_email }


### PR DESCRIPTION
A new email domain has been created and is in use by the HMCTS sustaining team.

This was needed so that we could add their users.