### PR TITLE
Displaying error message if password reset token is expired.

### DIFF
--- a/app/helpers/flash_message_helper.rb
+++ b/app/helpers/flash_message_helper.rb
@@ -18,4 +18,8 @@ module FlashMessageHelper
       "<a href='mailto:#{managers.map(&:email).join(';')}'>#{link_text}</a>"
     end
   end
+
+  def devise_reset_token_error?
+    resource && resource.errors.messages.key?(:reset_password_token)
+  end
 end

--- a/app/views/users/passwords/edit.html.slim
+++ b/app/views/users/passwords/edit.html.slim
@@ -1,4 +1,8 @@
 header
+  - if devise_reset_token_error?
+    .alert-box class="alert" data-alert=''
+      | #{I18n.t('activerecord.attributes.user.reset_password_token')}
+
   h2.heading-xlarge =t('devise.invitations.edit.header')
 
 = form_for(resource, as: resource_name, url: password_path(resource_name), html: { autocomplete: 'off', method: :put }) do |f|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -519,6 +519,7 @@ en-GB:
         new_password: New password
         new_password_hint: Use at least 8 numbers or letters for your password.
         password_confirmation: Confirm new password
+        reset_password_token: Your password reset link has expired. Please request a new link using the reset password function and try again.
       business_entity:
         name: BE Description
         be_code: BE Code

--- a/spec/features/password_reset_message_spec.rb
+++ b/spec/features/password_reset_message_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Password reset,', type: :feature do
+
+  let(:user) { create :user }
+
+  context 'User' do
+    scenario 'reset password token expired' do
+      visit edit_user_password_path(reset_password_token: 1)
+      fill_in :user_password, with: '123456789'
+      fill_in :user_password_confirmation, with: '123456789'
+      click_button 'Update password'
+      expect(page).to have_text("Your password reset link has expired. Please request a new link using the reset password function and try again.")
+    end
+
+    context 'valid token' do
+      let(:token) { user.send_reset_password_instructions }
+
+      scenario 'reset password' do
+        visit edit_user_password_path(reset_password_token: token)
+        fill_in :user_password, with: '123456789'
+        fill_in :user_password_confirmation, with: '123456789'
+        click_button 'Update password'
+        expect(current_path).to eql(root_path)
+        expect(page).not_to have_text("Your password reset link has expired. Please request a new link using the reset password function and try again.")
+        expect(page).to have_text("Your password has been changed successfully. You are now signed in.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Validation of password reset token is handled by Devise. 
The error is added as an AR error so we can display it as a flash message.
