### PR TITLE
Revert "Accept online applications without probate"

### DIFF
--- a/app/models/online_application.rb
+++ b/app/models/online_application.rb
@@ -3,7 +3,7 @@ class OnlineApplication < ActiveRecord::Base
 
   validates :ni_number, :date_of_birth, :first_name, :last_name, :address,
     :postcode, presence: true
-  validates :married, :min_threshold_exceeded, :benefits, :refund, :email_contact,
+  validates :married, :min_threshold_exceeded, :benefits, :refund, :probate, :email_contact,
     :phone_contact, :post_contact, :feedback_opt_in, inclusion: [true, false]
   validates :reference, uniqueness: true
 

--- a/db/migrate/20170331153241_change_probate_to_accept_null.rb
+++ b/db/migrate/20170331153241_change_probate_to_accept_null.rb
@@ -1,5 +1,0 @@
-class ChangeProbateToAcceptNull < ActiveRecord::Migration
-  def change
-    change_column_null :online_applications, :probate, true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170331153241) do
+ActiveRecord::Schema.define(version: 20170213153644) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "tablefunc"
 
   create_table "applicants", force: :cascade do |t|
     t.integer  "application_id", null: false
@@ -236,7 +237,7 @@ ActiveRecord::Schema.define(version: 20170331153241) do
     t.integer  "income"
     t.boolean  "refund",                        null: false
     t.date     "date_fee_paid"
-    t.boolean  "probate"
+    t.boolean  "probate",                       null: false
     t.string   "deceased_name"
     t.date     "date_of_death"
     t.string   "case_number"

--- a/spec/models/online_application_spec.rb
+++ b/spec/models/online_application_spec.rb
@@ -16,12 +16,11 @@ RSpec.describe OnlineApplication, type: :model do
   it { is_expected.not_to allow_value(nil).for(:min_threshold_exceeded) }
   it { is_expected.not_to allow_value(nil).for(:benefits) }
   it { is_expected.not_to allow_value(nil).for(:refund) }
+  it { is_expected.not_to allow_value(nil).for(:probate) }
   it { is_expected.not_to allow_value(nil).for(:email_contact) }
   it { is_expected.not_to allow_value(nil).for(:phone_contact) }
   it { is_expected.not_to allow_value(nil).for(:post_contact) }
   it { is_expected.not_to allow_value(nil).for(:feedback_opt_in) }
-
-  it { is_expected.to allow_value(nil).for(:probate) }
 
   it { is_expected.to validate_uniqueness_of(:reference) }
 


### PR DESCRIPTION
Announcement made in the media that changes to probate fees will be scrapped due to the general election (http://www.bbc.co.uk/news/uk-politics-39663204).

This means we will not get a decision on the HwF probate changes until well after the 2017 general election.