### PR TITLE
Unblock digital income based applications during DWP outage

### DIFF
--- a/app/controllers/online_applications_controller.rb
+++ b/app/controllers/online_applications_controller.rb
@@ -6,6 +6,8 @@ class OnlineApplicationsController < ApplicationController
   include SectionViewsHelper
 
   def edit
+    redirect_benefits_applications_when_dwp_is_offline
+
     @form = Forms::OnlineApplication.new(online_application)
     @form.enable_default_jurisdiction(current_user)
     assign_jurisdictions
@@ -68,5 +70,12 @@ class OnlineApplicationsController < ApplicationController
 
   def assign_jurisdictions
     @jurisdictions ||= current_user.office.jurisdictions
+  end
+
+  def redirect_benefits_applications_when_dwp_is_offline
+    if online_application.benefits? && DwpMonitor.new.state == 'offline'
+      flash[:alert] = t('error_messages.benefit_check.cannot_process_application')
+      redirect_to root_path
+    end
   end
 end

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -61,9 +61,9 @@ h1.visuallyhidden Help with fees - Staff application
             = f.label :reference, @online_search_form.errors[:reference].join('').html_safe, class: 'error' if @online_search_form.errors[:reference].present?
             .field-wrapper
               span.prefix HWF
-              = f.text_field :reference, { class: 'form-control small-field', autocomplete: 'off', disabled: @state=='offline' }
+              = f.text_field :reference, { class: 'form-control small-field', autocomplete: 'off' }
           .util_mt-0
-            = f.submit 'Look up', class: 'button util_margin-0', disabled: @state=='offline'
+            = f.submit 'Look up', class: 'button util_margin-0'
 
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en-GB:
   error_messages:
     benefit_check:
       dwp_unavailable: "You will only be able to process this application if you have paper evidence that the applicant is receiving benefits"
+      cannot_process_application: This is a benefits-based application which cannot be processed until the DWP checker is available
     dwp_maintenance: "The DWP checker will be unavailable from 9pm on Friday 22 April 2016 until 7am Monday 25 April 2016 for essential maintenance to be completed."
     dwp_unavailable: "The DWP checker is currently unavailable, you won't be able to check if applicants are receiving benefits. We are aware of this issue and are investigating. We apologise for the inconvenience."
     dwp_warning: "There may be a problem with the service. You may not be able to check if applicants are receiving benefits, this is being investigated."
@@ -150,7 +151,7 @@ en-GB:
             - "income-based applications"
             - "benefits-based applications if the applicant has provided paper evidence"
       digital:
-        dwp-down: "Please wait until the DWP checker is available to process online applications"
+        dwp-down: "You can only process income-based applications. Please wait until the DWP checker is available to process online benefits-based applications"
   feedback:
     rating_1: 'No'
     rating_2: 'I used an accessibility tool such as a screen reader'

--- a/spec/controllers/online_applications_controller_spec.rb
+++ b/spec/controllers/online_applications_controller_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe OnlineApplicationsController, type: :controller do
           expect(assigns(:form).jurisdiction_id).to be_nil
         end
       end
+
+      context 'when the Benefits Checker is down' do
+        before do
+          build_dwp_checks_with_bad_requests
+          get :edit, id: id
+        end
+
+        context 'when it is an income based application' do
+          let(:online_application) { build_stubbed(:online_application, :income) }
+
+          it 'renders the edit template' do
+            expect(response).to render_template(:edit)
+          end
+        end
+
+        context 'when it is a benefits based application' do
+          it 'redirects to homepage' do
+            expect(response).to redirect_to(root_path)
+          end
+
+          it 'sets the alert flash message' do
+            expect(flash[:alert]).to eql I18n.t('error_messages.benefit_check.cannot_process_application')
+          end
+        end
+      end
     end
   end
 

--- a/spec/views/home/index.html.slim_spec.rb
+++ b/spec/views/home/index.html.slim_spec.rb
@@ -193,11 +193,11 @@ RSpec.describe "home/index.html.slim", type: :view do
 
           it { is_expected.to have_content 'You can only process:' }
 
-          it { is_expected.to have_content 'Please wait until the DWP checker is available to process online applications' }
+          it { is_expected.to have_content I18n.t('error_messages.benefit_check.cannot_process_application') }
 
-          it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit" and @disabled]') }
+          it { is_expected.to have_xpath('//input[@value="Look up" and @name="commit"]') }
 
-          it { is_expected.to have_xpath('//input[@id="online_search_reference" and @disabled]') }
+          it { is_expected.to have_xpath('//input[@id="online_search_reference"]') }
         end
       end
     end


### PR DESCRIPTION
The staff can not look up for digital applications when the Benefit Checker is offline, blocking them from processing digital applications (like income based) which do not need to cross check data with the Department for Work and Pensions (DWP).

This PR will keep the look up functionality enabled during Benefit Checker outages, to allow the staff to process non benefits digital applications. At the same time, It will be redirecting the benefit based ones to the homepage with an alert message.