### PR TITLE
Fixing state skipping bug

### DIFF
--- a/app/controllers/applications/process/summary_controller.rb
+++ b/app/controllers/applications/process/summary_controller.rb
@@ -12,13 +12,20 @@ module Applications
       end
 
       def create
-        ResolverService.new(application, current_user).complete
+        resolve_only_new_applications
         redirect_to application_confirmation_path(application.id)
       rescue ActiveRecord::RecordInvalid => ex
         flash[:alert] = I18n.t('error_messages.summary.validation')
         Raven.capture_exception(ex, application_id: @application.id)
 
         redirect_to application_summary_path(@application)
+      end
+
+      private
+
+      def resolve_only_new_applications
+        return if application.state != 'created'
+        ResolverService.new(application, current_user).complete
       end
     end
   end

--- a/spec/controllers/applications/process/summary_controller_spec.rb
+++ b/spec/controllers/applications/process/summary_controller_spec.rb
@@ -111,6 +111,40 @@ RSpec.describe Applications::Process::SummaryController, type: :controller do
         post_summary_save
       end
     end
+
+    describe 'only new aplications are processed' do
+      before do
+        sign_in user
+        allow(ResolverService).to receive(:new)
+      end
+
+      context 'waiting_for_evidence_state' do
+        let(:application) { build_stubbed(:application, :waiting_for_evidence_state, office: user.office) }
+
+        it do
+          post :create, application_id: application.id
+          expect(ResolverService).not_to have_received(:new).with(application, user)
+        end
+      end
+
+      context 'waiting_for_part_payment_state' do
+        let(:application) { build_stubbed(:application, :waiting_for_part_payment_state, office: user.office) }
+
+        it do
+          post :create, application_id: application.id
+          expect(ResolverService).not_to have_received(:new).with(application, user)
+        end
+      end
+
+      context 'processed_state' do
+        let(:application) { build_stubbed(:application, :waiting_for_part_payment_state, office: user.office) }
+
+        it do
+          post :create, application_id: application.id
+          expect(ResolverService).not_to have_received(:new).with(application, user)
+        end
+      end
+    end
   end
 
 end


### PR DESCRIPTION
When you manage to re-submit the new application and the applicaiton is in other state then new the resolver will automaticly moves it to next state which in our case was skipping "waiting for payment" state.