### PR TITLE
RST-1085 Re-invite users

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,9 @@ Metrics/LineLength:
   Exclude:
     - 'spec/**/*'
 
+Metrics/ClassLength:
+  Max: 120
+
 # Allow expect {}.to blocks in specs
 # but not in the code
 Style/BlockDelimiters:

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,6 +49,14 @@ class UsersController < ApplicationController
     redirect_to redirect_after_restore
   end
 
+  def invite
+    authorize user
+    user.invite!
+
+    flash[:notice] = "An invitation was sent to #{user.name}"
+    redirect_to users_path
+  end
+
   protected
 
   def user

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,6 +3,10 @@ class UserPolicy < BasePolicy
     manager? || admin?
   end
 
+  def invite?
+    admin?
+  end
+
   def list_deleted?
     admin?
   end

--- a/app/views/users/index.html.slim
+++ b/app/views/users/index.html.slim
@@ -14,6 +14,7 @@ table.util_mb-large
       th Main jurisdiction
       th Activity flag
       th &nbsp;
+      th &nbsp;
   tbody
     -@users.each do |user|
       tr
@@ -30,6 +31,10 @@ table.util_mb-large
         td
           - if policy(user).edit?
             =link_to 'Change details', edit_user_path(user)
+        td
+          - if policy(user).invite? && user.invitation_sent_at? && !user.invitation_accepted_at?
+            =link_to 'Re-invite', invite_user_path(user), method: :patch
+
 
 ul.list
   - if policy(:user).new?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
 
   get 'users/deleted' => 'users#deleted', as: 'deleted_users'
   patch 'users/:id/restore' => 'users#restore', as: 'restore_user'
+  patch 'users/:id/invite' => 'users#invite', as: 'invite_user'
   devise_for :users, skip: :registrations, controllers: {
     invitations: 'users/invitations',
     passwords: 'users/passwords',

--- a/spec/controllers/users_controller/admin_user_spec.rb
+++ b/spec/controllers/users_controller/admin_user_spec.rb
@@ -196,5 +196,18 @@ RSpec.describe UsersController, type: :controller do
         end
       end
     end
+
+    describe 'PATCH #invite' do
+
+      before { patch :invite, id: user_not_on_admins_team.to_param }
+
+      it 'returns a redirect code' do
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it 'returns a confirmation message' do
+        expect(flash[:notice]).to eq("An invitation was sent to #{user_not_on_admins_team.name}")
+      end
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,5 +28,14 @@ FactoryGirl.define do
     factory :active_user do
       current_sign_in_at 1.month.ago
     end
+    trait :invitation_sent do
+      invitation_sent_at 3.months.ago
+    end
+    trait :invitation_not_accepted do
+      invitation_accepted_at nil
+    end
+    trait :invitation_accepted do
+      invitation_accepted_at 2.months.ago
+    end
   end
 end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe UserPolicy, type: :policy do
     it { is_expected.not_to permit_action(:list_deleted) }
     it { is_expected.not_to permit_action(:destroy) }
     it { is_expected.not_to permit_action(:restore) }
+    it { is_expected.not_to permit_action(:invite) }
     it { is_expected.not_to permit_action(:new) }
     it { is_expected.not_to permit_action(:create) }
 
@@ -66,6 +67,7 @@ RSpec.describe UserPolicy, type: :policy do
     it { is_expected.to permit_action(:new) }
     it { is_expected.not_to permit_action(:list_deleted) }
     it { is_expected.not_to permit_action(:restore) }
+    it { is_expected.not_to permit_action(:invite) }
 
     context 'when the subject_user belongs to the same office as the manager' do
       let(:subject_user) { build_stubbed(:user, office: office) }
@@ -138,6 +140,7 @@ RSpec.describe UserPolicy, type: :policy do
     it { is_expected.to permit_action(:index) }
     it { is_expected.to permit_action(:list_deleted) }
     it { is_expected.to permit_action(:restore) }
+    it { is_expected.to permit_action(:invite) }
     it { is_expected.to permit_action(:show) }
     it { is_expected.to permit_action(:new) }
     it { is_expected.to permit_action(:create) }
@@ -166,6 +169,7 @@ RSpec.describe UserPolicy, type: :policy do
     it { is_expected.not_to permit_action(:list_deleted) }
     it { is_expected.not_to permit_action(:destroy) }
     it { is_expected.not_to permit_action(:restore) }
+    it { is_expected.not_to permit_action(:invite) }
     it { is_expected.not_to permit_action(:new) }
     it { is_expected.not_to permit_action(:create) }
 

--- a/spec/routing/users_routing_spec.rb
+++ b/spec/routing/users_routing_spec.rb
@@ -34,5 +34,9 @@ RSpec.describe UsersController, type: :routing do
     it 'routes to #restore' do
       expect(patch: '/users/1/restore').to route_to('users#restore', id: '1')
     end
+
+    it 'routes to #invite' do
+      expect(patch: '/users/1/invite').to route_to('users#invite', id: '1')
+    end
   end
 end

--- a/spec/views/users/index.html.slim_spec.rb
+++ b/spec/views/users/index.html.slim_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe 'users/index', type: :view do
     assign(:users, users)
     allow(view).to receive(:current_user).and_return(instance_double(User, admin?: true))
     allow(view).to receive(:policy).with(:user).and_return(instance_double(UserPolicy, new?: user_new?, list_deleted?: user_list_deleted?))
-    allow(view).to receive(:policy).with(users[0]).and_return(instance_double(UserPolicy, edit?: true))
-    allow(view).to receive(:policy).with(users[1]).and_return(instance_double(UserPolicy, edit?: false))
+    allow(view).to receive(:policy).with(users[0]).and_return(instance_double(UserPolicy, edit?: true, invite?: true))
+    allow(view).to receive(:policy).with(users[1]).and_return(instance_double(UserPolicy, edit?: false, invite?: false))
 
     render
   end
@@ -25,7 +25,7 @@ RSpec.describe 'users/index', type: :view do
       end
     end
 
-    context 'when user does not have permission to chang the other user\'s details' do
+    context 'when user does not have permission to change the other user\'s details' do
       it 'is not rendered' do
         is_expected.not_to have_xpath('//tbody/tr[2]/td[6]/a')
       end
@@ -60,6 +60,32 @@ RSpec.describe 'users/index', type: :view do
     context 'when user does not have permission to list deleted users' do
       it 'is not rendered' do
         expect(rendered).not_to have_link('List deleted users')
+      end
+    end
+  end
+
+  describe 'The link to re-invite user' do
+    context 'When staff have permission to re-invite a user' do
+      context 'The user has not accepted the invitation yet' do
+        let(:users) { create_list(:user, 2, :invitation_sent, :invitation_not_accepted) }
+
+        it 'is rendered' do
+          expect(rendered).to have_link('Re-invite')
+        end
+      end
+
+      context 'The user has accepted the invitation' do
+        let(:users) { create_list(:user, 2, :invitation_sent, :invitation_accepted) }
+
+        it 'is not rendered' do
+          expect(rendered).not_to have_link('Re-invite')
+        end
+      end
+    end
+
+    context 'When staff does not have permission to re-invite user' do
+      it 'is not rendered' do
+        expect(rendered).not_to have_link('Re-invite')
       end
     end
   end


### PR DESCRIPTION
This enhancement allows admins to re-invite users who haven't accepted their account invitation or it expired