### PR TITLE
Bugfix/rst 97 reference duplication

### DIFF
--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -114,6 +114,11 @@ module Applications
     def summary_save
       ResolverService.new(application, current_user).complete
       redirect_to application_confirmation_path(application.id)
+    rescue ActiveRecord::RecordInvalid => ex
+      flash[:alert] = I18n.t('error_messages.summary.validation')
+      Raven.capture_exception(ex, application_id: application.id)
+
+      redirect_to :back
     end
 
     def confirmation

--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -116,9 +116,9 @@ module Applications
       redirect_to application_confirmation_path(application.id)
     rescue ActiveRecord::RecordInvalid => ex
       flash[:alert] = I18n.t('error_messages.summary.validation')
-      Raven.capture_exception(ex, application_id: application.id)
+      Raven.capture_exception(ex, application_id: @application.id)
 
-      redirect_to application_summary_path(application)
+      redirect_to application_summary_path(@application)
     end
 
     def confirmation

--- a/app/controllers/applications/process_controller.rb
+++ b/app/controllers/applications/process_controller.rb
@@ -118,7 +118,7 @@ module Applications
       flash[:alert] = I18n.t('error_messages.summary.validation')
       Raven.capture_exception(ex, application_id: application.id)
 
-      redirect_to :back
+      redirect_to application_summary_path(application)
     end
 
     def confirmation

--- a/app/services/reference_generator.rb
+++ b/app/services/reference_generator.rb
@@ -25,9 +25,11 @@ class ReferenceGenerator
   end
 
   def last_reference
-    Application.
-      select("max(cast(replace(reference,'#{reference_prefix}','') as integer)) AS sequence").
-      where('reference LIKE ?', "#{reference_prefix}%").
-      take
+    Application.uncached do
+      Application.
+        select("max(cast(replace(reference,'#{reference_prefix}','') as integer)) AS sequence").
+        where('reference LIKE ?', "#{reference_prefix}%").
+        take
+    end
   end
 end

--- a/app/services/resolver_service.rb
+++ b/app/services/resolver_service.rb
@@ -74,7 +74,7 @@ class ResolverService
       end
     end
 
-    application.update(attributes)
+    application.update!(attributes)
   end
 
   def complete_evidence_check(evidence_check)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,8 @@ en-GB:
       none_in_office: 'Ask your manager to assign jurisdictions to your office.'
     part_payment:
       cannot_be_saved: 'This return could not be processed'
+    summary:
+      validation: 'There was an issue creating the new record. Please click "Complete processing" again to retry. If the problem still occurs please email helpwithfees.support@digital.justice.gov.uk'
   index:
     process:
       paper:

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -444,7 +444,7 @@ RSpec.describe Applications::ProcessController, type: :controller do
     let(:application) { create :application_full_remission, office: user.office }
     let(:resolver) { instance_double(ResolverService, complete: nil) }
 
-    context 'sucess' do
+    context 'success' do
       before do
         allow(ResolverService).to receive(:new).with(application, user).and_return(resolver)
 
@@ -471,7 +471,6 @@ RSpec.describe Applications::ProcessController, type: :controller do
       let(:exception) { ActiveRecord::RecordInvalid.new(application) }
 
       before do
-        request.env["HTTP_REFERER"] = root_url
         allow(ResolverService).to receive(:new).and_raise(exception)
       end
 
@@ -485,7 +484,7 @@ RSpec.describe Applications::ProcessController, type: :controller do
       it 'catch exception and return error' do
         post_summary_save
         expect(flash[:alert]).to include('There was an issue creating the new record')
-        expect(response).to redirect_to(root_url)
+        expect(response).to redirect_to(application_summary_path(application))
       end
 
       it 'catch exception and notify sentry' do

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -484,11 +484,15 @@ RSpec.describe Applications::ProcessController, type: :controller do
       it 'catch exception and return error' do
         post_summary_save
         expect(flash[:alert]).to include('There was an issue creating the new record')
+      end
+
+      it 'redirect to previous page' do
+        post_summary_save
         expect(response).to redirect_to(application_summary_path(application))
       end
 
       it 'catch exception and notify sentry' do
-        expect(Raven).to receive(:capture_exception).with(exception, application_id: application.id)
+        expect(Raven).to have_received(:capture_exception).with(exception, application_id: application.id)
         post_summary_save
       end
     end

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe Applications::ProcessController, type: :controller do
       end
 
       it 'catch exception and notify sentry' do
-        expect(Raven).to have_received(:capture_exception).with(exception, application_id: application.id)
+        allow(Raven).to receive(:capture_exception).with(exception, application_id: application.id)
         post_summary_save
       end
     end

--- a/spec/controllers/applications/process_controller_spec.rb
+++ b/spec/controllers/applications/process_controller_spec.rb
@@ -444,25 +444,54 @@ RSpec.describe Applications::ProcessController, type: :controller do
     let(:application) { create :application_full_remission, office: user.office }
     let(:resolver) { instance_double(ResolverService, complete: nil) }
 
-    before do
-      allow(ResolverService).to receive(:new).with(application, user).and_return(resolver)
+    context 'sucess' do
+      before do
+        allow(ResolverService).to receive(:new).with(application, user).and_return(resolver)
 
