### PR TITLE
Adding more test 987 985

### DIFF
--- a/spec/features/no_evidence_check/rst_1111_spec.rb
+++ b/spec/features/no_evidence_check/rst_1111_spec.rb
@@ -1,0 +1,135 @@
+require 'rails_helper'
+
+RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
+
+  include Warden::Test::Helpers
+  Warden.test_mode!
+
+  let(:user) { create :user }
+  let(:dwp_result) { nil }
+  let(:dwp_status) { 200 }
+
+  before do
+    login_as user
+    dwp_api_response(dwp_result, dwp_status)
+  end
+
+  context 'DWP outcome is Undetermined' do
+    let(:dwp_result) { 'undetermined' }
+    let(:application) { create :application_full_remission }
+
+    before do
+      create_list :application_full_remission, 9
+    end
+
+    scenario 'Benefit application skipped from ev check when dwp is undertermined' do
+      start_new_application
+
+      fill_personal_details
+      fill_application_details
+      fill_saving_and_investment
+      fill_benefits(true)
+      fill_benefit_evidence(paper_provided: true)
+
+      click_button 'Complete processing'
+
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✗   Not eligible for help with fees')
+    end
+  end
+
+  context 'DWP outcome is pass' do
+    let(:dwp_result) { 'yes' }
+    let(:application) { create :application_full_remission }
+
+    before do
+      create_list :application_full_remission, 9
+    end
+
+    scenario 'Benefit application skipped from ev check when dwp is pass' do
+      start_new_application
+
+      fill_personal_details
+      fill_application_details
+      fill_saving_and_investment
+      fill_benefits(true)
+      fill_benefit_evidence(paper_provided: false)
+
+      click_button 'Complete processing'
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✗   Not eligible for help with fees')
+    end
+  end
+
+  context 'DWP Outcome is pass and paper evidence is true' do
+    let(:dwp_result) { 'yes' }
+    let(:application) { create :application_full_remission, :refund }
+
+    before do
+      create_list :application_full_remission, 1, :refund
+    end
+
+    scenario 'Benefit application skipped from ev check when dwp is pass and paper evidence confirmed' do
+      start_new_application
+
+      fill_personal_details
+      fill_application_refund_details
+      fill_saving_and_investment
+      fill_benefits(true)
+      fill_benefit_evidence(paper_provided: true)
+
+      click_button 'Complete processing'
+
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✓ Eligible for help with fees')
+    end
+  end
+
+  context 'DWP Outcome is ECONNREFUSED' do
+    let(:dwp_result) { 'no' }
+    let(:application) { create :application_full_remission, :refund }
+
+    before do
+      create_list :application_full_remission, 1, :refund
+    end
+
+    scenario 'Every 2nd application is not evidence check when paper evidence is false on Benefit Application' do
+      start_new_application
+
+      fill_personal_details
+      fill_application_refund_details
+      fill_saving_and_investment
+      fill_benefits(true)
+      fill_benefit_evidence(paper_provided: true)
+
+      click_button 'Complete processing'
+
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✗   Not eligible for help with fees')
+    end
+  end
+
+  context 'DWP Outcome is Yes for emergency application' do
+    let(:dwp_result) { 'yes' }
+    let(:application) { create :application_full_remission, :refund }
+
+    before do
+      create_list :application_full_remission, 1, :refund
+    end
+
+    scenario 'No evidence check on emergency applications' do
+      start_new_application
+
+      fill_personal_details
+      fill_application_emergency_details
+      fill_saving_and_investment
+      fill_benefits(true)
+      fill_benefit_evidence(paper_provided: true)
+
+      click_button 'Complete processing'
+
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✓ Eligible for help with fees')
+    end
+  end
+end

--- a/spec/features/no_evidence_check/rst_1111_spec.rb
+++ b/spec/features/no_evidence_check/rst_1111_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
   end
 
   context 'DWP outcome is Undetermined' do
-    let(:dwp_result) { 'undetermined' }
+    let(:dwp_result) { 'Undetermined' }
     let(:application) { create :application_full_remission }
 
     before do
@@ -34,12 +34,12 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
       click_button 'Complete processing'
 
       expect(page).not_to have_content('Evidence of income needs to be checked')
-      expect(page).to have_content('✗   Not eligible for help with fees')
+      expect(page).to have_content('✓ Eligible for help with fees')
     end
   end
 
   context 'DWP outcome is pass' do
-    let(:dwp_result) { 'yes' }
+    let(:dwp_result) { 'Yes' }
     let(:application) { create :application_full_remission }
 
     before do
@@ -53,16 +53,15 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
       fill_application_details
       fill_saving_and_investment
       fill_benefits(true)
-      fill_benefit_evidence(paper_provided: false)
 
       click_button 'Complete processing'
       expect(page).not_to have_content('Evidence of income needs to be checked')
-      expect(page).to have_content('✗   Not eligible for help with fees')
+      expect(page).to have_content('✓ Eligible for help with fees')
     end
   end
 
   context 'DWP Outcome is pass and paper evidence is true' do
-    let(:dwp_result) { 'yes' }
+    let(:dwp_result) { 'Yes' }
     let(:application) { create :application_full_remission, :refund }
 
     before do
