### PR TITLE
Add libqtwebkit-dev travis addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     packages:
     - qtbase5-dev
     - xvfb
+    - libqtwebkit-dev
   postgresql: 9.6
 script:
 - bundle exec rake rubocop


### PR DESCRIPTION
Travis is failing to build `capybara-webkit` with error message:
```
fatal error: QWebElement: No such file or directory
compilation terminated.
```

Adding the `libqtwebkit-dev` addon, solves the issue.