### PR TITLE
display the Edit banner link on the main menu only for admin users

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -41,6 +41,8 @@
             -if current_user.elevated?
               li= link_to 'View office', current_user.office
               li= link_to 'View staff', users_path
+            -if current_user.admin?
+              li= link_to 'Edit banner', edit_notifications_path
             li= link_to 'Sign out', destroy_user_session_path, :method => :delete
 
 

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'layouts/application', type: :view do
         before { render }
 
         it 'is hidden' do
-          expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+          expect(rendered).not_to have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
         end
       end
 
@@ -29,7 +29,7 @@ RSpec.describe 'layouts/application', type: :view do
           let(:user) { create :user }
 
           it 'is hidden' do
-            expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+            expect(rendered).not_to have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
           end
         end
 
@@ -37,7 +37,7 @@ RSpec.describe 'layouts/application', type: :view do
           let(:user) { create :manager }
 
           it 'is hidden' do
-            expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+            expect(rendered).not_to have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
           end
         end
 
@@ -45,7 +45,7 @@ RSpec.describe 'layouts/application', type: :view do
           let(:user) { create :mi }
 
           it 'is hidden' do
-            expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+            expect(rendered).not_to have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
           end
         end
       end

--- a/spec/views/layouts/application.html.slim_spec.rb
+++ b/spec/views/layouts/application.html.slim_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'layouts/application', type: :view do
+  describe 'menu' do
+    describe 'notifications link' do
+      context 'when logged out' do
+        before { render }
+
+        it 'is hidden' do
+          expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+        end
+      end
+
+      context 'when logged in' do
+        before do
+          sign_in user
+          render
+        end
+
+        describe 'as admin' do
+          let(:user) { create :admin_user }
+
+          it 'is visible' do
+            expect(rendered).to have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+          end
+        end
+
+        describe 'as user' do
+          let(:user) { create :user }
+
+          it 'is hidden' do
+            expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+          end
+        end
+
+        describe 'as manager' do
+          let(:user) { create :manager }
+
+          it 'is hidden' do
+            expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+          end
+        end
+
+        describe 'as mi' do
+          let(:user) { create :mi }
+
+          it 'is hidden' do
+            expect(rendered).to_not have_xpath("//a[contains(@href,'#{edit_notifications_path}')]")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When the notifications feature was implemented it was asked to not include any links to the edit page.

It is convenient though to have a link for the admins to use, so we decided to add one.