### PR TITLE
Prevent managers from changing office details

### DIFF
--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -39,8 +39,9 @@ class OfficesController < ApplicationController
   end
 
   def update
-    office.assign_attributes(office_params)
     authorize office
+
+    office.assign_attributes(office_params)
 
     if office.save
       flash[:notice] = 'Office was successfully updated'

--- a/app/policies/office_policy.rb
+++ b/app/policies/office_policy.rb
@@ -20,7 +20,7 @@ class OfficePolicy < BasePolicy
   end
 
   def update?
-    admin? || (manager? && same_office?)
+    admin?
   end
 
   private

--- a/app/views/offices/edit.html.slim
+++ b/app/views/offices/edit.html.slim
@@ -1,6 +1,10 @@
 header
   h2.heading-xlarge Change office details
 
+- if current_user.manager?
+  div.important-notice.util_mb-large
+    strong = t('offices.jurisdictions_warning')
+
 = render 'form', with_jurisdictions: true
 
 ul

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -232,6 +232,8 @@ en-GB:
         offline: "Display DWP check is down message"
         online: "Display DWP check is working message"
         default: "Use the default DWP check to display message"
+  offices:
+    jurisdictions_warning: "If the office name or jurisdictions assigned to this office are incorrect and need to be changed, please contact the HwF support desk on helpwithfees.support@digital.justice.gov.uk, confirming the change and the reasons for it. Please note these details should not change if you have moved office. Your assigned office can be changed via the 'View Profile' screen."
 
   activemodel:
     attributes:

--- a/spec/policies/office_policy_spec.rb
+++ b/spec/policies/office_policy_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe OfficePolicy, type: :policy do
 
       it { is_expected.to permit_action(:show) }
       it { is_expected.to permit_action(:edit) }
-      it { is_expected.to permit_action(:update) }
+      it { is_expected.not_to permit_action(:update) }
     end
 
     context 'when the user does not belong to the office' do


### PR DESCRIPTION
This PR restricts users with Manager role from editing offices and their jurisdictions and displays a message to contact the Admin if changes needed.