@@ -76,7 +75,6 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
       fill_application_refund_details
       fill_saving_and_investment
       fill_benefits(true)
-      fill_benefit_evidence(paper_provided: true)
 
       click_button 'Complete processing'
 
@@ -86,7 +84,7 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
   end
 
   context 'DWP Outcome is ECONNREFUSED' do
-    let(:dwp_result) { 'no' }
+    let(:dwp_result) { 'Server unavailable' }
     let(:application) { create :application_full_remission, :refund }
 
     before do
@@ -100,7 +98,7 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
       fill_application_refund_details
       fill_saving_and_investment
       fill_benefits(true)
-      fill_benefit_evidence(paper_provided: true)
+      fill_benefit_evidence(paper_provided: false)
 
       click_button 'Complete processing'
 
@@ -110,7 +108,7 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
   end
 
   context 'DWP Outcome is Yes for emergency application' do
-    let(:dwp_result) { 'yes' }
+    let(:dwp_result) { 'Yes' }
     let(:application) { create :application_full_remission, :refund }
 
     before do
@@ -124,7 +122,6 @@ RSpec.feature 'EV Skipped for All Benefit Application', type: :feature do
       fill_application_emergency_details
       fill_saving_and_investment
       fill_benefits(true)
-      fill_benefit_evidence(paper_provided: true)
 
       click_button 'Complete processing'
 

--- a/spec/features/no_evidence_check/rst_985_spec.rb
+++ b/spec/features/no_evidence_check/rst_985_spec.rb
@@ -101,4 +101,48 @@ RSpec.feature 'Application is not evidence check when income is above threshold'
       expect(page).not_to have_content('✓ Eligible for help with fees')
     end
   end
+
+  context 'Duplicate NINO not included in 1 in 2 count for Refund application' do
+    let(:application) { create :application_full_remission, :refund }
+
+    before do
+      create_list :application_full_remission, 1, :refund
+    end
+
+    scenario 'Create duplicate NINO and verify it is not included in 1 in 2 count' do
+      start_new_application
+      fill_personal_details('SN987654D')
+      fill_application_details
+      fill_saving_and_investment
+      fill_benefits(false)
+      fill_income(false)
+      expect(page).to have_text 'Check details'
+      click_button 'Complete processing'
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✓ Eligible for help with fees')
+
+      visit home_index_url
+      create_flag_check('SN987654D')
+
+      click_button 'Start now'
+      fill_personal_details('SN987654D')
+      fill_application_details
+      fill_saving_and_investment
+      fill_benefits(false)
+      fill_income(false)
+      click_button 'Complete processing'
+      expect(page).to have_content('Evidence of income needs to be checked')
+      expect(page).not_to have_content('✓ Eligible for help with fees')
+
+      start_new_application
+      fill_personal_details
+      fill_application_refund_details
+      fill_saving_and_investment
+      fill_benefits(false)
+      fill_income(false)
+      click_button 'Complete processing'
+      expect(page).to have_content('Evidence of income needs to be checked')
+      expect(page).not_to have_content('✓ Eligible for help with fees')
+    end
+  end
 end

--- a/spec/features/no_evidence_check/rst_987_spec.rb
+++ b/spec/features/no_evidence_check/rst_987_spec.rb
@@ -35,6 +35,28 @@ RSpec.feature 'Application is evidence checked when 1 in X', type: :feature do
     end
   end
 
+  context 'Benefit application with paper evidence false excluded in the 1 in 10 count' do
+    let(:application) { create :application_full_remission }
+
+    before do
+      create_list :application_full_remission, 9
+    end
+
+    scenario 'Every 10th application is not evidence check when a benefit application paper check is false' do
+      start_new_application
+
+      fill_personal_details
+      fill_application_details
+      fill_saving_and_investment
+      fill_benefits(true)
+      fill_benefit_evidence(paper_provided: false)
+
+      click_button 'Complete processing'
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✗   Not eligible for help with fees')
+    end
+  end
+
   context 'Benefit application excluded in the 1 in 2 count' do
     let(:application) { create :application_full_remission, :refund }
 
@@ -55,6 +77,29 @@ RSpec.feature 'Application is evidence checked when 1 in X', type: :feature do
 
       expect(page).not_to have_content('Evidence of income needs to be checked')
       expect(page).to have_content('✓ Eligible for help with fees')
+    end
+  end
+
+  context 'Benefit application with papper evidence false excluded in the 1 in 2 count' do
+    let(:application) { create :application_full_remission, :refund }
+
+    before do
+      create_list :application_full_remission, 1, :refund
+    end
+
+    scenario 'Every 2nd application is not evidence check when paper evidence is false on Benefit Application' do
+      start_new_application
+
+      fill_personal_details
+      fill_application_refund_details
+      fill_saving_and_investment
+      fill_benefits(true)
+      fill_benefit_evidence(paper_provided: false)
+
+      click_button 'Complete processing'
+
+      expect(page).not_to have_content('Evidence of income needs to be checked')
+      expect(page).to have_content('✗   Not eligible for help with fees')
     end
   end
 


### PR DESCRIPTION
Added 2 scenarios based on my discussion with Atull to check Benefit applications with Paper evidence failed. 
Also added test for Ticket RST-1111 
And a test to verify that Duplicate NINO is not included in 1 in 2 count for refund application.