### PR TITLE
Fix the update password spec

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -581,7 +581,6 @@ en-GB:
   devise:
     registrations:
       heading: Change your password
-      updated: Your password was updated successfully
   out_of_box:
     ie_warning: IE User! We recommend you use Firefox for a superior experience
     office:

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -47,7 +47,7 @@ RSpec.feature 'User profile', type: :feature do
         scenario 'allow users to change their password' do
           fill_in :user_password, with: 'password1'
           click_button 'Update password'
-          expect(page).to have_text 'Your password was updated successfully'
+          expect(page).to have_text 'Your account has been updated successfully'
         end
 
         scenario 'prompts user to set a new password' do


### PR DESCRIPTION
The app is using devise's default message when updating the password. 

This PR reflects that to the tests.