### PR TITLE
Create Medium field to recognise digital vs paper applications

### DIFF
--- a/app/builders/application_builder.rb
+++ b/app/builders/application_builder.rb
@@ -12,7 +12,8 @@ class ApplicationBuilder
       user_id: @user.id,
       applicant: build_applicant,
       detail: build_details,
-      saving: build_saving
+      saving: build_saving,
+      medium: 'paper'
     )
   end
 
@@ -23,7 +24,8 @@ class ApplicationBuilder
       online_application: online_application,
       applicant: Applicant.new(online_applicant_attributes(online_application)),
       detail: Detail.new(online_detail_attributes(online_application)),
-      saving: Saving.new(online_saving_attributes(online_application))
+      saving: Saving.new(online_saving_attributes(online_application)),
+      medium: 'digital'
     }.merge(online_application_attributes(online_application))
 
     Application.new(attributes)

--- a/db/migrate/20181114150745_add_medium_to_applications.rb
+++ b/db/migrate/20181114150745_add_medium_to_applications.rb
@@ -5,7 +5,7 @@ class AddMediumToApplications < ActiveRecord::Migration
     reversible do |direction|
       direction.up do
         Application.where("reference ~* ?", "HWF").update_all(medium: "digital")
-        Application.where.not("reference ~* ?", "HWF").update_all(medium: "paper")
+        Application.where("reference !~* ? OR reference IS NULL", "HWF").update_all(medium: 'paper')
       end
     end
   end

--- a/db/migrate/20181114150745_add_medium_to_applications.rb
+++ b/db/migrate/20181114150745_add_medium_to_applications.rb
@@ -1,0 +1,12 @@
+class AddMediumToApplications < ActiveRecord::Migration
+  def change
+    add_column :applications, :medium, :string
+
+    reversible do |direction|
+      direction.up do
+        Application.where("reference ~* ?", "HWF").update_all(medium: "digital")
+        Application.where.not("reference ~* ?", "HWF").update_all(medium: "paper")
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180808095028) do
+ActiveRecord::Schema.define(version: 20181114150745) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 20180808095028) do
     t.boolean  "income_max_threshold_exceeded"
     t.decimal  "income_min_threshold"
     t.decimal  "income_max_threshold"
+    t.string   "medium"
   end
 
   add_index "applications", ["business_entity_id"], name: "index_applications_on_business_entity_id", using: :btree

--- a/spec/builders/application_builder_spec.rb
+++ b/spec/builders/application_builder_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe ApplicationBuilder do
         expect(build_result.detail.jurisdiction).to eql(user.jurisdiction)
       end
 
+      it 'has the correct medium attribute stored' do
+        expect(build_result.medium).to eq('paper')
+      end
+
       it 'does not have reference set' do
         expect(build_result.reference).to be nil
       end
@@ -74,6 +78,10 @@ RSpec.describe ApplicationBuilder do
     describe 'the application' do
       it 'has the user stored' do
         expect(built_application.user).to eql(user)
+      end
+
+      it 'has the correct medium attribute stored' do
+        expect(built_application.medium).to eq('digital')
       end
 
       it 'has office assigned from the user' do


### PR DESCRIPTION
Up until now we were using the reference number to distinguish paper applications against digital. This PR introduces the "Medium" column in the applications table to make it easier to query the applications by type.