### PR TITLE
Remove office setup from the quick profile setup process for managers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,9 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     manager_setup = ManagerSetup.new(resource, session)
-    if manager_setup.setup_office?
+    if manager_setup.setup_profile?
       manager_setup.start!
-      edit_office_path(current_user.office)
+      edit_user_path(current_user)
     else
       root_path
     end

--- a/spec/features/manager_out_of_the_box_experience_spec.rb
+++ b/spec/features/manager_out_of_the_box_experience_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 # I'm disabling this Rubocop check to allow writing readable scenarios
 # rubocop:disable RSpec/InstanceVariable
 
-RSpec.feature 'Manager has to setup their office and preferences', type: :feature do
+RSpec.feature 'Manager has to setup their preferences', type: :feature do
 
   let(:jurisdictions) { create_list :jurisdiction, 3 }
   let(:office) { create(:office, jurisdictions: jurisdictions) }
@@ -14,23 +14,15 @@ RSpec.feature 'Manager has to setup their office and preferences', type: :featur
     then_they_are_redirected_to_the_dashboard
   end
 
-  scenario 'Signing in for the first time is redirected to office setup' do
+  scenario 'Signing in for the first time is redirected to their profile setup' do
     manager_has_not_signed_in_before
     when_they_sign_in
-    then_they_are_redirected_to_the_office_setup
-  end
-
-  scenario 'After setting up the office, they are redirected to their profile setup if signing in for the first time' do
-    manager_has_not_signed_in_before
-    and_they_sign_in
-    when_they_setup_the_office
     then_they_are_redirected_to_the_profile_setup
   end
 
   scenario 'After setting up their profile, they are redirected to dashboard if signing in for the first time' do
     manager_has_not_signed_in_before
     and_they_sign_in
-    when_they_setup_the_office
     when_whey_setup_their_profile
     then_they_are_redirected_to_the_dashboard
   end
@@ -51,19 +43,9 @@ RSpec.feature 'Manager has to setup their office and preferences', type: :featur
   end
   alias_method :and_they_sign_in, :when_they_sign_in
 
-  def when_they_setup_the_office
-    jurisdiction = Jurisdiction.first
-    check "#{jurisdiction.display_full} (#{BusinessEntity.where(jurisdiction_id: jurisdiction.id).first.code})"
-    click_button 'Update office'
-  end
-
   def when_whey_setup_their_profile
     choose Jurisdiction.first.name
     click_button 'Save changes'
-  end
-
-  def then_they_are_redirected_to_the_office_setup
-    expect(page.current_path).to eql "/offices/#{@manager.office.id}/edit"
   end
 
   def then_they_are_redirected_to_the_dashboard


### PR DESCRIPTION
Managers get confused when they are setting up their accounts for the first time and they change the office name of their assigned office. Therefore, it was decided to remove the office setup from the account setup process. 

Managers will still be able to change the office details from the change office page.