### PR TITLE
Adding overwrite for DWP message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,4 +33,9 @@ class ApplicationController < ActionController::Base
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = 3.hours.ago.to_formatted_s(:rfc822)
   end
+
+  def dwp_checker_state
+    return DwpMonitor.new.state if DwpWarning.use_default_check?
+    DwpWarning.last.check_state
+  end
 end

--- a/app/controllers/applications/process/benefits_controller.rb
+++ b/app/controllers/applications/process/benefits_controller.rb
@@ -4,7 +4,7 @@ module Applications
       before_action :authorize_application_update
 
       def index
-        @state = DwpMonitor.new.state
+        @state = dwp_checker_state
         if application.saving.passed?
           @form = Forms::Application::Benefit.new(application)
           render :index

--- a/app/controllers/dwp_warnings_controller.rb
+++ b/app/controllers/dwp_warnings_controller.rb
@@ -1,0 +1,29 @@
+class DwpWarningsController < ApplicationController
+
+  def edit
+    authorize dwp_warning
+  end
+
+  def update
+    authorize dwp_warning
+
+    notice_message =
+      if dwp_warning.update_attributes(notification_params)
+        'Your changes have been saved.'
+      else
+        'Your changes have not been saved.'
+      end
+
+    redirect_to edit_dwp_warnings_path, notice: notice_message
+  end
+
+  private
+
+  def dwp_warning
+    @dwp_warning = DwpWarning.first_or_create
+  end
+
+  def notification_params
+    params.require(:dwp_warning).permit(:check_state)
+  end
+end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,7 @@ class HomeController < ApplicationController
     load_users_last_applications
     @online_search_form = Forms::Search.new
     @completed_search_form = Forms::Search.new
-    @state = DwpMonitor.new.state
+    @state = dwp_checker_state
     @notification = Notification.first
   end
 

--- a/app/models/dwp_warning.rb
+++ b/app/models/dwp_warning.rb
@@ -1,0 +1,22 @@
+class DwpWarning < ActiveRecord::Base
+  before_create :only_one_record_allowed
+
+  STATES = { online: 'online', offline: 'offline', default_checker: 'default_checker' }.freeze
+
+  def self.use_default_check?
+    return true if self.last.blank?
+
+    self.last.check_state == STATES[:default_checker]
+  end
+
+  private
+
+  def only_one_record_allowed
+    if DwpWarning.count >= 1
+      errors.add(:base, 'Only one DwpWarning is allowed')
+      return false
+    end
+
+    true
+  end
+end

--- a/app/models/dwp_warning.rb
+++ b/app/models/dwp_warning.rb
@@ -4,9 +4,9 @@ class DwpWarning < ActiveRecord::Base
   STATES = { online: 'online', offline: 'offline', default_checker: 'default_checker' }.freeze
 
   def self.use_default_check?
-    return true if self.last.blank?
+    return true if last.blank?
 
-    self.last.check_state == STATES[:default_checker]
+    last.check_state == STATES[:default_checker]
   end
 
   private

--- a/app/policies/dwp_warning_policy.rb
+++ b/app/policies/dwp_warning_policy.rb
@@ -1,0 +1,9 @@
+class DwpWarningPolicy < BasePolicy
+  def edit?
+    admin?
+  end
+
+  def update?
+    admin?
+  end
+end

--- a/app/views/dwp_warnings/edit.html.slim
+++ b/app/views/dwp_warnings/edit.html.slim
@@ -1,0 +1,21 @@
+header
+  h2.heading-xlarge = t('.header')
+
+
+= form_for(@dwp_warning, url: dwp_warnings_path, action: :patch) do |f|
+  .form-group
+    fieldset
+
+      = f.label :check_state, class: 'block-label', for: 'dwp_warning_check_state_offline' do
+        = f.radio_button :check_state, DwpWarning::STATES[:offline]
+        = t('.form.offline')
+
+      = f.label :check_state, class: 'block-label', for: 'dwp_warning_check_state_online' do
+        = f.radio_button :check_state, DwpWarning::STATES[:online]
+        = t('.form.online')
+
+      = f.label :check_state, class: 'block-label', for: 'dwp_warning_check_state_default_checker' do
+        = f.radio_button :check_state, DwpWarning::STATES[:default_checker]
+        = t('.form.default')
+
+  = f.submit 'Save changes', class: 'button'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -43,6 +43,7 @@
               li= link_to 'View staff', users_path
             -if current_user.admin?
               li= link_to 'Edit banner', edit_notifications_path
