### PR TITLE
Ensure both codes are displayed

### DIFF
--- a/app/models/views/reports/finance_report_data_row.rb
+++ b/app/models/views/reports/finance_report_data_row.rb
@@ -21,7 +21,8 @@ module Views
 
       def initialize(business_entity, date_from, date_to)
         @business_entity = business_entity
-        @be_code = business_entity.code
+        @be_code = business_entity.be_code
+        @sop_code = business_entity.sop_code
         @office = business_entity.office.name
         @jurisdiction = business_entity.jurisdiction.name
         @date_from = date_from

--- a/spec/models/jurisdiction_spec.rb
+++ b/spec/models/jurisdiction_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Jurisdiction, type: :model do
     end
 
     context 'if a business entity is removed' do
-      before { office.business_entities.first.update_attributes(valid_to: Time.zone.now) }
+      before { office.business_entities.first.update_attributes(valid_to: Time.zone.now + 1.day) }
 
       it 'no longer returns it as available' do
         is_expected.to match_array []

--- a/spec/models/office_spec.rb
+++ b/spec/models/office_spec.rb
@@ -51,8 +51,7 @@ RSpec.describe Office, type: :model do
     end
 
     context 'after "deleting" one' do
-      let(:business_entities) { BusinessEntity.where(office_id: office.id) }
-      before { business_entities.first.update_attributes(valid_to: Time.zone.now) }
+      before { office.business_entities.first.update_attributes(valid_to: Time.zone.now + 1.day) }
 
       it { is_expected.to eq 1 }
     end

--- a/spec/models/views/reports/finance_report_data_row_spec.rb
+++ b/spec/models/views/reports/finance_report_data_row_spec.rb
@@ -43,7 +43,13 @@ RSpec.describe Views::Reports::FinanceReportDataRow do
     describe 'sets the business entity code' do
       subject { data.be_code }
 
-      it { is_expected.to eq business_entity.code }
+      it { is_expected.to eq business_entity.be_code }
+    end
+
+    describe 'sets the SOP code' do
+      subject { data.sop_code }
+
+      it { is_expected.to eq business_entity.sop_code }
     end
 
     describe 'sets total_count' do


### PR DESCRIPTION
When the finance report is generated only the SOP code was shown, now the legacy BE codes are displayed too.

Fixed a couple of validation, race conditions too