### PR TITLE
Bugfix/rst 594 income fail check

### DIFF
--- a/app/services/benefit_check_runner.rb
+++ b/app/services/benefit_check_runner.rb
@@ -73,11 +73,7 @@ class BenefitCheckRunner
   end
 
   def benefit_check_date
-    if detail.date_fee_paid.present?
-      detail.date_fee_paid
-    elsif detail.date_received.present?
-      detail.date_received
-    end
+    detail.date_received || detail.date_fee_paid
   end
 
   def build_hash

--- a/spec/factories/details.rb
+++ b/spec/factories/details.rb
@@ -22,6 +22,7 @@ FactoryGirl.define do
     trait :out_of_time_refund do
       refund true
       date_fee_paid Time.zone.now - 3.months
+      date_received nil
     end
 
     trait :emergency do

--- a/spec/features/applications/processing_refund_application_spec.rb
+++ b/spec/features/applications/processing_refund_application_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Processing refund application with valid date received date', typ
     dwp_api_response 'Yes'
   end
 
-  it "should not fail based on invalid date" do
+  it "do not fail when valid date" do
     visit '/'
     fill_in :online_search_reference, with: online_application_1.reference
     click_button 'Look up'
@@ -56,7 +56,7 @@ RSpec.feature 'Processing refund application with valid date received date', typ
     expect(page).to have_content 'Eligible for help with fees'
   end
 
-  it "should fail based on invalid date" do
+  it "fail when invalid date" do
     visit '/'
     fill_in :online_search_reference, with: online_application_2.reference
     click_button 'Look up'

--- a/spec/features/applications/processing_refund_application_spec.rb
+++ b/spec/features/applications/processing_refund_application_spec.rb
@@ -22,21 +22,51 @@ RSpec.feature 'Processing refund application with valid date received date', typ
       jurisdiction: jurisdiction)
   end
 
+  let(:online_application_2) do
+    create(:online_application, :completed, :with_reference,
+      married: false,
+      children: 3,
+      benefits: true,
+      fee: 1550,
+      form_name: 'D11',
+      income_min_threshold_exceeded: false,
+      refund: true,
+      date_fee_paid: 5.months.ago,
+      date_received: 3.months.ago,
+      jurisdiction: jurisdiction)
+  end
+
   before do
     login_as user
     dwp_api_response 'Yes'
   end
 
-  it "should not fail based on wrong date" do
+  it "should not fail based on invalid date" do
     visit '/'
     fill_in :online_search_reference, with: online_application_1.reference
     click_button 'Look up'
+    expect(page).to have_content "Application details"
     choose jurisdiction.name
     click_button 'Next'
+    expect(page).to have_content "Check details"
     click_button 'Complete processing'
-    # save_and_open_page
+
     expect(page).to have_content 'Savings and investments✓ Passed'
     expect(page).to have_content 'Benefits✓ Passed'
     expect(page).to have_content 'Eligible for help with fees'
+  end
+
+  it "should fail based on invalid date" do
+    visit '/'
+    fill_in :online_search_reference, with: online_application_2.reference
+    click_button 'Look up'
+    expect(page).to have_content "Application details"
+    choose jurisdiction.name
+    click_button 'Next'
+    expect(page).to have_content "Check details"
+    click_button 'Complete processing'
+
+    expect(page).to have_content 'Not eligible for help with fees'
+    expect(page).to have_content 'Savings and investments✓ Passed'
   end
 end

--- a/spec/features/applications/processing_refund_application_spec.rb
+++ b/spec/features/applications/processing_refund_application_spec.rb
@@ -1,0 +1,42 @@
+# coding: utf-8
+
+require 'rails_helper'
+
+RSpec.feature 'Processing refund application with valid date received date', type: :feature do
+
+  let(:jurisdiction) { create :jurisdiction }
+  let(:office) { create :office, jurisdictions: [jurisdiction] }
+  let(:user) { create :user, office: office }
+
+  let(:online_application_1) do
+    create(:online_application, :completed, :with_reference,
+      married: false,
+      children: 3,
+      benefits: true,
+      fee: 1550,
+      form_name: 'D11',
+      income_min_threshold_exceeded: false,
+      refund: true,
+      date_fee_paid: 4.months.ago,
+      date_received: 2.months.ago,
+      jurisdiction: jurisdiction)
+  end
+
+  before do
+    login_as user
+    dwp_api_response 'Yes'
+  end
+
+  it "should not fail based on wrong date" do
+    visit '/'
+    fill_in :online_search_reference, with: online_application_1.reference
+    click_button 'Look up'
+    choose jurisdiction.name
+    click_button 'Next'
+    click_button 'Complete processing'
+    # save_and_open_page
+    expect(page).to have_content 'Savings and investments✓ Passed'
+    expect(page).to have_content 'Benefits✓ Passed'
+    expect(page).to have_content 'Eligible for help with fees'
+  end
+end

--- a/spec/services/benefit_check_runner_spec.rb
+++ b/spec/services/benefit_check_runner_spec.rb
@@ -264,7 +264,7 @@ RSpec.describe BenefitCheckRunner do
     context 'when date_received and date_fee_paid is blank' do
       let(:date_fee_paid) { '' }
       let(:date_received) { '' }
-      it { expect { subject }.to raise_error(NoMethodError)}
+      it { expect { service.benefit_check_date_valid? }.to raise_error(NoMethodError) }
     end
   end
 end


### PR DESCRIPTION
There was a bug in the code when we suppose to check the date when the application was received. But we check when the fee was paid instead, which was wrong. There is another ticket coming to cover multiple scenarios. 