+              li= link_to 'DWP message', edit_dwp_warnings_path
             li= link_to 'Staff Guides', guide_path
             li= link_to 'Sign out', destroy_user_session_path, :method => :delete
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,7 +127,7 @@ en-GB:
     dwp_maintenance: "The DWP checker will be unavailable from 9pm on Friday 22 April 2016 until 7am Monday 25 April 2016 for essential maintenance to be completed."
     dwp_unavailable: "The DWP checker is currently unavailable, you won't be able to check if applicants are receiving benefits. We are aware of this issue and are investigating. We apologise for the inconvenience."
     dwp_warning: "There may be a problem with the service. You may not be able to check if applicants are receiving benefits, this is being investigated."
-    dwp_restored: "The connection with the DWP is currently working.  Benefits based and income based applications can now be processed."
+    dwp_restored: "The connection with the DWP is currently working. Benefits based and income based applications can now be processed."
     create_be_exists: "A business entity record for %{jurisdiction} already exists in %{office}"
     manager_cant_invite_admin: 'You cannot create an admin account'
     benefit_checker:
@@ -225,6 +225,14 @@ en-GB:
         - 'Write the reference number on the top right corner of the paper form'
         - 'Write to the applicant using the letter on this page to ask for evidence'
         - 'Store the application form in a secure location until you receive the evidence'
+  dwp_warnings:
+    edit:
+      header: Choose the DWP message
+      form:
+        offline: "Display DWP check is down message"
+        online: "Display DWP check is working message"
+        default: "Use the default DWP check to display message"
+
   activemodel:
     attributes:
       forms/evidence/income:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
 
   resource :notifications, only: [:edit, :update]
+  resource :dwp_warnings
 
   post 'api/submissions' => 'api/submissions#create'
   get 'reports' => 'reports#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   resource :notifications, only: [:edit, :update]
-  resource :dwp_warnings
+  resource :dwp_warnings, only: [:edit, :update]
 
   post 'api/submissions' => 'api/submissions#create'
   get 'reports' => 'reports#index'

--- a/db/migrate/20180717100104_create_dwp_warnings.rb
+++ b/db/migrate/20180717100104_create_dwp_warnings.rb
@@ -1,0 +1,9 @@
+class CreateDwpWarnings < ActiveRecord::Migration
+  def change
+    create_table :dwp_warnings do |t|
+      t.string :check_state, default: 'default_checker'
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180223104947) do
+ActiveRecord::Schema.define(version: 20180717100104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,12 @@ ActiveRecord::Schema.define(version: 20180223104947) do
   end
 
   add_index "details", ["application_id"], name: "index_details_on_application_id", using: :btree
+
+  create_table "dwp_warnings", force: :cascade do |t|
+    t.string   "check_state", default: "default_checker"
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+  end
 
   create_table "evidence_check_flags", force: :cascade do |t|
     t.string   "ni_number"

--- a/spec/factories/dwp_warnings.rb
+++ b/spec/factories/dwp_warnings.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :dwp_warning do
+    check_state "default_checker"
+  end
+end

--- a/spec/models/dwp_warning_spec.rb
+++ b/spec/models/dwp_warning_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DwpWarning, type: :model do
+  let(:dwp_warning) { build :dwp_warning }
+
+  it "has a default value" do
+    expect(dwp_warning.check_state).to eql(DwpWarning::STATES[:default_checker])
+  end
+
+  describe 'Use default check?' do
+    it { expect(DwpWarning.use_default_check?).to be_truthy }
+
+    context 'online' do
+      before { create :dwp_warning, check_state: DwpWarning::STATES[:online] }
+
+      it { expect(DwpWarning.use_default_check?).to be_falsey }
+    end
+
+    context 'offline' do
+      before { create :dwp_warning, check_state: DwpWarning::STATES[:offline] }
+
+      it { expect(DwpWarning.use_default_check?).to be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
We can now choose if we want to use default DWP monitor or just say that DWP is down/up.