### PR TITLE
Bump chartkick from 2.3.5 to 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ end
 # heroku deployment
 gem 'rails_12factor', group: :production
 
-gem 'chartkick', '2.3.5'
+gem 'chartkick', '~> 3.2.0'
 gem 'ckeditor_rails', '~> 4.6'
 gem 'groupdate'
 gem 'pg_search'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
     capybara-webkit (1.15.1)
       capybara (>= 2.3, < 4.0)
       json
-    chartkick (2.3.5)
+    chartkick (3.2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.2.0)
@@ -518,7 +518,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   capybara-webkit
-  chartkick (= 2.3.5)
+  chartkick (~> 3.2.0)
   chromedriver-helper (~> 1.1)
   ckeditor_rails (~> 4.6)
   climate_control

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -1,4 +1,4 @@
-=content_for(:head_scripts) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
+=content_for(:head_scripts) { javascript_include_tag '//www.gstatic.com/charts/loader.js', 'chartkick' }
 
 h1.visuallyhidden Help with fees - Staff application
 

--- a/app/views/reports/graphs.html.slim
+++ b/app/views/reports/graphs.html.slim
@@ -1,4 +1,4 @@
-= content_for(:head_scripts) { javascript_include_tag '//www.google.com/jsapi', 'chartkick' }
+= content_for(:head_scripts) { javascript_include_tag '//www.gstatic.com/charts/loader.js', 'chartkick' }
 
 -if policy(:report).graphs?
   - if @report_data.present?

--- a/spec/features/applications/stray_error_on_confirmation_page_spec.rb
+++ b/spec/features/applications/stray_error_on_confirmation_page_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Stray error on the confirmation page', type: :feature do
   let(:date_received) { Time.zone.today - 3.days }
 
   before do
-    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
+    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.gstatic.com/charts/loader.js'])
     Capybara.current_driver = :webkit
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -94,11 +94,11 @@ RSpec.configure do |config|
   end
 
   config.before(:all) do
-    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.google.com/jsapi'])
+    WebMock.disable_net_connect!(allow: ['127.0.0.1', 'codeclimate.com', 'www.gstatic.com/charts/loader.js'])
   end
 
   Capybara::Webkit.configure do |config|
-    config.allow_url('http://www.google.com/jsapi')
+    config.allow_url('http://www.gstatic.com/charts/loader.js')
     config.block_unknown_urls
   end
 


### PR DESCRIPTION
This PR sorts out the [CVE-2019-12732](https://nvd.nist.gov/vuln/detail/CVE-2019-12732) issue in chartkick gem.