### PR TITLE
Making sure that the prefix HWF is unique

### DIFF
--- a/app/services/hwf_reference_generator.rb
+++ b/app/services/hwf_reference_generator.rb
@@ -16,12 +16,16 @@ class HwfReferenceGenerator
   def generate_reference
     begin
       reference = reference_string
-    end until OnlineApplication.find_by(reference: reference).nil?
+    end until (OnlineApplication.find_by(reference: reference).nil? && prefix_is_unique(reference))
 
     reference
   end
 
   def reference_string
     "HWF-#{Array.new(LENGTH) { DICTIONARY.sample }.join.scan(/.{1,3}/).join('-')}"
+  end
+
+  def prefix_is_unique(reference)
+    reference.scan(/(HWF)+/i).count == 1
   end
 end

--- a/spec/services/hwf_reference_generator_spec.rb
+++ b/spec/services/hwf_reference_generator_spec.rb
@@ -22,12 +22,22 @@ RSpec.describe HwfReferenceGenerator, type: :service do
 
     context 'when the generated reference number already exists' do
       before do
-        create(:online_application, reference: 'collision')
-        allow(generator).to receive(:reference_string).and_return('collision', 'no-collision')
+        create(:online_application, reference: 'hwf-collision')
+        allow(generator).to receive(:reference_string).and_return('hwf-collision', 'hwf-no-collision')
       end
 
       it 'keeps generating until there is no collision' do
-        expect(attributes[:reference]).to eql('no-collision')
+        expect(attributes[:reference]).to eql('hwf-no-collision')
+      end
+    end
+
+    context 'when the generated reference contains HWF more then once' do
+      before do
+        allow(generator).to receive(:reference_string).and_return('HWF-AHW-HWF', 'HWF-HWF-HWF', 'HWF-HWF-HWA', 'HWF-HAF-HWA')
+      end
+
+      it 'keeps generating until there is no collision' do
+        expect(attributes[:reference]).to eql('HWF-HAF-HWA')
       end
     end
   end


### PR DESCRIPTION
There was an issue when the reference generator generated refernce HWF-AHW-HWF. The issue was that the application was invisible because of the way how the search is parsing the string (removing the hwf prefix). So I'm just making sure that there is no duplication again.