### PR TITLE
RST-1952 - Adding GM tracking for error messages

### DIFF
--- a/app/assets/javascripts/gtm_track_timestamps.js
+++ b/app/assets/javascripts/gtm_track_timestamps.js
@@ -149,5 +149,31 @@ window.moj.Modules.GtmTrackTimestamps = {
     $('.search-button').click(function(){
       moj.Modules.GtmTrackTimestamps.serchPerformed('');
     });
+  },
+
+  trackErrorMessage:  function() {
+    var error_messages = moj.Modules.GtmTrackTimestamps.readErrorMessages()
+    if(error_messages.length > 0) {
+      dataLayer.push({
+        'event': 'ErrorMessage',
+        'errorMessageText': error_messages
+      });
+    }
+  },
+
+  readErrorMessages: function(){
+    var val = []
+    var error_messages = '';
+
+    if($('.alert-box').size() > 0){
+      error_messages = $('.alert-box').text()
+    } else if($('label.error').size() > 0) {
+      $('label.error').each(function() {
+        val.push($( this ).text());
+      });
+      error_messages = val.join(' ');
+    }
+
+    return error_messages;
   }
 };

--- a/app/assets/javascripts/gtm_track_timestamps.js
+++ b/app/assets/javascripts/gtm_track_timestamps.js
@@ -171,7 +171,7 @@ window.moj.Modules.GtmTrackTimestamps = {
       $('label.error').each(function() {
         val.push($( this ).text());
       });
-      error_messages = val.join(' ');
+      error_messages = val.join(', ');
     }
 
     return error_messages;

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -58,5 +58,11 @@
 - content_for :javascripts
   = javascript_include_tag('application.js')
 
+- if (flash.present? && flash.keys.join != 'notice') || (@form && @form.errors.present?)
+  - content_for :javascripts
+    javascript:
+      $(document).ready(function () {
+        moj.Modules.GtmTrackTimestamps.trackErrorMessage();
+      });
 
 = render template: "layouts/local-template"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -58,11 +58,9 @@
 - content_for :javascripts
   = javascript_include_tag('application.js')
 
-- if (flash.present? && flash.keys.join != 'notice') || (@form && @form.errors.present?)
-  - content_for :javascripts
-    javascript:
-      $(document).ready(function () {
-        moj.Modules.GtmTrackTimestamps.trackErrorMessage();
-      });
+  javascript:
+    $(document).ready(function () {
+      moj.Modules.GtmTrackTimestamps.trackErrorMessage();
+    });
 
 = render template: "layouts/local-template"


### PR DESCRIPTION
I had to separate the tracking in two logics because for some reason we are not displaying the header alert when some forms have validation errors.