### PR TITLE
Fixing issue with blank application type

### DIFF
--- a/app/repositories/application_form_repository.rb
+++ b/app/repositories/application_form_repository.rb
@@ -37,8 +37,8 @@ class ApplicationFormRepository
     @form.discretion_applied != false
   end
 
-  def application_outcome(outcome)
-    application.update(outcome: outcome)
+  def application_outcome_and_type(outcome, application_type)
+    application.update(outcome: outcome, application_type: application_type)
   end
 
   def assign_template_path
@@ -53,7 +53,8 @@ class ApplicationFormRepository
 
   def udpate_outcome
     return if continue_with_discretion_applied?
-    application_outcome('none')
+
+    application_outcome_and_type('none', 'none')
   end
 
 end

--- a/spec/features/applications/processing_refund_application_spec.rb
+++ b/spec/features/applications/processing_refund_application_spec.rb
@@ -177,9 +177,11 @@ RSpec.feature 'Processing refund application with valid date received date', typ
           expect(page).not_to have_content "Savings and investments"
 
           click_button 'Complete processing'
+
           expect(page).to have_content 'Not eligible for help with fees'
           expect(page).to have_content 'Delivery Manager Discretion✗ Failed'
           expect(page).not_to have_content 'Savings and investments'
+          expect(Application.last.application_type).not_to be_nil
         end
 
         it "discretion granted" do

--- a/spec/repositories/application_form_repository_spec.rb
+++ b/spec/repositories/application_form_repository_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ApplicationFormRepository do
       let(:discretion_applied) { false }
 
       it "return saving path" do
-        allow(application).to receive(:update).with(outcome: "none")
+        allow(application).to receive(:update).with(outcome: "none", application_type: 'none')
         repository.process(:detail)
         expect(repository.redirect_url).to eql("/applications/#{application.id}/summary")
       end
@@ -53,7 +53,7 @@ RSpec.describe ApplicationFormRepository do
         let(:application) { instance_spy('Application') }
         it "set the outcome" do
           repository.process(:detail)
-          expect(application).to have_received(:update).with(outcome: "none")
+          expect(application).to have_received(:update).with(outcome: "none", application_type: 'none')
         end
       end
     end


### PR DESCRIPTION
When the refund application is processed and the discretion is not applied aka is set to false it will not fill the application type so it stays nil. So when the discretion is not applied it will set the outcome but not the application type. And because that's the end of the process the application type is never filled. I'm making sure that the application type is set when the discretion is not applied. 