### PR TITLE
Upgrade vulnerable gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,7 +276,7 @@ GEM
     public_suffix (2.0.5)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-host-redirect (1.3.0)
       rack
     rack-livereload (0.3.16)


### PR DESCRIPTION
This PR sorts out the Rack gem vulnerabilities [CVE-2018-16470](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16470) and [CVE-2018-16471](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16471)

More info here:
https://groups.google.com/forum/#!topic/rubyonrails-security/U_x-YkfuVTg
https://groups.google.com/forum/#!topic/rubyonrails-security/GKsAFT924Ag