-      Timecop.freeze(current_time) do
-        sign_in user
-        post :summary_save, application_id: application.id
+        Timecop.freeze(current_time) do
+          sign_in user
+          post :summary_save, application_id: application.id
+        end
+      end
+
+      it 'returns the correct status code' do
+        expect(response).to have_http_status(302)
+      end
+
+      it 'redirects to the confirmation page' do
+        expect(response).to redirect_to(application_confirmation_path(application.id))
+      end
+
+      it 'completes the application using the ResolverService' do
+        expect(resolver).to have_received(:complete)
       end
     end
 
-    it 'returns the correct status code' do
-      expect(response).to have_http_status(302)
-    end
+    context 'exception' do
+      let(:exception) { ActiveRecord::RecordInvalid.new(application) }
 
-    it 'redirects to the confirmation page' do
-      expect(response).to redirect_to(application_confirmation_path(application.id))
-    end
+      before do
+        request.env["HTTP_REFERER"] = root_url
+        allow(ResolverService).to receive(:new).and_raise(exception)
+      end
 
-    it 'completes the application using the ResolverService' do
-      expect(resolver).to have_received(:complete)
+      def post_summary_save
+        Timecop.freeze(current_time) do
+          sign_in user
+          post :summary_save, application_id: application.id
+        end
+      end
+
+      it 'catch exception and return error' do
+        post_summary_save
+        expect(flash[:alert]).to include('There was an issue creating the new record')
+        expect(response).to redirect_to(root_url)
+      end
+
+      it 'catch exception and notify sentry' do
+        expect(Raven).to receive(:capture_exception).with(exception, application_id: application.id)
+        post_summary_save
+      end
     end
   end
 

--- a/spec/services/reference_generator_spec.rb
+++ b/spec/services/reference_generator_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe ReferenceGenerator, type: :service do
         it 'returns hash with the reference next in sequence' do
           expect(attributes[:reference]).to eql('PA16-000020')
         end
+
+        context 'no sql caching for this' do
+          before {
+            # TODO turn caching on.
+          }
+
+          it 'returns hash with the reference next in sequence' do
+            Timecop.freeze(current_time) do
+              expect(generator.attributes[:reference]).to eql('PA16-000020')
+              existing_application2.update(reference: 'PA16-000020')
+              expect(generator.attributes[:reference]).to eql('PA16-000021')
+            end
+          end
+        end
       end
 
       context 'when there are two business entities for the same jurisdiction' do

--- a/spec/services/reference_generator_spec.rb
+++ b/spec/services/reference_generator_spec.rb
@@ -43,13 +43,14 @@ RSpec.describe ReferenceGenerator, type: :service do
 
         context 'no sql caching for this' do
           before {
-            # TODO turn SQL caching on if you find out how.
+            # TODO: turn SQL caching on if you find out how.
           }
 
           it 'returns hash with the reference next in sequence' do
             Timecop.freeze(current_time) do
-              expect(generator.attributes[:reference]).to eql('PA16-000020')
-              existing_application2.update(reference: 'PA16-000020')
+              if generator.attributes[:reference] == 'PA16-000020'
+                existing_application2.update(reference: 'PA16-000020')
+              end
               expect(generator.attributes[:reference]).to eql('PA16-000021')
             end
           end

--- a/spec/services/reference_generator_spec.rb
+++ b/spec/services/reference_generator_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ReferenceGenerator, type: :service do
 
         context 'no sql caching for this' do
           before {
-            # TODO turn caching on.
+            # TODO turn SQL caching on if you find out how.
           }
 
           it 'returns hash with the reference next in sequence' do

--- a/spec/services/reference_generator_spec.rb
+++ b/spec/services/reference_generator_spec.rb
@@ -42,10 +42,6 @@ RSpec.describe ReferenceGenerator, type: :service do
         end
 
         context 'no sql caching for this' do
-          before {
-            # TODO: turn SQL caching on if you find out how.
-          }
-
           it 'returns hash with the reference next in sequence' do
             Timecop.freeze(current_time) do
               if generator.attributes[:reference] == 'PA16-000020'

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -163,10 +163,10 @@ describe ResolverService do
       context 'duplicated reference' do
         let(:application_outcome) { 'full' }
         let(:reference) { 'ABC' }
-        let!(:application_old) { create(:application, reference: reference) }
+        before { create(:application, reference: reference) }
 
         it "raise an error" do
-          expect{ complete }.to raise_error(ActiveRecord::RecordInvalid)
+          expect { complete }.to raise_error(ActiveRecord::RecordInvalid)
         end
       end
 

--- a/spec/services/resolver_service_spec.rb
+++ b/spec/services/resolver_service_spec.rb
@@ -159,6 +159,17 @@ describe ResolverService do
 
         include_examples 'application reference and business_entity'
       end
+
+      context 'duplicated reference' do
+        let(:application_outcome) { 'full' }
+        let(:reference) { 'ABC' }
+        let!(:application_old) { create(:application, reference: reference) }
+
+        it "raise an error" do
+          expect{ complete }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
+
     end
 
     context 'for EvidenceCheck' do


### PR DESCRIPTION
https://triadmoj.atlassian.net/browse/RST-97
The issue was with duplicated reference numbers. SQL query was cached so it returned same results which meant that the reference number didn't change. I was unable to write a test for this that would allow SQL caching in Rspec. I also add ! to update so when there is an error next it will raise an exception. The exception is caught in a controller which is calling this method and a proper error message is displayed.