### PR TITLE
Change the generate reports link

### DIFF
--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -77,7 +77,7 @@ h1.visuallyhidden Help with fees - Staff application
         .panel
           h3.heading-medium.util_mt-0 Generate reports
           p Export national finance reports related to Help with fees applications and download monthly summary data.
-          = link_to 'Generate reports', '/reports/finance_report', class: 'button util_mb-0'
+          = link_to 'Generate reports', reports_path, class: 'button util_mb-0'
     - if policy(:office).index?
       .column-one-half
         .panel

--- a/features/step_definitions/generate_report_steps.rb
+++ b/features/step_definitions/generate_report_steps.rb
@@ -1,5 +1,6 @@
 Given("I am on the finance aggregated report page") do
   dashboard_page.generate_reports
+  reports_page.finance_aggregated_report
   expect(current_path).to include '/reports/finance_report'
   expect(generate_report_page.content).to have_aggregated_header
 end

--- a/features/step_definitions/reports_steps.rb
+++ b/features/step_definitions/reports_steps.rb
@@ -1,5 +1,7 @@
 And("I am on the reports page") do
-  visit(reports_page.url)
+  dashboard_page.generate_reports
+  expect(reports_page).to be_displayed
+  expect(reports_page.content).to have_management_information_header
 end
 
 When("I click on finance aggregated report") do

--- a/features/support/page_objects/reports_page.rb
+++ b/features/support/page_objects/reports_page.rb
@@ -2,6 +2,7 @@ class ReportsPage < BasePage
   set_url '/reports'
 
   section :content, '#content' do
+    element :management_information_header, 'h2', text: 'Management Information'
     element :finance_aggregated_report_link, 'a', text: 'Finance aggregated report'
     element :finance_aggregated_report_help, 'dd', text: 'Date delimited report of financial expenditure'
     element :finance_transactional_report_link, 'a', text: 'Finance transactional report'


### PR DESCRIPTION
The generate reports link on the homepage will now be redirecting the users to the reports page, where they can choose which report they like to generate.