### PR TITLE
Upgrade gems with security issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,7 +399,7 @@ GEM
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -515,4 +515,4 @@ DEPENDENCIES
   will_paginate
 
 BUNDLED WITH
-   1.16.1
+   1.16.5


### PR DESCRIPTION
Patch for [CVE-2018-3760](https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k)